### PR TITLE
Allow '0' in "Flash containers" TabSRMM setting to disable flashing.

### DIFF
--- a/plugins/TabSRMM/src/msgoptions.cpp
+++ b/plugins/TabSRMM/src/msgoptions.cpp
@@ -1081,7 +1081,7 @@ static INT_PTR CALLBACK DlgProcContainerSettings(HWND hwndDlg, UINT msg, WPARAM 
 		CheckDlgButton(hwndDlg, IDC_DEFAULTCONTAINERMODE, !(IsDlgButtonChecked(hwndDlg, IDC_CONTAINERGROUPMODE) || IsDlgButtonChecked(hwndDlg, IDC_LIMITTABS) || IsDlgButtonChecked(hwndDlg, IDC_SINGLEWINDOWMODE)) ? BST_CHECKED : BST_UNCHECKED);
 
 		SetDlgItemInt(hwndDlg, IDC_NRFLASH, M.GetByte("nrflash", 4), FALSE);
-		SendDlgItemMessage(hwndDlg, IDC_NRFLASHSPIN, UDM_SETRANGE, 0, MAKELONG(255, 1));
+		SendDlgItemMessage(hwndDlg, IDC_NRFLASHSPIN, UDM_SETRANGE, 0, MAKELONG(255, 0));
 		SendDlgItemMessage(hwndDlg, IDC_NRFLASHSPIN, UDM_SETPOS, 0, (int)M.GetByte("nrflash", 4));
 
 		SetDlgItemInt(hwndDlg, IDC_FLASHINTERVAL, M.GetDword("flashinterval", 1000), FALSE);


### PR DESCRIPTION
``` Options -> Message sessions -> Containers -> Flash containers [ 0 ] times ```
Even on the lowest setting, the taskbar item will flash at least once everytime someone speaks. This can be quite distracting and annoying. For me, it's enough that the icon changes, so I made this modification for myself many years ago. I use this together with the setting that disables the notification area icon blinking.