### PR TITLE
SendSS: fixed uploadpie upload by using HTTPS

### DIFF
--- a/plugins/SendScreenshotPlus/src/CSend.cpp
+++ b/plugins/SendScreenshotPlus/src/CSend.cpp
@@ -649,7 +649,7 @@ void CSend::HTTPFormDestroy(NETLIBHTTPREQUEST* nlhr)
 	mir_free(nlhr->pData), nlhr->pData = NULL;
 }
 
-int CSend::HTTPFormCreate(NETLIBHTTPREQUEST* nlhr, int requestType, char* url, HTTPFormData* frm, size_t frmNum)
+int CSend::HTTPFormCreate(NETLIBHTTPREQUEST* nlhr, int requestType, const char* url, HTTPFormData* frm, size_t frmNum)
 {
 	char boundary[16];
 	memcpy(boundary, "--M461C/", 8);
@@ -670,7 +670,7 @@ int CSend::HTTPFormCreate(NETLIBHTTPREQUEST* nlhr, int requestType, char* url, H
 	nlhr->requestType = requestType;
 	nlhr->flags = NLHRF_HTTP11;
 	if (!strncmp(url, "https://", 8)) nlhr->flags |= NLHRF_SSL;
-	nlhr->szUrl = url;
+	nlhr->szUrl = (char*)url;
 	nlhr->headersCount = 3;
 	for (HTTPFormData* iter = frm, *end = frm + frmNum; iter != end; ++iter) {
 		if (!(iter->flags&HTTPFF_HEADER)) break;

--- a/plugins/SendScreenshotPlus/src/CSend.h
+++ b/plugins/SendScreenshotPlus/src/CSend.h
@@ -128,7 +128,7 @@ class CSend {
 		static int GetJSONInteger(const char* json, size_t jsonlen, const char* variable,int defvalue);
 		static bool GetJSONBool(const char* json, size_t jsonlen, const char* variable);
 		void HTTPFormDestroy(NETLIBHTTPREQUEST* nlhr); /// use to free data inside "nlhr" created by HTTPFormCreate
-		int HTTPFormCreate(NETLIBHTTPREQUEST* nlhr,int requestType,char* url,HTTPFormData* frm,size_t frmNum); /// returns "0" on success, Exit() will be called on failure (stop processing)
+		int HTTPFormCreate(NETLIBHTTPREQUEST* nlhr, int requestType, const char* url, HTTPFormData* frm, size_t frmNum); /// returns "0" on success, Exit() will be called on failure (stop processing)
 };
 
 #endif

--- a/plugins/SendScreenshotPlus/src/CSendHost_uploadpie.cpp
+++ b/plugins/SendScreenshotPlus/src/CSendHost_uploadpie.cpp
@@ -26,6 +26,7 @@ CSendHost_UploadPie::~CSendHost_UploadPie()
 {
 }
 
+static const char kHostURL[] = "https://uploadpie.com/";
 //---------------------------------------------------------------------------
 int CSendHost_UploadPie::Send()
 {
@@ -45,10 +46,10 @@ int CSendHost_UploadPie::Send()
 		//{"expire",HTTPFORM_INT(3)},// 6h
 		//{"expire",HTTPFORM_INT(4)},// 1d
 		//{"expire",HTTPFORM_INT(5)},// 1w
-		//{"x",HTTPFORM_INT(130)},// ??
-		//{"y",HTTPFORM_INT(17)},// ??
+		//{"x",HTTPFORM_INT(130)},// relative X coordinate of "BAKE FILE" button (unused?)
+		//{"y",HTTPFORM_INT(17)},// relative Y coordinate of "BAKE FILE" button (unused?)
 	};
-	int error = HTTPFormCreate(&m_nlhr, REQUEST_POST, "http://uploadpie.com/", frm, sizeof(frm) / sizeof(HTTPFormData));
+	int error = HTTPFormCreate(&m_nlhr, REQUEST_POST, kHostURL, frm, sizeof(frm) / sizeof(HTTPFormData));
 	mir_free(tmp);
 	if (error)
 		return !m_bAsync;
@@ -73,11 +74,11 @@ void CSendHost_UploadPie::SendThread(void* obj)
 			char* url = reply->pData;
 			do {
 				char* pos;
-				if ((url = strstr(url, "http://uploadpie.com/"))) {
-					for (pos = url + 21; (*pos >= '0'&&*pos <= '9') || (*pos >= 'a'&&*pos <= 'z') || (*pos >= 'A'&&*pos <= 'Z') || *pos == '_' || *pos == '-' || *pos == '"' || *pos == '\''; ++pos) {
+				if ((url = strstr(url, kHostURL))) {
+					for (pos = url + _countof(kHostURL)-1; (*pos >= '0'&&*pos <= '9') || (*pos >= 'a'&&*pos <= 'z') || (*pos >= 'A'&&*pos <= 'Z') || *pos == '_' || *pos == '-' || *pos == '"' || *pos == '\''; ++pos) {
 						if (*pos == '"' || *pos == '\'') break;
 					}
-					if (url + 21 != pos && (*pos == '"' || *pos == '\'')) {
+					if (url + _countof(kHostURL)-1 != pos && (*pos == '"' || *pos == '\'')) {
 						*pos = '\0';
 						break;
 					}


### PR DESCRIPTION
P.S. why is NETLIBHTTPREQUEST->szUrl non-const? Netlib shouldn't (and doesn't IIRC) write to it, just read.