### PR TITLE
Fixed Unicode conversion for WhoUsesMyFiles plugin

### DIFF
--- a/plugins/WhoUsesMyFiles/src/wumf.cpp
+++ b/plugins/WhoUsesMyFiles/src/wumf.cpp
@@ -173,7 +173,7 @@ void LogWumf(PWumf w)
 	GetTimeFormat(LOCALE_USER_DEFAULT, TIME_FORCE24HOURFORMAT | TIME_NOTIMEMARKER, &time, NULL, lpTimeStr, 20);
 	mir_sntprintf(str, SIZEOF(str), _T("%s %s %20s\t%s\r\n\0"), lpDateStr, lpTimeStr, w->szUser, w->szPath);
 	SetFilePointer(hLog, 0, NULL, FILE_END);
-	WriteFile(hLog, str, (DWORD)_tcslen(str), &bytes, NULL);
+	WriteFile(hLog, _T2A(str), (DWORD)_tcslen(str), &bytes, NULL);
 }
 
 BOOL wumf()


### PR DESCRIPTION
WhoUsesMyFiles has a feature to log accessed data to txt file. But seems in Unicode version of Miranda it doesn't work correctly. It tries to save Unicode string with incorrect size, so it cuts half of saved data. 
