### PR TITLE
zlib: update to 1.2.11

### DIFF
--- a/libs/zlib/docs/ChangeLog
+++ b/libs/zlib/docs/ChangeLog
@@ -1,10 +1,53 @@
 
                 ChangeLog file for zlib
 
+Changes in 1.2.11 (15 Jan 2017)
+- Fix deflate stored bug when pulling last block from window
+- Permit immediate deflateParams changes before any deflate input
+
+Changes in 1.2.10 (2 Jan 2017)
+- Avoid warnings on snprintf() return value
+- Fix bug in deflate_stored() for zero-length input
+- Fix bug in gzwrite.c that produced corrupt gzip files
+- Remove files to be installed before copying them in Makefile.in
+- Add warnings when compiling with assembler code
+
+Changes in 1.2.9 (31 Dec 2016)
+- Fix contrib/minizip to permit unzipping with desktop API [Zouzou]
+- Improve contrib/blast to return unused bytes
+- Assure that gzoffset() is correct when appending
+- Improve compress() and uncompress() to support large lengths
+- Fix bug in test/example.c where error code not saved
+- Remedy Coverity warning [Randers-Pehrson]
+- Improve speed of gzprintf() in transparent mode
+- Fix inflateInit2() bug when windowBits is 16 or 32
+- Change DEBUG macro to ZLIB_DEBUG
+- Avoid uninitialized access by gzclose_w()
+- Allow building zlib outside of the source directory
+- Fix bug that accepted invalid zlib header when windowBits is zero
+- Fix gzseek() problem on MinGW due to buggy _lseeki64 there
+- Loop on write() calls in gzwrite.c in case of non-blocking I/O
+- Add --warn (-w) option to ./configure for more compiler warnings
+- Reject a window size of 256 bytes if not using the zlib wrapper
+- Fix bug when level 0 used with Z_HUFFMAN or Z_RLE
+- Add --debug (-d) option to ./configure to define ZLIB_DEBUG
+- Fix bugs in creating a very large gzip header
+- Add uncompress2() function, which returns the input size used
+- Assure that deflateParams() will not switch functions mid-block
+- Dramatically speed up deflation for level 0 (storing)
+- Add gzfread(), duplicating the interface of fread()
+- Add gzfwrite(), duplicating the interface of fwrite()
+- Add deflateGetDictionary() function
+- Use snprintf() for later versions of Microsoft C
+- Fix *Init macros to use z_ prefix when requested
+- Replace as400 with os400 for OS/400 support [Monnerat]
+- Add crc32_z() and adler32_z() functions with size_t lengths
+- Update Visual Studio project files [AraHaan]
+
 Changes in 1.2.8 (28 Apr 2013)
 - Update contrib/minizip/iowin32.c for Windows RT [Vollant]
 - Do not force Z_CONST for C++
-- Clean up contrib/vstudio [Ro§]
+- Clean up contrib/vstudio [RoÃŸ]
 - Correct spelling error in zlib.h
 - Fix mixed line endings in contrib/vstudio
 
@@ -34,7 +77,7 @@ Changes in 1.2.7.1 (24 Mar 2013)
 - Clean up the usage of z_const and respect const usage within zlib
 - Clean up examples/gzlog.[ch] comparisons of different types
 - Avoid shift equal to bits in type (caused endless loop)
-- Fix unintialized value bug in gzputc() introduced by const patches
+- Fix uninitialized value bug in gzputc() introduced by const patches
 - Fix memory allocation error in examples/zran.c [Nor]
 - Fix bug where gzopen(), gzclose() would write an empty file
 - Fix bug in gzclose() when gzwrite() runs out of memory
@@ -194,7 +237,7 @@ Changes in 1.2.5.2 (17 Dec 2011)
 - Add a transparent write mode to gzopen() when 'T' is in the mode
 - Update python link in zlib man page
 - Get inffixed.h and MAKEFIXED result to match
-- Add a ./config --solo option to make zlib subset with no libary use
+- Add a ./config --solo option to make zlib subset with no library use
 - Add undocumented inflateResetKeep() function for CAB file decoding
 - Add --cover option to ./configure for gcc coverage testing
 - Add #define ZLIB_CONST option to use const in the z_stream interface
@@ -564,7 +607,7 @@ Changes in 1.2.3.1 (16 August 2006)
 - Update make_vms.com [Zinser]
 - Use -fPIC for shared build in configure [Teredesai, Nicholson]
 - Use only major version number for libz.so on IRIX and OSF1 [Reinholdtsen]
-- Use fdopen() (not _fdopen()) for Interix in zutil.h [BŠck]
+- Use fdopen() (not _fdopen()) for Interix in zutil.h [BÃ¤ck]
 - Add some FAQ entries about the contrib directory
 - Update the MVS question in the FAQ
 - Avoid extraneous reads after EOF in gzio.c [Brown]
@@ -1178,7 +1221,7 @@ Changes in 1.0.6 (19 Jan 1998)
         386 asm code replacing longest_match().
    contrib/iostream/ by Kevin Ruland <kevin@rodin.wustl.edu>
         A C++ I/O streams interface to the zlib gz* functions
-   contrib/iostream2/  by Tyge Løvset <Tyge.Lovset@cmr.no>
+   contrib/iostream2/  by Tyge LÃ¸vset <Tyge.Lovset@cmr.no>
         Another C++ I/O streams interface
    contrib/untgz/  by "Pedro A. Aranda Guti\irrez" <paag@tid.es>
         A very simple tar.gz file extractor using zlib
@@ -1267,7 +1310,7 @@ Changes in 1.0.1 (20 May 96) [1.0 skipped to avoid confusion]
 - fix array overlay in deflate.c which sometimes caused bad compressed data
 - fix inflate bug with empty stored block
 - fix MSDOS medium model which was broken in 0.99
-- fix deflateParams() which could generated bad compressed data.
+- fix deflateParams() which could generate bad compressed data.
 - Bytef is define'd instead of typedef'ed (work around Borland bug)
 - added an INDEX file
 - new makefiles for DJGPP (Makefile.dj2), 32-bit Borland (Makefile.b32),

--- a/libs/zlib/docs/README
+++ b/libs/zlib/docs/README
@@ -1,6 +1,6 @@
 ZLIB DATA COMPRESSION LIBRARY
 
-zlib 1.2.8 is a general purpose data compression library.  All the code is
+zlib 1.2.11 is a general purpose data compression library.  All the code is
 thread safe.  The data format used by the zlib library is described by RFCs
 (Request for Comments) 1950 to 1952 in the files
 http://tools.ietf.org/html/rfc1950 (zlib format), rfc1951 (deflate format) and
@@ -31,7 +31,7 @@ Mark Nelson <markn@ieee.org> wrote an article about zlib for the Jan.  1997
 issue of Dr.  Dobb's Journal; a copy of the article is available at
 http://marknelson.us/1997/01/01/zlib-engine/ .
 
-The changes made in version 1.2.8 are documented in the file ChangeLog.
+The changes made in version 1.2.11 are documented in the file ChangeLog.
 
 Unsupported third party contributions are provided in directory contrib/ .
 
@@ -84,7 +84,7 @@ Acknowledgments:
 
 Copyright notice:
 
- (C) 1995-2013 Jean-loup Gailly and Mark Adler
+ (C) 1995-2017 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages

--- a/libs/zlib/res/zlib.rc
+++ b/libs/zlib/res/zlib.rc
@@ -1,5 +1,5 @@
 #include <winver.h>
-#include "../zlib.h"
+#include "..\src\zlib.h"
 
 #ifdef GCC_WINDRES
 VS_VERSION_INFO		VERSIONINFO

--- a/libs/zlib/res/zlib.rc
+++ b/libs/zlib/res/zlib.rc
@@ -1,5 +1,5 @@
 #include <winver.h>
-#include "..\src\zlib.h"
+#include "../zlib.h"
 
 #ifdef GCC_WINDRES
 VS_VERSION_INFO		VERSIONINFO
@@ -26,7 +26,7 @@ BEGIN
       VALUE "FileDescription",	"zlib data compression library\0"
       VALUE "FileVersion",	ZLIB_VERSION "\0"
       VALUE "InternalName",	"zlib1.dll\0"
-      VALUE "LegalCopyright",	"(C) 1995-2013 Jean-loup Gailly & Mark Adler\0"
+      VALUE "LegalCopyright",	"(C) 1995-2017 Jean-loup Gailly & Mark Adler\0"
       VALUE "OriginalFilename",	"zlib1.dll\0"
       VALUE "ProductName",	"zlib\0"
       VALUE "ProductVersion",	ZLIB_VERSION "\0"

--- a/libs/zlib/src/adler32.c
+++ b/libs/zlib/src/adler32.c
@@ -1,5 +1,5 @@
 /* adler32.c -- compute the Adler-32 checksum of a data stream
- * Copyright (C) 1995-2011 Mark Adler
+ * Copyright (C) 1995-2011, 2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -7,11 +7,9 @@
 
 #include "zutil.h"
 
-#define local static
-
 local uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 
-#define BASE 65521      /* largest prime smaller than 65536 */
+#define BASE 65521U     /* largest prime smaller than 65536 */
 #define NMAX 5552
 /* NMAX is the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1 */
 
@@ -61,119 +59,128 @@ local uLong adler32_combine_ OF((uLong adler1, uLong adler2, z_off64_t len2));
 #  define MOD63(a) a %= BASE
 #endif
 
-	/* ========================================================================= */
-uLong ZEXPORT adler32(adler, buf, len)
-uLong adler;
-const Bytef *buf;
-uInt len;
+/* ========================================================================= */
+uLong ZEXPORT adler32_z(adler, buf, len)
+    uLong adler;
+    const Bytef *buf;
+    z_size_t len;
 {
-	unsigned long sum2;
-	unsigned n;
+    unsigned long sum2;
+    unsigned n;
 
-	/* split Adler-32 into component sums */
-	sum2 = (adler >> 16) & 0xffff;
-	adler &= 0xffff;
+    /* split Adler-32 into component sums */
+    sum2 = (adler >> 16) & 0xffff;
+    adler &= 0xffff;
 
-	/* in case user likes doing a byte at a time, keep it fast */
-	if (len == 1) {
-		adler += buf[0];
-		if (adler >= BASE)
-			adler -= BASE;
-		sum2 += adler;
-		if (sum2 >= BASE)
-			sum2 -= BASE;
-		return adler | (sum2 << 16);
-	}
+    /* in case user likes doing a byte at a time, keep it fast */
+    if (len == 1) {
+        adler += buf[0];
+        if (adler >= BASE)
+            adler -= BASE;
+        sum2 += adler;
+        if (sum2 >= BASE)
+            sum2 -= BASE;
+        return adler | (sum2 << 16);
+    }
 
-	/* initial Adler-32 value (deferred check for len == 1 speed) */
-	if (buf == Z_NULL)
-		return 1L;
+    /* initial Adler-32 value (deferred check for len == 1 speed) */
+    if (buf == Z_NULL)
+        return 1L;
 
-	/* in case short lengths are provided, keep it somewhat fast */
-	if (len < 16) {
-		while (len--) {
-			adler += *buf++;
-			sum2 += adler;
-		}
-		if (adler >= BASE)
-			adler -= BASE;
-		MOD28(sum2);            /* only added so many BASE's */
-		return adler | (sum2 << 16);
-	}
+    /* in case short lengths are provided, keep it somewhat fast */
+    if (len < 16) {
+        while (len--) {
+            adler += *buf++;
+            sum2 += adler;
+        }
+        if (adler >= BASE)
+            adler -= BASE;
+        MOD28(sum2);            /* only added so many BASE's */
+        return adler | (sum2 << 16);
+    }
 
-	/* do length NMAX blocks -- requires just one modulo operation */
-	while (len >= NMAX) {
-		len -= NMAX;
-		n = NMAX / 16;          /* NMAX is divisible by 16 */
-		do {
-			DO16(buf);          /* 16 sums unrolled */
-			buf += 16;
-		} while (--n);
-		MOD(adler);
-		MOD(sum2);
-	}
+    /* do length NMAX blocks -- requires just one modulo operation */
+    while (len >= NMAX) {
+        len -= NMAX;
+        n = NMAX / 16;          /* NMAX is divisible by 16 */
+        do {
+            DO16(buf);          /* 16 sums unrolled */
+            buf += 16;
+        } while (--n);
+        MOD(adler);
+        MOD(sum2);
+    }
 
-	/* do remaining bytes (less than NMAX, still just one modulo) */
-	if (len) {                  /* avoid modulos if none remaining */
-		while (len >= 16) {
-			len -= 16;
-			DO16(buf);
-			buf += 16;
-		}
-		while (len--) {
-			adler += *buf++;
-			sum2 += adler;
-		}
-		MOD(adler);
-		MOD(sum2);
-	}
+    /* do remaining bytes (less than NMAX, still just one modulo) */
+    if (len) {                  /* avoid modulos if none remaining */
+        while (len >= 16) {
+            len -= 16;
+            DO16(buf);
+            buf += 16;
+        }
+        while (len--) {
+            adler += *buf++;
+            sum2 += adler;
+        }
+        MOD(adler);
+        MOD(sum2);
+    }
 
-	/* return recombined sums */
-	return adler | (sum2 << 16);
+    /* return recombined sums */
+    return adler | (sum2 << 16);
+}
+
+/* ========================================================================= */
+uLong ZEXPORT adler32(adler, buf, len)
+    uLong adler;
+    const Bytef *buf;
+    uInt len;
+{
+    return adler32_z(adler, buf, len);
 }
 
 /* ========================================================================= */
 local uLong adler32_combine_(adler1, adler2, len2)
-uLong adler1;
-uLong adler2;
-z_off64_t len2;
+    uLong adler1;
+    uLong adler2;
+    z_off64_t len2;
 {
-	unsigned long sum1;
-	unsigned long sum2;
-	unsigned rem;
+    unsigned long sum1;
+    unsigned long sum2;
+    unsigned rem;
 
-	/* for negative len, return invalid adler32 as a clue for debugging */
-	if (len2 < 0)
-		return 0xffffffffUL;
+    /* for negative len, return invalid adler32 as a clue for debugging */
+    if (len2 < 0)
+        return 0xffffffffUL;
 
-	/* the derivation of this formula is left as an exercise for the reader */
-	MOD63(len2);                /* assumes len2 >= 0 */
-	rem = (unsigned)len2;
-	sum1 = adler1 & 0xffff;
-	sum2 = rem * sum1;
-	MOD(sum2);
-	sum1 += (adler2 & 0xffff) + BASE - 1;
-	sum2 += ((adler1 >> 16) & 0xffff) + ((adler2 >> 16) & 0xffff) + BASE - rem;
-	if (sum1 >= BASE) sum1 -= BASE;
-	if (sum1 >= BASE) sum1 -= BASE;
-	if (sum2 >= (BASE << 1)) sum2 -= (BASE << 1);
-	if (sum2 >= BASE) sum2 -= BASE;
-	return sum1 | (sum2 << 16);
+    /* the derivation of this formula is left as an exercise for the reader */
+    MOD63(len2);                /* assumes len2 >= 0 */
+    rem = (unsigned)len2;
+    sum1 = adler1 & 0xffff;
+    sum2 = rem * sum1;
+    MOD(sum2);
+    sum1 += (adler2 & 0xffff) + BASE - 1;
+    sum2 += ((adler1 >> 16) & 0xffff) + ((adler2 >> 16) & 0xffff) + BASE - rem;
+    if (sum1 >= BASE) sum1 -= BASE;
+    if (sum1 >= BASE) sum1 -= BASE;
+    if (sum2 >= ((unsigned long)BASE << 1)) sum2 -= ((unsigned long)BASE << 1);
+    if (sum2 >= BASE) sum2 -= BASE;
+    return sum1 | (sum2 << 16);
 }
 
 /* ========================================================================= */
 uLong ZEXPORT adler32_combine(adler1, adler2, len2)
-uLong adler1;
-uLong adler2;
-z_off_t len2;
+    uLong adler1;
+    uLong adler2;
+    z_off_t len2;
 {
-	return adler32_combine_(adler1, adler2, len2);
+    return adler32_combine_(adler1, adler2, len2);
 }
 
 uLong ZEXPORT adler32_combine64(adler1, adler2, len2)
-uLong adler1;
-uLong adler2;
-z_off64_t len2;
+    uLong adler1;
+    uLong adler2;
+    z_off64_t len2;
 {
-	return adler32_combine_(adler1, adler2, len2);
+    return adler32_combine_(adler1, adler2, len2);
 }

--- a/libs/zlib/src/compress.c
+++ b/libs/zlib/src/compress.c
@@ -1,5 +1,5 @@
 /* compress.c -- compress a memory buffer
- * Copyright (C) 1995-2005 Jean-loup Gailly.
+ * Copyright (C) 1995-2005, 2014, 2016 Jean-loup Gailly, Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -19,62 +19,68 @@
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
    Z_STREAM_ERROR if the level parameter is invalid.
 */
-int ZEXPORT compress2(dest, destLen, source, sourceLen, level)
-Bytef *dest;
-uLongf *destLen;
-const Bytef *source;
-uLong sourceLen;
-int level;
+int ZEXPORT compress2 (dest, destLen, source, sourceLen, level)
+    Bytef *dest;
+    uLongf *destLen;
+    const Bytef *source;
+    uLong sourceLen;
+    int level;
 {
-	z_stream stream;
-	int err;
+    z_stream stream;
+    int err;
+    const uInt max = (uInt)-1;
+    uLong left;
 
-	stream.next_in = (z_const Bytef *)source;
-	stream.avail_in = (uInt)sourceLen;
-	#ifdef MAXSEG_64K
-	/* Check for source > 64K on 16-bit machine: */
-	if ((uLong)stream.avail_in != sourceLen) return Z_BUF_ERROR;
-	#endif
-	stream.next_out = dest;
-	stream.avail_out = (uInt)*destLen;
-	if ((uLong)stream.avail_out != *destLen) return Z_BUF_ERROR;
+    left = *destLen;
+    *destLen = 0;
 
-	stream.zalloc = (alloc_func)0;
-	stream.zfree = (free_func)0;
-	stream.opaque = (voidpf)0;
+    stream.zalloc = (alloc_func)0;
+    stream.zfree = (free_func)0;
+    stream.opaque = (voidpf)0;
 
-	err = deflateInit(&stream, level);
-	if (err != Z_OK) return err;
+    err = deflateInit(&stream, level);
+    if (err != Z_OK) return err;
 
-	err = deflate(&stream, Z_FINISH);
-	if (err != Z_STREAM_END) {
-		deflateEnd(&stream);
-		return err == Z_OK ? Z_BUF_ERROR : err;
-	}
-	*destLen = stream.total_out;
+    stream.next_out = dest;
+    stream.avail_out = 0;
+    stream.next_in = (z_const Bytef *)source;
+    stream.avail_in = 0;
 
-	err = deflateEnd(&stream);
-	return err;
+    do {
+        if (stream.avail_out == 0) {
+            stream.avail_out = left > (uLong)max ? max : (uInt)left;
+            left -= stream.avail_out;
+        }
+        if (stream.avail_in == 0) {
+            stream.avail_in = sourceLen > (uLong)max ? max : (uInt)sourceLen;
+            sourceLen -= stream.avail_in;
+        }
+        err = deflate(&stream, sourceLen ? Z_NO_FLUSH : Z_FINISH);
+    } while (err == Z_OK);
+
+    *destLen = stream.total_out;
+    deflateEnd(&stream);
+    return err == Z_STREAM_END ? Z_OK : err;
 }
 
 /* ===========================================================================
  */
-int ZEXPORT compress(dest, destLen, source, sourceLen)
-Bytef *dest;
-uLongf *destLen;
-const Bytef *source;
-uLong sourceLen;
+int ZEXPORT compress (dest, destLen, source, sourceLen)
+    Bytef *dest;
+    uLongf *destLen;
+    const Bytef *source;
+    uLong sourceLen;
 {
-	return compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
+    return compress2(dest, destLen, source, sourceLen, Z_DEFAULT_COMPRESSION);
 }
 
 /* ===========================================================================
-	  If the default memLevel or windowBits for deflateInit() is changed, then
-	this function needs to be updated.
+     If the default memLevel or windowBits for deflateInit() is changed, then
+   this function needs to be updated.
  */
-uLong ZEXPORT compressBound(sourceLen)
-uLong sourceLen;
+uLong ZEXPORT compressBound (sourceLen)
+    uLong sourceLen;
 {
-	return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) +
-		(sourceLen >> 25) + 13;
+    return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) +
+           (sourceLen >> 25) + 13;
 }

--- a/libs/zlib/src/crc32.c
+++ b/libs/zlib/src/crc32.c
@@ -1,5 +1,5 @@
 /* crc32.c -- compute the CRC-32 of a data stream
- * Copyright (C) 1995-2006, 2010, 2011, 2012 Mark Adler
+ * Copyright (C) 1995-2006, 2010, 2011, 2012, 2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  *
  * Thanks to Rodney Brown <rbrown64@csc.com.au> for his contribution of faster
@@ -30,17 +30,15 @@
 
 #include "zutil.h"      /* for STDC and FAR definitions */
 
-#define local static
-
 /* Definitions for doing the crc four data bytes at a time. */
 #if !defined(NOBYFOUR) && defined(Z_U4)
 #  define BYFOUR
 #endif
 #ifdef BYFOUR
    local unsigned long crc32_little OF((unsigned long,
-                        const unsigned char FAR *, unsigned));
+                        const unsigned char FAR *, z_size_t));
    local unsigned long crc32_big OF((unsigned long,
-                        const unsigned char FAR *, unsigned));
+                        const unsigned char FAR *, z_size_t));
 #  define TBLS 8
 #else
 #  define TBLS 1
@@ -184,16 +182,16 @@ local void write_table(out, table)
 #include "crc32.h"
 #endif /* DYNAMIC_CRC_TABLE */
 
- /* =========================================================================
-  * This function can be used by asm versions of crc32()
-  */
+/* =========================================================================
+ * This function can be used by asm versions of crc32()
+ */
 const z_crc_t FAR * ZEXPORT get_crc_table()
 {
-	#ifdef DYNAMIC_CRC_TABLE
-	if (crc_table_empty)
-		make_crc_table();
-	#endif /* DYNAMIC_CRC_TABLE */
-	return (const z_crc_t FAR *)crc_table;
+#ifdef DYNAMIC_CRC_TABLE
+    if (crc_table_empty)
+        make_crc_table();
+#endif /* DYNAMIC_CRC_TABLE */
+    return (const z_crc_t FAR *)crc_table;
 }
 
 /* ========================================================================= */
@@ -201,41 +199,62 @@ const z_crc_t FAR * ZEXPORT get_crc_table()
 #define DO8 DO1; DO1; DO1; DO1; DO1; DO1; DO1; DO1
 
 /* ========================================================================= */
-unsigned long ZEXPORT crc32(crc, buf, len)
-unsigned long crc;
-const unsigned char FAR *buf;
-uInt len;
+unsigned long ZEXPORT crc32_z(crc, buf, len)
+    unsigned long crc;
+    const unsigned char FAR *buf;
+    z_size_t len;
 {
-	if (buf == Z_NULL) return 0UL;
+    if (buf == Z_NULL) return 0UL;
 
-	#ifdef DYNAMIC_CRC_TABLE
-	if (crc_table_empty)
-		make_crc_table();
-	#endif /* DYNAMIC_CRC_TABLE */
+#ifdef DYNAMIC_CRC_TABLE
+    if (crc_table_empty)
+        make_crc_table();
+#endif /* DYNAMIC_CRC_TABLE */
 
-	#ifdef BYFOUR
-	if (sizeof(void *) == sizeof(ptrdiff_t)) {
-		z_crc_t endian;
+#ifdef BYFOUR
+    if (sizeof(void *) == sizeof(ptrdiff_t)) {
+        z_crc_t endian;
 
-		endian = 1;
-		if (*((unsigned char *)(&endian)))
-			return crc32_little(crc, buf, len);
-		else
-			return crc32_big(crc, buf, len);
-	}
-	#endif /* BYFOUR */
-	crc = crc ^ 0xffffffffUL;
-	while (len >= 8) {
-		DO8;
-		len -= 8;
-	}
-	if (len) do {
-		DO1;
-	} while (--len);
-	return crc ^ 0xffffffffUL;
+        endian = 1;
+        if (*((unsigned char *)(&endian)))
+            return crc32_little(crc, buf, len);
+        else
+            return crc32_big(crc, buf, len);
+    }
+#endif /* BYFOUR */
+    crc = crc ^ 0xffffffffUL;
+    while (len >= 8) {
+        DO8;
+        len -= 8;
+    }
+    if (len) do {
+        DO1;
+    } while (--len);
+    return crc ^ 0xffffffffUL;
+}
+
+/* ========================================================================= */
+unsigned long ZEXPORT crc32(crc, buf, len)
+    unsigned long crc;
+    const unsigned char FAR *buf;
+    uInt len;
+{
+    return crc32_z(crc, buf, len);
 }
 
 #ifdef BYFOUR
+
+/*
+   This BYFOUR code accesses the passed unsigned char * buffer with a 32-bit
+   integer pointer type. This violates the strict aliasing rule, where a
+   compiler can assume, for optimization purposes, that two pointers to
+   fundamentally different types won't ever point to the same memory. This can
+   manifest as a problem only if one of the pointers is written to. This code
+   only reads from those pointers. So long as this code remains isolated in
+   this compilation unit, there won't be a problem. For this reason, this code
+   should not be copied and pasted into a compilation unit in which other code
+   writes to the buffer that is passed to these routines.
+ */
 
 /* ========================================================================= */
 #define DOLIT4 c ^= *buf4++; \
@@ -245,78 +264,76 @@ uInt len;
 
 /* ========================================================================= */
 local unsigned long crc32_little(crc, buf, len)
-unsigned long crc;
-const unsigned char FAR *buf;
-unsigned len;
+    unsigned long crc;
+    const unsigned char FAR *buf;
+    z_size_t len;
 {
-	register z_crc_t c;
-	register const z_crc_t FAR *buf4;
+    register z_crc_t c;
+    register const z_crc_t FAR *buf4;
 
-	c = (z_crc_t)crc;
-	c = ~c;
-	while (len && ((ptrdiff_t)buf & 3)) {
-		c = crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8);
-		len--;
-	}
+    c = (z_crc_t)crc;
+    c = ~c;
+    while (len && ((ptrdiff_t)buf & 3)) {
+        c = crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8);
+        len--;
+    }
 
-	buf4 = (const z_crc_t FAR *)(const void FAR *)buf;
-	while (len >= 32) {
-		DOLIT32;
-		len -= 32;
-	}
-	while (len >= 4) {
-		DOLIT4;
-		len -= 4;
-	}
-	buf = (const unsigned char FAR *)buf4;
+    buf4 = (const z_crc_t FAR *)(const void FAR *)buf;
+    while (len >= 32) {
+        DOLIT32;
+        len -= 32;
+    }
+    while (len >= 4) {
+        DOLIT4;
+        len -= 4;
+    }
+    buf = (const unsigned char FAR *)buf4;
 
-	if (len) do {
-		c = crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8);
-	} while (--len);
-	c = ~c;
-	return (unsigned long)c;
+    if (len) do {
+        c = crc_table[0][(c ^ *buf++) & 0xff] ^ (c >> 8);
+    } while (--len);
+    c = ~c;
+    return (unsigned long)c;
 }
 
 /* ========================================================================= */
-#define DOBIG4 c ^= *++buf4; \
+#define DOBIG4 c ^= *buf4++; \
         c = crc_table[4][c & 0xff] ^ crc_table[5][(c >> 8) & 0xff] ^ \
             crc_table[6][(c >> 16) & 0xff] ^ crc_table[7][c >> 24]
 #define DOBIG32 DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4; DOBIG4
 
 /* ========================================================================= */
 local unsigned long crc32_big(crc, buf, len)
-unsigned long crc;
-const unsigned char FAR *buf;
-unsigned len;
+    unsigned long crc;
+    const unsigned char FAR *buf;
+    z_size_t len;
 {
-	register z_crc_t c;
-	register const z_crc_t FAR *buf4;
+    register z_crc_t c;
+    register const z_crc_t FAR *buf4;
 
-	c = ZSWAP32((z_crc_t)crc);
-	c = ~c;
-	while (len && ((ptrdiff_t)buf & 3)) {
-		c = crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8);
-		len--;
-	}
+    c = ZSWAP32((z_crc_t)crc);
+    c = ~c;
+    while (len && ((ptrdiff_t)buf & 3)) {
+        c = crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8);
+        len--;
+    }
 
-	buf4 = (const z_crc_t FAR *)(const void FAR *)buf;
-	buf4--;
-	while (len >= 32) {
-		DOBIG32;
-		len -= 32;
-	}
-	while (len >= 4) {
-		DOBIG4;
-		len -= 4;
-	}
-	buf4++;
-	buf = (const unsigned char FAR *)buf4;
+    buf4 = (const z_crc_t FAR *)(const void FAR *)buf;
+    while (len >= 32) {
+        DOBIG32;
+        len -= 32;
+    }
+    while (len >= 4) {
+        DOBIG4;
+        len -= 4;
+    }
+    buf = (const unsigned char FAR *)buf4;
 
-	if (len) do {
-		c = crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8);
-	} while (--len);
-	c = ~c;
-	return (unsigned long)(ZSWAP32(c));
+    if (len) do {
+        c = crc_table[4][(c >> 24) ^ *buf++] ^ (c << 8);
+    } while (--len);
+    c = ~c;
+    return (unsigned long)(ZSWAP32(c));
 }
 
 #endif /* BYFOUR */
@@ -325,101 +342,101 @@ unsigned len;
 
 /* ========================================================================= */
 local unsigned long gf2_matrix_times(mat, vec)
-unsigned long *mat;
-unsigned long vec;
+    unsigned long *mat;
+    unsigned long vec;
 {
-	unsigned long sum;
+    unsigned long sum;
 
-	sum = 0;
-	while (vec) {
-		if (vec & 1)
-			sum ^= *mat;
-		vec >>= 1;
-		mat++;
-	}
-	return sum;
+    sum = 0;
+    while (vec) {
+        if (vec & 1)
+            sum ^= *mat;
+        vec >>= 1;
+        mat++;
+    }
+    return sum;
 }
 
 /* ========================================================================= */
 local void gf2_matrix_square(square, mat)
-unsigned long *square;
-unsigned long *mat;
+    unsigned long *square;
+    unsigned long *mat;
 {
-	int n;
+    int n;
 
-	for (n = 0; n < GF2_DIM; n++)
-		square[n] = gf2_matrix_times(mat, mat[n]);
+    for (n = 0; n < GF2_DIM; n++)
+        square[n] = gf2_matrix_times(mat, mat[n]);
 }
 
 /* ========================================================================= */
 local uLong crc32_combine_(crc1, crc2, len2)
-uLong crc1;
-uLong crc2;
-z_off64_t len2;
+    uLong crc1;
+    uLong crc2;
+    z_off64_t len2;
 {
-	int n;
-	unsigned long row;
-	unsigned long even[GF2_DIM];    /* even-power-of-two zeros operator */
-	unsigned long odd[GF2_DIM];     /* odd-power-of-two zeros operator */
+    int n;
+    unsigned long row;
+    unsigned long even[GF2_DIM];    /* even-power-of-two zeros operator */
+    unsigned long odd[GF2_DIM];     /* odd-power-of-two zeros operator */
 
-	/* degenerate case (also disallow negative lengths) */
-	if (len2 <= 0)
-		return crc1;
+    /* degenerate case (also disallow negative lengths) */
+    if (len2 <= 0)
+        return crc1;
 
-	/* put operator for one zero bit in odd */
-	odd[0] = 0xedb88320UL;          /* CRC-32 polynomial */
-	row = 1;
-	for (n = 1; n < GF2_DIM; n++) {
-		odd[n] = row;
-		row <<= 1;
-	}
+    /* put operator for one zero bit in odd */
+    odd[0] = 0xedb88320UL;          /* CRC-32 polynomial */
+    row = 1;
+    for (n = 1; n < GF2_DIM; n++) {
+        odd[n] = row;
+        row <<= 1;
+    }
 
-	/* put operator for two zero bits in even */
-	gf2_matrix_square(even, odd);
+    /* put operator for two zero bits in even */
+    gf2_matrix_square(even, odd);
 
-	/* put operator for four zero bits in odd */
-	gf2_matrix_square(odd, even);
+    /* put operator for four zero bits in odd */
+    gf2_matrix_square(odd, even);
 
-	/* apply len2 zeros to crc1 (first square will put the operator for one
-		zero byte, eight zero bits, in even) */
-	do {
-		/* apply zeros operator for this bit of len2 */
-		gf2_matrix_square(even, odd);
-		if (len2 & 1)
-			crc1 = gf2_matrix_times(even, crc1);
-		len2 >>= 1;
+    /* apply len2 zeros to crc1 (first square will put the operator for one
+       zero byte, eight zero bits, in even) */
+    do {
+        /* apply zeros operator for this bit of len2 */
+        gf2_matrix_square(even, odd);
+        if (len2 & 1)
+            crc1 = gf2_matrix_times(even, crc1);
+        len2 >>= 1;
 
-		/* if no more bits set, then done */
-		if (len2 == 0)
-			break;
+        /* if no more bits set, then done */
+        if (len2 == 0)
+            break;
 
-		/* another iteration of the loop with odd and even swapped */
-		gf2_matrix_square(odd, even);
-		if (len2 & 1)
-			crc1 = gf2_matrix_times(odd, crc1);
-		len2 >>= 1;
+        /* another iteration of the loop with odd and even swapped */
+        gf2_matrix_square(odd, even);
+        if (len2 & 1)
+            crc1 = gf2_matrix_times(odd, crc1);
+        len2 >>= 1;
 
-		/* if no more bits set, then done */
-	} while (len2 != 0);
+        /* if no more bits set, then done */
+    } while (len2 != 0);
 
-	/* return combined crc */
-	crc1 ^= crc2;
-	return crc1;
+    /* return combined crc */
+    crc1 ^= crc2;
+    return crc1;
 }
 
 /* ========================================================================= */
 uLong ZEXPORT crc32_combine(crc1, crc2, len2)
-uLong crc1;
-uLong crc2;
-z_off_t len2;
+    uLong crc1;
+    uLong crc2;
+    z_off_t len2;
 {
-	return crc32_combine_(crc1, crc2, len2);
+    return crc32_combine_(crc1, crc2, len2);
 }
 
 uLong ZEXPORT crc32_combine64(crc1, crc2, len2)
-uLong crc1;
-uLong crc2;
-z_off64_t len2;
+    uLong crc1;
+    uLong crc2;
+    z_off64_t len2;
 {
-	return crc32_combine_(crc1, crc2, len2);
+    return crc32_combine_(crc1, crc2, len2);
 }

--- a/libs/zlib/src/deflate.c
+++ b/libs/zlib/src/deflate.c
@@ -1,5 +1,5 @@
 /* deflate.c -- compress data using the deflation algorithm
- * Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
+ * Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -52,7 +52,7 @@
 #include "deflate.h"
 
 const char deflate_copyright[] =
-   " deflate 1.2.8 Copyright 1995-2013 Jean-loup Gailly and Mark Adler ";
+   " deflate 1.2.11 Copyright 1995-2017 Jean-loup Gailly and Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot
@@ -60,20 +60,21 @@ const char deflate_copyright[] =
   copyright string in the executable of your product.
  */
 
- /* ===========================================================================
-  *  Function prototypes.
-  */
-typedef enum
-{
-	need_more,      /* block not completed, need more input or more output */
-	block_done,     /* block flush performed */
-	finish_started, /* finish started, need only more output at next deflate */
-	finish_done     /* finish done, accept no more input or output */
+/* ===========================================================================
+ *  Function prototypes.
+ */
+typedef enum {
+    need_more,      /* block not completed, need more input or more output */
+    block_done,     /* block flush performed */
+    finish_started, /* finish started, need only more output at next deflate */
+    finish_done     /* finish done, accept no more input or output */
 } block_state;
 
-typedef block_state(*compress_func) OF((deflate_state *s, int flush));
+typedef block_state (*compress_func) OF((deflate_state *s, int flush));
 /* Compression function. Returns the block state after the call. */
 
+local int deflateStateCheck      OF((z_streamp strm));
+local void slide_hash     OF((deflate_state *s));
 local void fill_window    OF((deflate_state *s));
 local block_state deflate_stored OF((deflate_state *s, int flush));
 local block_state deflate_fast   OF((deflate_state *s, int flush));
@@ -85,17 +86,18 @@ local block_state deflate_huff   OF((deflate_state *s, int flush));
 local void lm_init        OF((deflate_state *s));
 local void putShortMSB    OF((deflate_state *s, uInt b));
 local void flush_pending  OF((z_streamp strm));
-local int read_buf        OF((z_streamp strm, Bytef *buf, unsigned size));
+local unsigned read_buf   OF((z_streamp strm, Bytef *buf, unsigned size));
 #ifdef ASMV
-void match_init OF((void)); /* asm code initialization */
-uInt longest_match  OF((deflate_state *s, IPos cur_match));
+#  pragma message("Assembler code may have bugs -- use at your own risk")
+      void match_init OF((void)); /* asm code initialization */
+      uInt longest_match  OF((deflate_state *s, IPos cur_match));
 #else
 local uInt longest_match  OF((deflate_state *s, IPos cur_match));
 #endif
 
-#ifdef DEBUG
+#ifdef ZLIB_DEBUG
 local  void check_match OF((deflate_state *s, IPos start, IPos match,
-	int length));
+                            int length));
 #endif
 
 /* ===========================================================================
@@ -103,7 +105,7 @@ local  void check_match OF((deflate_state *s, IPos start, IPos match,
  */
 
 #define NIL 0
- /* Tail of hash chains */
+/* Tail of hash chains */
 
 #ifndef TOO_FAR
 #  define TOO_FAR 4096
@@ -115,34 +117,33 @@ local  void check_match OF((deflate_state *s, IPos start, IPos match,
  * exclude worst case performance for pathological files. Better values may be
  * found for specific files.
  */
-typedef struct config_s
-{
-	ush good_length; /* reduce lazy search above this match length */
-	ush max_lazy;    /* do not perform lazy search above this match length */
-	ush nice_length; /* quit search above this match length */
-	ush max_chain;
-	compress_func func;
+typedef struct config_s {
+   ush good_length; /* reduce lazy search above this match length */
+   ush max_lazy;    /* do not perform lazy search above this match length */
+   ush nice_length; /* quit search above this match length */
+   ush max_chain;
+   compress_func func;
 } config;
 
 #ifdef FASTEST
 local const config configuration_table[2] = {
-	/*      good lazy nice chain */
-	/* 0 */ {0,    0,  0,    0, deflate_stored},  /* store only */
-	/* 1 */ {4,    4,  8,    4, deflate_fast} }; /* max speed, no lazy matches */
+/*      good lazy nice chain */
+/* 0 */ {0,    0,  0,    0, deflate_stored},  /* store only */
+/* 1 */ {4,    4,  8,    4, deflate_fast}}; /* max speed, no lazy matches */
 #else
 local const config configuration_table[10] = {
-	/*      good lazy nice chain */
-	/* 0 */ {0,    0,  0,    0, deflate_stored},  /* store only */
-	/* 1 */ {4,    4,  8,    4, deflate_fast}, /* max speed, no lazy matches */
-	/* 2 */ {4,    5, 16,    8, deflate_fast},
-	/* 3 */ {4,    6, 32,   32, deflate_fast},
+/*      good lazy nice chain */
+/* 0 */ {0,    0,  0,    0, deflate_stored},  /* store only */
+/* 1 */ {4,    4,  8,    4, deflate_fast}, /* max speed, no lazy matches */
+/* 2 */ {4,    5, 16,    8, deflate_fast},
+/* 3 */ {4,    6, 32,   32, deflate_fast},
 
-	/* 4 */ {4,    4, 16,   16, deflate_slow},  /* lazy matches */
-	/* 5 */ {8,   16, 32,   32, deflate_slow},
-	/* 6 */ {8,   16, 128, 128, deflate_slow},
-	/* 7 */ {8,   32, 128, 256, deflate_slow},
-	/* 8 */ {32, 128, 258, 1024, deflate_slow},
-	/* 9 */ {32, 258, 258, 4096, deflate_slow} }; /* max compression */
+/* 4 */ {4,    4, 16,   16, deflate_slow},  /* lazy matches */
+/* 5 */ {8,   16, 32,   32, deflate_slow},
+/* 6 */ {8,   16, 128, 128, deflate_slow},
+/* 7 */ {8,   32, 128, 256, deflate_slow},
+/* 8 */ {32, 128, 258, 1024, deflate_slow},
+/* 9 */ {32, 258, 258, 4096, deflate_slow}}; /* max compression */
 #endif
 
 /* Note: the deflate() code requires max_lazy >= MIN_MATCH and max_chain >= 4
@@ -150,35 +151,28 @@ local const config configuration_table[10] = {
  * meaning.
  */
 
-#define EQUAL 0
- /* result of memcmp for equal strings */
-
-#ifndef NO_DUMMY_DECL
-struct static_tree_desc_s { int dummy; }; /* for buggy compilers */
-#endif
-
 /* rank Z_BLOCK between Z_NO_FLUSH and Z_PARTIAL_FLUSH */
-#define RANK(f) (((f) << 1) - ((f) > 4 ? 9 : 0))
+#define RANK(f) (((f) * 2) - ((f) > 4 ? 9 : 0))
 
 /* ===========================================================================
  * Update a hash value with the given input byte
- * IN  assertion: all calls to to UPDATE_HASH are made with consecutive
- *    input characters, so that a running hash key can be computed from the
- *    previous key instead of complete recalculation each time.
+ * IN  assertion: all calls to UPDATE_HASH are made with consecutive input
+ *    characters, so that a running hash key can be computed from the previous
+ *    key instead of complete recalculation each time.
  */
 #define UPDATE_HASH(s,h,c) (h = (((h)<<s->hash_shift) ^ (c)) & s->hash_mask)
 
 
- /* ===========================================================================
-  * Insert string str in the dictionary and set match_head to the previous head
-  * of the hash chain (the most recent string with same hash key). Return
-  * the previous length of the hash chain.
-  * If this file is compiled with -DFASTEST, the compression level is forced
-  * to 1, and no hash chains are maintained.
-  * IN  assertion: all calls to to INSERT_STRING are made with consecutive
-  *    input characters and the first MIN_MATCH bytes of str are valid
-  *    (except for the last MIN_MATCH-1 bytes of the input file).
-  */
+/* ===========================================================================
+ * Insert string str in the dictionary and set match_head to the previous head
+ * of the hash chain (the most recent string with same hash key). Return
+ * the previous length of the hash chain.
+ * If this file is compiled with -DFASTEST, the compression level is forced
+ * to 1, and no hash chains are maintained.
+ * IN  assertion: all calls to INSERT_STRING are made with consecutive input
+ *    characters and the first MIN_MATCH bytes of str are valid (except for
+ *    the last MIN_MATCH-1 bytes of the input file).
+ */
 #ifdef FASTEST
 #define INSERT_STRING(s, str, match_head) \
    (UPDATE_HASH(s, s->ins_h, s->window[(str) + (MIN_MATCH-1)]), \
@@ -191,361 +185,451 @@ struct static_tree_desc_s { int dummy; }; /* for buggy compilers */
     s->head[s->ins_h] = (Pos)(str))
 #endif
 
-  /* ===========================================================================
-	* Initialize the hash table (avoiding 64K overflow for 16 bit systems).
-	* prev[] will be initialized on the fly.
-	*/
+/* ===========================================================================
+ * Initialize the hash table (avoiding 64K overflow for 16 bit systems).
+ * prev[] will be initialized on the fly.
+ */
 #define CLEAR_HASH(s) \
     s->head[s->hash_size-1] = NIL; \
     zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head));
 
-	/* ========================================================================= */
-int ZEXPORT deflateInit_(strm, level, version, stream_size)
-z_streamp strm;
-int level;
-const char *version;
-int stream_size;
+/* ===========================================================================
+ * Slide the hash table when sliding the window down (could be avoided with 32
+ * bit values at the expense of memory usage). We slide even when level == 0 to
+ * keep the hash table consistent if we switch back to level > 0 later.
+ */
+local void slide_hash(s)
+    deflate_state *s;
 {
-	return deflateInit2_(strm, level, Z_DEFLATED, MAX_WBITS, DEF_MEM_LEVEL,
-		Z_DEFAULT_STRATEGY, version, stream_size);
-	/* To do: ignore strm->next_in if we use it as window */
+    unsigned n, m;
+    Posf *p;
+    uInt wsize = s->w_size;
+
+    n = s->hash_size;
+    p = &s->head[n];
+    do {
+        m = *--p;
+        *p = (Pos)(m >= wsize ? m - wsize : NIL);
+    } while (--n);
+    n = wsize;
+#ifndef FASTEST
+    p = &s->prev[n];
+    do {
+        m = *--p;
+        *p = (Pos)(m >= wsize ? m - wsize : NIL);
+        /* If n is not on any hash chain, prev[n] is garbage but
+         * its value will never be used.
+         */
+    } while (--n);
+#endif
+}
+
+/* ========================================================================= */
+int ZEXPORT deflateInit_(strm, level, version, stream_size)
+    z_streamp strm;
+    int level;
+    const char *version;
+    int stream_size;
+{
+    return deflateInit2_(strm, level, Z_DEFLATED, MAX_WBITS, DEF_MEM_LEVEL,
+                         Z_DEFAULT_STRATEGY, version, stream_size);
+    /* To do: ignore strm->next_in if we use it as window */
 }
 
 /* ========================================================================= */
 int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
-	version, stream_size)
-	z_streamp strm;
-int  level;
-int  method;
-int  windowBits;
-int  memLevel;
-int  strategy;
-const char *version;
-int stream_size;
+                  version, stream_size)
+    z_streamp strm;
+    int  level;
+    int  method;
+    int  windowBits;
+    int  memLevel;
+    int  strategy;
+    const char *version;
+    int stream_size;
 {
-	deflate_state *s;
-	int wrap = 1;
-	static const char my_version[] = ZLIB_VERSION;
+    deflate_state *s;
+    int wrap = 1;
+    static const char my_version[] = ZLIB_VERSION;
 
-	ushf *overlay;
-	/* We overlay pending_buf and d_buf+l_buf. This works since the average
-	 * output size for (length,distance) codes is <= 24 bits.
-	 */
+    ushf *overlay;
+    /* We overlay pending_buf and d_buf+l_buf. This works since the average
+     * output size for (length,distance) codes is <= 24 bits.
+     */
 
-	if (version == Z_NULL || version[0] != my_version[0] ||
-		stream_size != sizeof(z_stream)) {
-		return Z_VERSION_ERROR;
-	}
-	if (strm == Z_NULL) return Z_STREAM_ERROR;
+    if (version == Z_NULL || version[0] != my_version[0] ||
+        stream_size != sizeof(z_stream)) {
+        return Z_VERSION_ERROR;
+    }
+    if (strm == Z_NULL) return Z_STREAM_ERROR;
 
-	strm->msg = Z_NULL;
-	if (strm->zalloc == (alloc_func)0) {
-		#ifdef Z_SOLO
-		return Z_STREAM_ERROR;
-		#else
-		strm->zalloc = zcalloc;
-		strm->opaque = (voidpf)0;
-		#endif
-	}
-	if (strm->zfree == (free_func)0)
-		#ifdef Z_SOLO
-		return Z_STREAM_ERROR;
-	#else
-		strm->zfree = zcfree;
-	#endif
+    strm->msg = Z_NULL;
+    if (strm->zalloc == (alloc_func)0) {
+#ifdef Z_SOLO
+        return Z_STREAM_ERROR;
+#else
+        strm->zalloc = zcalloc;
+        strm->opaque = (voidpf)0;
+#endif
+    }
+    if (strm->zfree == (free_func)0)
+#ifdef Z_SOLO
+        return Z_STREAM_ERROR;
+#else
+        strm->zfree = zcfree;
+#endif
 
-	#ifdef FASTEST
-	if (level != 0) level = 1;
-	#else
-	if (level == Z_DEFAULT_COMPRESSION) level = 6;
-	#endif
+#ifdef FASTEST
+    if (level != 0) level = 1;
+#else
+    if (level == Z_DEFAULT_COMPRESSION) level = 6;
+#endif
 
-	if (windowBits < 0) { /* suppress zlib wrapper */
-		wrap = 0;
-		windowBits = -windowBits;
-	}
-	#ifdef GZIP
-	else if (windowBits > 15) {
-		wrap = 2;       /* write gzip wrapper instead */
-		windowBits -= 16;
-	}
-	#endif
-	if (memLevel < 1 || memLevel > MAX_MEM_LEVEL || method != Z_DEFLATED ||
-		windowBits < 8 || windowBits > 15 || level < 0 || level > 9 ||
-		strategy < 0 || strategy > Z_FIXED) {
-		return Z_STREAM_ERROR;
-	}
-	if (windowBits == 8) windowBits = 9;  /* until 256-byte window bug fixed */
-	s = (deflate_state *)ZALLOC(strm, 1, sizeof(deflate_state));
-	if (s == Z_NULL) return Z_MEM_ERROR;
-	strm->state = (struct internal_state FAR *)s;
-	s->strm = strm;
+    if (windowBits < 0) { /* suppress zlib wrapper */
+        wrap = 0;
+        windowBits = -windowBits;
+    }
+#ifdef GZIP
+    else if (windowBits > 15) {
+        wrap = 2;       /* write gzip wrapper instead */
+        windowBits -= 16;
+    }
+#endif
+    if (memLevel < 1 || memLevel > MAX_MEM_LEVEL || method != Z_DEFLATED ||
+        windowBits < 8 || windowBits > 15 || level < 0 || level > 9 ||
+        strategy < 0 || strategy > Z_FIXED || (windowBits == 8 && wrap != 1)) {
+        return Z_STREAM_ERROR;
+    }
+    if (windowBits == 8) windowBits = 9;  /* until 256-byte window bug fixed */
+    s = (deflate_state *) ZALLOC(strm, 1, sizeof(deflate_state));
+    if (s == Z_NULL) return Z_MEM_ERROR;
+    strm->state = (struct internal_state FAR *)s;
+    s->strm = strm;
+    s->status = INIT_STATE;     /* to pass state test in deflateReset() */
 
-	s->wrap = wrap;
-	s->gzhead = Z_NULL;
-	s->w_bits = windowBits;
-	s->w_size = 1 << s->w_bits;
-	s->w_mask = s->w_size - 1;
+    s->wrap = wrap;
+    s->gzhead = Z_NULL;
+    s->w_bits = (uInt)windowBits;
+    s->w_size = 1 << s->w_bits;
+    s->w_mask = s->w_size - 1;
 
-	s->hash_bits = memLevel + 7;
-	s->hash_size = 1 << s->hash_bits;
-	s->hash_mask = s->hash_size - 1;
-	s->hash_shift = ((s->hash_bits + MIN_MATCH - 1) / MIN_MATCH);
+    s->hash_bits = (uInt)memLevel + 7;
+    s->hash_size = 1 << s->hash_bits;
+    s->hash_mask = s->hash_size - 1;
+    s->hash_shift =  ((s->hash_bits+MIN_MATCH-1)/MIN_MATCH);
 
-	s->window = (Bytef *)ZALLOC(strm, s->w_size, 2 * sizeof(Byte));
-	s->prev = (Posf *)ZALLOC(strm, s->w_size, sizeof(Pos));
-	s->head = (Posf *)ZALLOC(strm, s->hash_size, sizeof(Pos));
+    s->window = (Bytef *) ZALLOC(strm, s->w_size, 2*sizeof(Byte));
+    s->prev   = (Posf *)  ZALLOC(strm, s->w_size, sizeof(Pos));
+    s->head   = (Posf *)  ZALLOC(strm, s->hash_size, sizeof(Pos));
 
-	s->high_water = 0;      /* nothing written to s->window yet */
+    s->high_water = 0;      /* nothing written to s->window yet */
 
-	s->lit_bufsize = 1 << (memLevel + 6); /* 16K elements by default */
+    s->lit_bufsize = 1 << (memLevel + 6); /* 16K elements by default */
 
-	overlay = (ushf *)ZALLOC(strm, s->lit_bufsize, sizeof(ush) + 2);
-	s->pending_buf = (uchf *)overlay;
-	s->pending_buf_size = (ulg)s->lit_bufsize * (sizeof(ush) + 2L);
+    overlay = (ushf *) ZALLOC(strm, s->lit_bufsize, sizeof(ush)+2);
+    s->pending_buf = (uchf *) overlay;
+    s->pending_buf_size = (ulg)s->lit_bufsize * (sizeof(ush)+2L);
 
-	if (s->window == Z_NULL || s->prev == Z_NULL || s->head == Z_NULL ||
-		s->pending_buf == Z_NULL) {
-		s->status = FINISH_STATE;
-		strm->msg = ERR_MSG(Z_MEM_ERROR);
-		deflateEnd(strm);
-		return Z_MEM_ERROR;
-	}
-	s->d_buf = overlay + s->lit_bufsize / sizeof(ush);
-	s->l_buf = s->pending_buf + (1 + sizeof(ush))*s->lit_bufsize;
+    if (s->window == Z_NULL || s->prev == Z_NULL || s->head == Z_NULL ||
+        s->pending_buf == Z_NULL) {
+        s->status = FINISH_STATE;
+        strm->msg = ERR_MSG(Z_MEM_ERROR);
+        deflateEnd (strm);
+        return Z_MEM_ERROR;
+    }
+    s->d_buf = overlay + s->lit_bufsize/sizeof(ush);
+    s->l_buf = s->pending_buf + (1+sizeof(ush))*s->lit_bufsize;
 
-	s->level = level;
-	s->strategy = strategy;
-	s->method = (Byte)method;
+    s->level = level;
+    s->strategy = strategy;
+    s->method = (Byte)method;
 
-	return deflateReset(strm);
+    return deflateReset(strm);
+}
+
+/* =========================================================================
+ * Check for a valid deflate stream state. Return 0 if ok, 1 if not.
+ */
+local int deflateStateCheck (strm)
+    z_streamp strm;
+{
+    deflate_state *s;
+    if (strm == Z_NULL ||
+        strm->zalloc == (alloc_func)0 || strm->zfree == (free_func)0)
+        return 1;
+    s = strm->state;
+    if (s == Z_NULL || s->strm != strm || (s->status != INIT_STATE &&
+#ifdef GZIP
+                                           s->status != GZIP_STATE &&
+#endif
+                                           s->status != EXTRA_STATE &&
+                                           s->status != NAME_STATE &&
+                                           s->status != COMMENT_STATE &&
+                                           s->status != HCRC_STATE &&
+                                           s->status != BUSY_STATE &&
+                                           s->status != FINISH_STATE))
+        return 1;
+    return 0;
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateSetDictionary(strm, dictionary, dictLength)
-z_streamp strm;
-const Bytef *dictionary;
-uInt  dictLength;
+int ZEXPORT deflateSetDictionary (strm, dictionary, dictLength)
+    z_streamp strm;
+    const Bytef *dictionary;
+    uInt  dictLength;
 {
-	deflate_state *s;
-	uInt str, n;
-	int wrap;
-	unsigned avail;
-	z_const unsigned char *next;
+    deflate_state *s;
+    uInt str, n;
+    int wrap;
+    unsigned avail;
+    z_const unsigned char *next;
 
-	if (strm == Z_NULL || strm->state == Z_NULL || dictionary == Z_NULL)
-		return Z_STREAM_ERROR;
-	s = strm->state;
-	wrap = s->wrap;
-	if (wrap == 2 || (wrap == 1 && s->status != INIT_STATE) || s->lookahead)
-		return Z_STREAM_ERROR;
+    if (deflateStateCheck(strm) || dictionary == Z_NULL)
+        return Z_STREAM_ERROR;
+    s = strm->state;
+    wrap = s->wrap;
+    if (wrap == 2 || (wrap == 1 && s->status != INIT_STATE) || s->lookahead)
+        return Z_STREAM_ERROR;
 
-	/* when using zlib wrappers, compute Adler-32 for provided dictionary */
-	if (wrap == 1)
-		strm->adler = adler32(strm->adler, dictionary, dictLength);
-	s->wrap = 0;                    /* avoid computing Adler-32 in read_buf */
+    /* when using zlib wrappers, compute Adler-32 for provided dictionary */
+    if (wrap == 1)
+        strm->adler = adler32(strm->adler, dictionary, dictLength);
+    s->wrap = 0;                    /* avoid computing Adler-32 in read_buf */
 
-	/* if dictionary would fill window, just replace the history */
-	if (dictLength >= s->w_size) {
-		if (wrap == 0) {            /* already empty otherwise */
-			CLEAR_HASH(s);
-			s->strstart = 0;
-			s->block_start = 0L;
-			s->insert = 0;
-		}
-		dictionary += dictLength - s->w_size;  /* use the tail */
-		dictLength = s->w_size;
-	}
+    /* if dictionary would fill window, just replace the history */
+    if (dictLength >= s->w_size) {
+        if (wrap == 0) {            /* already empty otherwise */
+            CLEAR_HASH(s);
+            s->strstart = 0;
+            s->block_start = 0L;
+            s->insert = 0;
+        }
+        dictionary += dictLength - s->w_size;  /* use the tail */
+        dictLength = s->w_size;
+    }
 
-	/* insert dictionary into window and hash */
-	avail = strm->avail_in;
-	next = strm->next_in;
-	strm->avail_in = dictLength;
-	strm->next_in = (z_const Bytef *)dictionary;
-	fill_window(s);
-	while (s->lookahead >= MIN_MATCH) {
-		str = s->strstart;
-		n = s->lookahead - (MIN_MATCH - 1);
-		do {
-			UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH - 1]);
-			#ifndef FASTEST
-			s->prev[str & s->w_mask] = s->head[s->ins_h];
-			#endif
-			s->head[s->ins_h] = (Pos)str;
-			str++;
-		} while (--n);
-		s->strstart = str;
-		s->lookahead = MIN_MATCH - 1;
-		fill_window(s);
-	}
-	s->strstart += s->lookahead;
-	s->block_start = (long)s->strstart;
-	s->insert = s->lookahead;
-	s->lookahead = 0;
-	s->match_length = s->prev_length = MIN_MATCH - 1;
-	s->match_available = 0;
-	strm->next_in = next;
-	strm->avail_in = avail;
-	s->wrap = wrap;
-	return Z_OK;
+    /* insert dictionary into window and hash */
+    avail = strm->avail_in;
+    next = strm->next_in;
+    strm->avail_in = dictLength;
+    strm->next_in = (z_const Bytef *)dictionary;
+    fill_window(s);
+    while (s->lookahead >= MIN_MATCH) {
+        str = s->strstart;
+        n = s->lookahead - (MIN_MATCH-1);
+        do {
+            UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
+#ifndef FASTEST
+            s->prev[str & s->w_mask] = s->head[s->ins_h];
+#endif
+            s->head[s->ins_h] = (Pos)str;
+            str++;
+        } while (--n);
+        s->strstart = str;
+        s->lookahead = MIN_MATCH-1;
+        fill_window(s);
+    }
+    s->strstart += s->lookahead;
+    s->block_start = (long)s->strstart;
+    s->insert = s->lookahead;
+    s->lookahead = 0;
+    s->match_length = s->prev_length = MIN_MATCH-1;
+    s->match_available = 0;
+    strm->next_in = next;
+    strm->avail_in = avail;
+    s->wrap = wrap;
+    return Z_OK;
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateResetKeep(strm)
-z_streamp strm;
+int ZEXPORT deflateGetDictionary (strm, dictionary, dictLength)
+    z_streamp strm;
+    Bytef *dictionary;
+    uInt  *dictLength;
 {
-	deflate_state *s;
+    deflate_state *s;
+    uInt len;
 
-	if (strm == Z_NULL || strm->state == Z_NULL ||
-		strm->zalloc == (alloc_func)0 || strm->zfree == (free_func)0) {
-		return Z_STREAM_ERROR;
-	}
-
-	strm->total_in = strm->total_out = 0;
-	strm->msg = Z_NULL; /* use zfree if we ever allocate msg dynamically */
-	strm->data_type = Z_UNKNOWN;
-
-	s = (deflate_state *)strm->state;
-	s->pending = 0;
-	s->pending_out = s->pending_buf;
-
-	if (s->wrap < 0) {
-		s->wrap = -s->wrap; /* was made negative by deflate(..., Z_FINISH); */
-	}
-	s->status = s->wrap ? INIT_STATE : BUSY_STATE;
-	strm->adler =
-		#ifdef GZIP
-		s->wrap == 2 ? crc32(0L, Z_NULL, 0) :
-		#endif
-		adler32(0L, Z_NULL, 0);
-	s->last_flush = Z_NO_FLUSH;
-
-	_tr_init(s);
-
-	return Z_OK;
+    if (deflateStateCheck(strm))
+        return Z_STREAM_ERROR;
+    s = strm->state;
+    len = s->strstart + s->lookahead;
+    if (len > s->w_size)
+        len = s->w_size;
+    if (dictionary != Z_NULL && len)
+        zmemcpy(dictionary, s->window + s->strstart + s->lookahead - len, len);
+    if (dictLength != Z_NULL)
+        *dictLength = len;
+    return Z_OK;
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateReset(strm)
-z_streamp strm;
+int ZEXPORT deflateResetKeep (strm)
+    z_streamp strm;
 {
-	int ret;
+    deflate_state *s;
 
-	ret = deflateResetKeep(strm);
-	if (ret == Z_OK)
-		lm_init(strm->state);
-	return ret;
+    if (deflateStateCheck(strm)) {
+        return Z_STREAM_ERROR;
+    }
+
+    strm->total_in = strm->total_out = 0;
+    strm->msg = Z_NULL; /* use zfree if we ever allocate msg dynamically */
+    strm->data_type = Z_UNKNOWN;
+
+    s = (deflate_state *)strm->state;
+    s->pending = 0;
+    s->pending_out = s->pending_buf;
+
+    if (s->wrap < 0) {
+        s->wrap = -s->wrap; /* was made negative by deflate(..., Z_FINISH); */
+    }
+    s->status =
+#ifdef GZIP
+        s->wrap == 2 ? GZIP_STATE :
+#endif
+        s->wrap ? INIT_STATE : BUSY_STATE;
+    strm->adler =
+#ifdef GZIP
+        s->wrap == 2 ? crc32(0L, Z_NULL, 0) :
+#endif
+        adler32(0L, Z_NULL, 0);
+    s->last_flush = Z_NO_FLUSH;
+
+    _tr_init(s);
+
+    return Z_OK;
 }
 
 /* ========================================================================= */
-int ZEXPORT deflateSetHeader(strm, head)
-z_streamp strm;
-gz_headerp head;
+int ZEXPORT deflateReset (strm)
+    z_streamp strm;
 {
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	if (strm->state->wrap != 2) return Z_STREAM_ERROR;
-	strm->state->gzhead = head;
-	return Z_OK;
+    int ret;
+
+    ret = deflateResetKeep(strm);
+    if (ret == Z_OK)
+        lm_init(strm->state);
+    return ret;
 }
 
 /* ========================================================================= */
-int ZEXPORT deflatePending(strm, pending, bits)
-unsigned *pending;
-int *bits;
-z_streamp strm;
+int ZEXPORT deflateSetHeader (strm, head)
+    z_streamp strm;
+    gz_headerp head;
 {
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	if (pending != Z_NULL)
-		*pending = strm->state->pending;
-	if (bits != Z_NULL)
-		*bits = strm->state->bi_valid;
-	return Z_OK;
+    if (deflateStateCheck(strm) || strm->state->wrap != 2)
+        return Z_STREAM_ERROR;
+    strm->state->gzhead = head;
+    return Z_OK;
 }
 
 /* ========================================================================= */
-int ZEXPORT deflatePrime(strm, bits, value)
-z_streamp strm;
-int bits;
-int value;
+int ZEXPORT deflatePending (strm, pending, bits)
+    unsigned *pending;
+    int *bits;
+    z_streamp strm;
 {
-	deflate_state *s;
-	int put;
+    if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
+    if (pending != Z_NULL)
+        *pending = strm->state->pending;
+    if (bits != Z_NULL)
+        *bits = strm->state->bi_valid;
+    return Z_OK;
+}
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	s = strm->state;
-	if ((Bytef *)(s->d_buf) < s->pending_out + ((Buf_size + 7) >> 3))
-		return Z_BUF_ERROR;
-	do {
-		put = Buf_size - s->bi_valid;
-		if (put > bits)
-			put = bits;
-		s->bi_buf |= (ush)((value & ((1 << put) - 1)) << s->bi_valid);
-		s->bi_valid += put;
-		_tr_flush_bits(s);
-		value >>= put;
-		bits -= put;
-	} while (bits);
-	return Z_OK;
+/* ========================================================================= */
+int ZEXPORT deflatePrime (strm, bits, value)
+    z_streamp strm;
+    int bits;
+    int value;
+{
+    deflate_state *s;
+    int put;
+
+    if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
+    s = strm->state;
+    if ((Bytef *)(s->d_buf) < s->pending_out + ((Buf_size + 7) >> 3))
+        return Z_BUF_ERROR;
+    do {
+        put = Buf_size - s->bi_valid;
+        if (put > bits)
+            put = bits;
+        s->bi_buf |= (ush)((value & ((1 << put) - 1)) << s->bi_valid);
+        s->bi_valid += put;
+        _tr_flush_bits(s);
+        value >>= put;
+        bits -= put;
+    } while (bits);
+    return Z_OK;
 }
 
 /* ========================================================================= */
 int ZEXPORT deflateParams(strm, level, strategy)
-z_streamp strm;
-int level;
-int strategy;
+    z_streamp strm;
+    int level;
+    int strategy;
 {
-	deflate_state *s;
-	compress_func func;
-	int err = Z_OK;
+    deflate_state *s;
+    compress_func func;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	s = strm->state;
+    if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
+    s = strm->state;
 
-	#ifdef FASTEST
-	if (level != 0) level = 1;
-	#else
-	if (level == Z_DEFAULT_COMPRESSION) level = 6;
-	#endif
-	if (level < 0 || level > 9 || strategy < 0 || strategy > Z_FIXED) {
-		return Z_STREAM_ERROR;
-	}
-	func = configuration_table[s->level].func;
+#ifdef FASTEST
+    if (level != 0) level = 1;
+#else
+    if (level == Z_DEFAULT_COMPRESSION) level = 6;
+#endif
+    if (level < 0 || level > 9 || strategy < 0 || strategy > Z_FIXED) {
+        return Z_STREAM_ERROR;
+    }
+    func = configuration_table[s->level].func;
 
-	if ((strategy != s->strategy || func != configuration_table[level].func) &&
-		strm->total_in != 0) {
-		/* Flush the last buffer: */
-		err = deflate(strm, Z_BLOCK);
-		if (err == Z_BUF_ERROR && s->pending == 0)
-			err = Z_OK;
-	}
-	if (s->level != level) {
-		s->level = level;
-		s->max_lazy_match = configuration_table[level].max_lazy;
-		s->good_match = configuration_table[level].good_length;
-		s->nice_match = configuration_table[level].nice_length;
-		s->max_chain_length = configuration_table[level].max_chain;
-	}
-	s->strategy = strategy;
-	return err;
+    if ((strategy != s->strategy || func != configuration_table[level].func) &&
+        s->high_water) {
+        /* Flush the last buffer: */
+        int err = deflate(strm, Z_BLOCK);
+        if (err == Z_STREAM_ERROR)
+            return err;
+        if (strm->avail_out == 0)
+            return Z_BUF_ERROR;
+    }
+    if (s->level != level) {
+        if (s->level == 0 && s->matches != 0) {
+            if (s->matches == 1)
+                slide_hash(s);
+            else
+                CLEAR_HASH(s);
+            s->matches = 0;
+        }
+        s->level = level;
+        s->max_lazy_match   = configuration_table[level].max_lazy;
+        s->good_match       = configuration_table[level].good_length;
+        s->nice_match       = configuration_table[level].nice_length;
+        s->max_chain_length = configuration_table[level].max_chain;
+    }
+    s->strategy = strategy;
+    return Z_OK;
 }
 
 /* ========================================================================= */
 int ZEXPORT deflateTune(strm, good_length, max_lazy, nice_length, max_chain)
-z_streamp strm;
-int good_length;
-int max_lazy;
-int nice_length;
-int max_chain;
+    z_streamp strm;
+    int good_length;
+    int max_lazy;
+    int nice_length;
+    int max_chain;
 {
-	deflate_state *s;
+    deflate_state *s;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	s = strm->state;
-	s->good_match = good_length;
-	s->max_lazy_match = max_lazy;
-	s->nice_match = nice_length;
-	s->max_chain_length = max_chain;
-	return Z_OK;
+    if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
+    s = strm->state;
+    s->good_match = (uInt)good_length;
+    s->max_lazy_match = (uInt)max_lazy;
+    s->nice_match = nice_length;
+    s->max_chain_length = (uInt)max_chain;
+    return Z_OK;
 }
 
 /* =========================================================================
@@ -566,60 +650,62 @@ int max_chain;
  * allocation.
  */
 uLong ZEXPORT deflateBound(strm, sourceLen)
-z_streamp strm;
-uLong sourceLen;
+    z_streamp strm;
+    uLong sourceLen;
 {
-	deflate_state *s;
-	uLong complen, wraplen;
-	Bytef *str;
+    deflate_state *s;
+    uLong complen, wraplen;
 
-	/* conservative upper bound for compressed data */
-	complen = sourceLen +
-		((sourceLen + 7) >> 3) + ((sourceLen + 63) >> 6) + 5;
+    /* conservative upper bound for compressed data */
+    complen = sourceLen +
+              ((sourceLen + 7) >> 3) + ((sourceLen + 63) >> 6) + 5;
 
-	/* if can't get parameters, return conservative bound plus zlib wrapper */
-	if (strm == Z_NULL || strm->state == Z_NULL)
-		return complen + 6;
+    /* if can't get parameters, return conservative bound plus zlib wrapper */
+    if (deflateStateCheck(strm))
+        return complen + 6;
 
-	/* compute wrapper length */
-	s = strm->state;
-	switch (s->wrap) {
-	case 0:                                 /* raw deflate */
-		wraplen = 0;
-		break;
-	case 1:                                 /* zlib wrapper */
-		wraplen = 6 + (s->strstart ? 4 : 0);
-		break;
-	case 2:                                 /* gzip wrapper */
-		wraplen = 18;
-		if (s->gzhead != Z_NULL) {          /* user-supplied gzip header */
-			if (s->gzhead->extra != Z_NULL)
-				wraplen += 2 + s->gzhead->extra_len;
-			str = s->gzhead->name;
-			if (str != Z_NULL)
-				do {
-					wraplen++;
-				} while (*str++);
-				str = s->gzhead->comment;
-				if (str != Z_NULL)
-					do {
-						wraplen++;
-					} while (*str++);
-					if (s->gzhead->hcrc)
-						wraplen += 2;
-		}
-		break;
-	default:                                /* for compiler happiness */
-		wraplen = 6;
-	}
+    /* compute wrapper length */
+    s = strm->state;
+    switch (s->wrap) {
+    case 0:                                 /* raw deflate */
+        wraplen = 0;
+        break;
+    case 1:                                 /* zlib wrapper */
+        wraplen = 6 + (s->strstart ? 4 : 0);
+        break;
+#ifdef GZIP
+    case 2:                                 /* gzip wrapper */
+        wraplen = 18;
+        if (s->gzhead != Z_NULL) {          /* user-supplied gzip header */
+            Bytef *str;
+            if (s->gzhead->extra != Z_NULL)
+                wraplen += 2 + s->gzhead->extra_len;
+            str = s->gzhead->name;
+            if (str != Z_NULL)
+                do {
+                    wraplen++;
+                } while (*str++);
+            str = s->gzhead->comment;
+            if (str != Z_NULL)
+                do {
+                    wraplen++;
+                } while (*str++);
+            if (s->gzhead->hcrc)
+                wraplen += 2;
+        }
+        break;
+#endif
+    default:                                /* for compiler happiness */
+        wraplen = 6;
+    }
 
-	/* if not default parameters, return conservative bound */
-	if (s->w_bits != 15 || s->hash_bits != 8 + 7)
-		return complen + wraplen;
+    /* if not default parameters, return conservative bound */
+    if (s->w_bits != 15 || s->hash_bits != 8 + 7)
+        return complen + wraplen;
 
-	/* default settings: return tight bound for that case */
-	return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) +
-		(sourceLen >> 25) + 13 - 6 + wraplen;
+    /* default settings: return tight bound for that case */
+    return sourceLen + (sourceLen >> 12) + (sourceLen >> 14) +
+           (sourceLen >> 25) + 13 - 6 + wraplen;
 }
 
 /* =========================================================================
@@ -627,387 +713,385 @@ uLong sourceLen;
  * IN assertion: the stream state is correct and there is enough room in
  * pending_buf.
  */
-local void putShortMSB(s, b)
-deflate_state *s;
-uInt b;
+local void putShortMSB (s, b)
+    deflate_state *s;
+    uInt b;
 {
-	put_byte(s, (Byte)(b >> 8));
-	put_byte(s, (Byte)(b & 0xff));
+    put_byte(s, (Byte)(b >> 8));
+    put_byte(s, (Byte)(b & 0xff));
 }
 
 /* =========================================================================
- * Flush as much pending output as possible. All deflate() output goes
- * through this function so some applications may wish to modify it
- * to avoid allocating a large strm->next_out buffer and copying into it.
- * (See also read_buf()).
+ * Flush as much pending output as possible. All deflate() output, except for
+ * some deflate_stored() output, goes through this function so some
+ * applications may wish to modify it to avoid allocating a large
+ * strm->next_out buffer and copying into it. (See also read_buf()).
  */
 local void flush_pending(strm)
-z_streamp strm;
+    z_streamp strm;
 {
-	unsigned len;
-	deflate_state *s = strm->state;
+    unsigned len;
+    deflate_state *s = strm->state;
 
-	_tr_flush_bits(s);
-	len = s->pending;
-	if (len > strm->avail_out) len = strm->avail_out;
-	if (len == 0) return;
+    _tr_flush_bits(s);
+    len = s->pending;
+    if (len > strm->avail_out) len = strm->avail_out;
+    if (len == 0) return;
 
-	zmemcpy(strm->next_out, s->pending_out, len);
-	strm->next_out += len;
-	s->pending_out += len;
-	strm->total_out += len;
-	strm->avail_out -= len;
-	s->pending -= len;
-	if (s->pending == 0) {
-		s->pending_out = s->pending_buf;
-	}
+    zmemcpy(strm->next_out, s->pending_out, len);
+    strm->next_out  += len;
+    s->pending_out  += len;
+    strm->total_out += len;
+    strm->avail_out -= len;
+    s->pending      -= len;
+    if (s->pending == 0) {
+        s->pending_out = s->pending_buf;
+    }
+}
+
+/* ===========================================================================
+ * Update the header CRC with the bytes s->pending_buf[beg..s->pending - 1].
+ */
+#define HCRC_UPDATE(beg) \
+    do { \
+        if (s->gzhead->hcrc && s->pending > (beg)) \
+            strm->adler = crc32(strm->adler, s->pending_buf + (beg), \
+                                s->pending - (beg)); \
+    } while (0)
+
+/* ========================================================================= */
+int ZEXPORT deflate (strm, flush)
+    z_streamp strm;
+    int flush;
+{
+    int old_flush; /* value of flush param for previous deflate call */
+    deflate_state *s;
+
+    if (deflateStateCheck(strm) || flush > Z_BLOCK || flush < 0) {
+        return Z_STREAM_ERROR;
+    }
+    s = strm->state;
+
+    if (strm->next_out == Z_NULL ||
+        (strm->avail_in != 0 && strm->next_in == Z_NULL) ||
+        (s->status == FINISH_STATE && flush != Z_FINISH)) {
+        ERR_RETURN(strm, Z_STREAM_ERROR);
+    }
+    if (strm->avail_out == 0) ERR_RETURN(strm, Z_BUF_ERROR);
+
+    old_flush = s->last_flush;
+    s->last_flush = flush;
+
+    /* Flush as much pending output as possible */
+    if (s->pending != 0) {
+        flush_pending(strm);
+        if (strm->avail_out == 0) {
+            /* Since avail_out is 0, deflate will be called again with
+             * more output space, but possibly with both pending and
+             * avail_in equal to zero. There won't be anything to do,
+             * but this is not an error situation so make sure we
+             * return OK instead of BUF_ERROR at next call of deflate:
+             */
+            s->last_flush = -1;
+            return Z_OK;
+        }
+
+    /* Make sure there is something to do and avoid duplicate consecutive
+     * flushes. For repeated and useless calls with Z_FINISH, we keep
+     * returning Z_STREAM_END instead of Z_BUF_ERROR.
+     */
+    } else if (strm->avail_in == 0 && RANK(flush) <= RANK(old_flush) &&
+               flush != Z_FINISH) {
+        ERR_RETURN(strm, Z_BUF_ERROR);
+    }
+
+    /* User must not provide more input after the first FINISH: */
+    if (s->status == FINISH_STATE && strm->avail_in != 0) {
+        ERR_RETURN(strm, Z_BUF_ERROR);
+    }
+
+    /* Write the header */
+    if (s->status == INIT_STATE) {
+        /* zlib header */
+        uInt header = (Z_DEFLATED + ((s->w_bits-8)<<4)) << 8;
+        uInt level_flags;
+
+        if (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2)
+            level_flags = 0;
+        else if (s->level < 6)
+            level_flags = 1;
+        else if (s->level == 6)
+            level_flags = 2;
+        else
+            level_flags = 3;
+        header |= (level_flags << 6);
+        if (s->strstart != 0) header |= PRESET_DICT;
+        header += 31 - (header % 31);
+
+        putShortMSB(s, header);
+
+        /* Save the adler32 of the preset dictionary: */
+        if (s->strstart != 0) {
+            putShortMSB(s, (uInt)(strm->adler >> 16));
+            putShortMSB(s, (uInt)(strm->adler & 0xffff));
+        }
+        strm->adler = adler32(0L, Z_NULL, 0);
+        s->status = BUSY_STATE;
+
+        /* Compression must start with an empty pending buffer */
+        flush_pending(strm);
+        if (s->pending != 0) {
+            s->last_flush = -1;
+            return Z_OK;
+        }
+    }
+#ifdef GZIP
+    if (s->status == GZIP_STATE) {
+        /* gzip header */
+        strm->adler = crc32(0L, Z_NULL, 0);
+        put_byte(s, 31);
+        put_byte(s, 139);
+        put_byte(s, 8);
+        if (s->gzhead == Z_NULL) {
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, 0);
+            put_byte(s, s->level == 9 ? 2 :
+                     (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
+                      4 : 0));
+            put_byte(s, OS_CODE);
+            s->status = BUSY_STATE;
+
+            /* Compression must start with an empty pending buffer */
+            flush_pending(strm);
+            if (s->pending != 0) {
+                s->last_flush = -1;
+                return Z_OK;
+            }
+        }
+        else {
+            put_byte(s, (s->gzhead->text ? 1 : 0) +
+                     (s->gzhead->hcrc ? 2 : 0) +
+                     (s->gzhead->extra == Z_NULL ? 0 : 4) +
+                     (s->gzhead->name == Z_NULL ? 0 : 8) +
+                     (s->gzhead->comment == Z_NULL ? 0 : 16)
+                     );
+            put_byte(s, (Byte)(s->gzhead->time & 0xff));
+            put_byte(s, (Byte)((s->gzhead->time >> 8) & 0xff));
+            put_byte(s, (Byte)((s->gzhead->time >> 16) & 0xff));
+            put_byte(s, (Byte)((s->gzhead->time >> 24) & 0xff));
+            put_byte(s, s->level == 9 ? 2 :
+                     (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
+                      4 : 0));
+            put_byte(s, s->gzhead->os & 0xff);
+            if (s->gzhead->extra != Z_NULL) {
+                put_byte(s, s->gzhead->extra_len & 0xff);
+                put_byte(s, (s->gzhead->extra_len >> 8) & 0xff);
+            }
+            if (s->gzhead->hcrc)
+                strm->adler = crc32(strm->adler, s->pending_buf,
+                                    s->pending);
+            s->gzindex = 0;
+            s->status = EXTRA_STATE;
+        }
+    }
+    if (s->status == EXTRA_STATE) {
+        if (s->gzhead->extra != Z_NULL) {
+            ulg beg = s->pending;   /* start of bytes to update crc */
+            uInt left = (s->gzhead->extra_len & 0xffff) - s->gzindex;
+            while (s->pending + left > s->pending_buf_size) {
+                uInt copy = s->pending_buf_size - s->pending;
+                zmemcpy(s->pending_buf + s->pending,
+                        s->gzhead->extra + s->gzindex, copy);
+                s->pending = s->pending_buf_size;
+                HCRC_UPDATE(beg);
+                s->gzindex += copy;
+                flush_pending(strm);
+                if (s->pending != 0) {
+                    s->last_flush = -1;
+                    return Z_OK;
+                }
+                beg = 0;
+                left -= copy;
+            }
+            zmemcpy(s->pending_buf + s->pending,
+                    s->gzhead->extra + s->gzindex, left);
+            s->pending += left;
+            HCRC_UPDATE(beg);
+            s->gzindex = 0;
+        }
+        s->status = NAME_STATE;
+    }
+    if (s->status == NAME_STATE) {
+        if (s->gzhead->name != Z_NULL) {
+            ulg beg = s->pending;   /* start of bytes to update crc */
+            int val;
+            do {
+                if (s->pending == s->pending_buf_size) {
+                    HCRC_UPDATE(beg);
+                    flush_pending(strm);
+                    if (s->pending != 0) {
+                        s->last_flush = -1;
+                        return Z_OK;
+                    }
+                    beg = 0;
+                }
+                val = s->gzhead->name[s->gzindex++];
+                put_byte(s, val);
+            } while (val != 0);
+            HCRC_UPDATE(beg);
+            s->gzindex = 0;
+        }
+        s->status = COMMENT_STATE;
+    }
+    if (s->status == COMMENT_STATE) {
+        if (s->gzhead->comment != Z_NULL) {
+            ulg beg = s->pending;   /* start of bytes to update crc */
+            int val;
+            do {
+                if (s->pending == s->pending_buf_size) {
+                    HCRC_UPDATE(beg);
+                    flush_pending(strm);
+                    if (s->pending != 0) {
+                        s->last_flush = -1;
+                        return Z_OK;
+                    }
+                    beg = 0;
+                }
+                val = s->gzhead->comment[s->gzindex++];
+                put_byte(s, val);
+            } while (val != 0);
+            HCRC_UPDATE(beg);
+        }
+        s->status = HCRC_STATE;
+    }
+    if (s->status == HCRC_STATE) {
+        if (s->gzhead->hcrc) {
+            if (s->pending + 2 > s->pending_buf_size) {
+                flush_pending(strm);
+                if (s->pending != 0) {
+                    s->last_flush = -1;
+                    return Z_OK;
+                }
+            }
+            put_byte(s, (Byte)(strm->adler & 0xff));
+            put_byte(s, (Byte)((strm->adler >> 8) & 0xff));
+            strm->adler = crc32(0L, Z_NULL, 0);
+        }
+        s->status = BUSY_STATE;
+
+        /* Compression must start with an empty pending buffer */
+        flush_pending(strm);
+        if (s->pending != 0) {
+            s->last_flush = -1;
+            return Z_OK;
+        }
+    }
+#endif
+
+    /* Start a new block or continue the current one.
+     */
+    if (strm->avail_in != 0 || s->lookahead != 0 ||
+        (flush != Z_NO_FLUSH && s->status != FINISH_STATE)) {
+        block_state bstate;
+
+        bstate = s->level == 0 ? deflate_stored(s, flush) :
+                 s->strategy == Z_HUFFMAN_ONLY ? deflate_huff(s, flush) :
+                 s->strategy == Z_RLE ? deflate_rle(s, flush) :
+                 (*(configuration_table[s->level].func))(s, flush);
+
+        if (bstate == finish_started || bstate == finish_done) {
+            s->status = FINISH_STATE;
+        }
+        if (bstate == need_more || bstate == finish_started) {
+            if (strm->avail_out == 0) {
+                s->last_flush = -1; /* avoid BUF_ERROR next call, see above */
+            }
+            return Z_OK;
+            /* If flush != Z_NO_FLUSH && avail_out == 0, the next call
+             * of deflate should use the same flush parameter to make sure
+             * that the flush is complete. So we don't have to output an
+             * empty block here, this will be done at next call. This also
+             * ensures that for a very small output buffer, we emit at most
+             * one empty block.
+             */
+        }
+        if (bstate == block_done) {
+            if (flush == Z_PARTIAL_FLUSH) {
+                _tr_align(s);
+            } else if (flush != Z_BLOCK) { /* FULL_FLUSH or SYNC_FLUSH */
+                _tr_stored_block(s, (char*)0, 0L, 0);
+                /* For a full flush, this empty block will be recognized
+                 * as a special marker by inflate_sync().
+                 */
+                if (flush == Z_FULL_FLUSH) {
+                    CLEAR_HASH(s);             /* forget history */
+                    if (s->lookahead == 0) {
+                        s->strstart = 0;
+                        s->block_start = 0L;
+                        s->insert = 0;
+                    }
+                }
+            }
+            flush_pending(strm);
+            if (strm->avail_out == 0) {
+              s->last_flush = -1; /* avoid BUF_ERROR at next call, see above */
+              return Z_OK;
+            }
+        }
+    }
+
+    if (flush != Z_FINISH) return Z_OK;
+    if (s->wrap <= 0) return Z_STREAM_END;
+
+    /* Write the trailer */
+#ifdef GZIP
+    if (s->wrap == 2) {
+        put_byte(s, (Byte)(strm->adler & 0xff));
+        put_byte(s, (Byte)((strm->adler >> 8) & 0xff));
+        put_byte(s, (Byte)((strm->adler >> 16) & 0xff));
+        put_byte(s, (Byte)((strm->adler >> 24) & 0xff));
+        put_byte(s, (Byte)(strm->total_in & 0xff));
+        put_byte(s, (Byte)((strm->total_in >> 8) & 0xff));
+        put_byte(s, (Byte)((strm->total_in >> 16) & 0xff));
+        put_byte(s, (Byte)((strm->total_in >> 24) & 0xff));
+    }
+    else
+#endif
+    {
+        putShortMSB(s, (uInt)(strm->adler >> 16));
+        putShortMSB(s, (uInt)(strm->adler & 0xffff));
+    }
+    flush_pending(strm);
+    /* If avail_out is zero, the application will call deflate again
+     * to flush the rest.
+     */
+    if (s->wrap > 0) s->wrap = -s->wrap; /* write the trailer only once! */
+    return s->pending != 0 ? Z_OK : Z_STREAM_END;
 }
 
 /* ========================================================================= */
-int ZEXPORT deflate(strm, flush)
-z_streamp strm;
-int flush;
+int ZEXPORT deflateEnd (strm)
+    z_streamp strm;
 {
-	int old_flush; /* value of flush param for previous deflate call */
-	deflate_state *s;
+    int status;
 
-	if (strm == Z_NULL || strm->state == Z_NULL ||
-		flush > Z_BLOCK || flush < 0) {
-		return Z_STREAM_ERROR;
-	}
-	s = strm->state;
+    if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
 
-	if (strm->next_out == Z_NULL ||
-		(strm->next_in == Z_NULL && strm->avail_in != 0) ||
-		(s->status == FINISH_STATE && flush != Z_FINISH)) {
-		ERR_RETURN(strm, Z_STREAM_ERROR);
-	}
-	if (strm->avail_out == 0) ERR_RETURN(strm, Z_BUF_ERROR);
+    status = strm->state->status;
 
-	s->strm = strm; /* just in case */
-	old_flush = s->last_flush;
-	s->last_flush = flush;
+    /* Deallocate in reverse order of allocations: */
+    TRY_FREE(strm, strm->state->pending_buf);
+    TRY_FREE(strm, strm->state->head);
+    TRY_FREE(strm, strm->state->prev);
+    TRY_FREE(strm, strm->state->window);
 
-	/* Write the header */
-	if (s->status == INIT_STATE) {
-		#ifdef GZIP
-		if (s->wrap == 2) {
-			strm->adler = crc32(0L, Z_NULL, 0);
-			put_byte(s, 31);
-			put_byte(s, 139);
-			put_byte(s, 8);
-			if (s->gzhead == Z_NULL) {
-				put_byte(s, 0);
-				put_byte(s, 0);
-				put_byte(s, 0);
-				put_byte(s, 0);
-				put_byte(s, 0);
-				put_byte(s, s->level == 9 ? 2 :
-					(s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
-						4 : 0));
-				put_byte(s, OS_CODE);
-				s->status = BUSY_STATE;
-			}
-			else {
-				put_byte(s, (s->gzhead->text ? 1 : 0) +
-					(s->gzhead->hcrc ? 2 : 0) +
-					(s->gzhead->extra == Z_NULL ? 0 : 4) +
-					(s->gzhead->name == Z_NULL ? 0 : 8) +
-					(s->gzhead->comment == Z_NULL ? 0 : 16)
-					);
-				put_byte(s, (Byte)(s->gzhead->time & 0xff));
-				put_byte(s, (Byte)((s->gzhead->time >> 8) & 0xff));
-				put_byte(s, (Byte)((s->gzhead->time >> 16) & 0xff));
-				put_byte(s, (Byte)((s->gzhead->time >> 24) & 0xff));
-				put_byte(s, s->level == 9 ? 2 :
-					(s->strategy >= Z_HUFFMAN_ONLY || s->level < 2 ?
-						4 : 0));
-				put_byte(s, s->gzhead->os & 0xff);
-				if (s->gzhead->extra != Z_NULL) {
-					put_byte(s, s->gzhead->extra_len & 0xff);
-					put_byte(s, (s->gzhead->extra_len >> 8) & 0xff);
-				}
-				if (s->gzhead->hcrc)
-					strm->adler = crc32(strm->adler, s->pending_buf,
-						s->pending);
-				s->gzindex = 0;
-				s->status = EXTRA_STATE;
-			}
-		}
-		else
-			#endif
-		{
-			uInt header = (Z_DEFLATED + ((s->w_bits - 8) << 4)) << 8;
-			uInt level_flags;
+    ZFREE(strm, strm->state);
+    strm->state = Z_NULL;
 
-			if (s->strategy >= Z_HUFFMAN_ONLY || s->level < 2)
-				level_flags = 0;
-			else if (s->level < 6)
-				level_flags = 1;
-			else if (s->level == 6)
-				level_flags = 2;
-			else
-				level_flags = 3;
-			header |= (level_flags << 6);
-			if (s->strstart != 0) header |= PRESET_DICT;
-			header += 31 - (header % 31);
-
-			s->status = BUSY_STATE;
-			putShortMSB(s, header);
-
-			/* Save the adler32 of the preset dictionary: */
-			if (s->strstart != 0) {
-				putShortMSB(s, (uInt)(strm->adler >> 16));
-				putShortMSB(s, (uInt)(strm->adler & 0xffff));
-			}
-			strm->adler = adler32(0L, Z_NULL, 0);
-		}
-	}
-	#ifdef GZIP
-	if (s->status == EXTRA_STATE) {
-		if (s->gzhead->extra != Z_NULL) {
-			uInt beg = s->pending;  /* start of bytes to update crc */
-
-			while (s->gzindex < (s->gzhead->extra_len & 0xffff)) {
-				if (s->pending == s->pending_buf_size) {
-					if (s->gzhead->hcrc && s->pending > beg)
-						strm->adler = crc32(strm->adler, s->pending_buf + beg,
-							s->pending - beg);
-					flush_pending(strm);
-					beg = s->pending;
-					if (s->pending == s->pending_buf_size)
-						break;
-				}
-				put_byte(s, s->gzhead->extra[s->gzindex]);
-				s->gzindex++;
-			}
-			if (s->gzhead->hcrc && s->pending > beg)
-				strm->adler = crc32(strm->adler, s->pending_buf + beg,
-					s->pending - beg);
-			if (s->gzindex == s->gzhead->extra_len) {
-				s->gzindex = 0;
-				s->status = NAME_STATE;
-			}
-		}
-		else
-			s->status = NAME_STATE;
-	}
-	if (s->status == NAME_STATE) {
-		if (s->gzhead->name != Z_NULL) {
-			uInt beg = s->pending;  /* start of bytes to update crc */
-			int val;
-
-			do {
-				if (s->pending == s->pending_buf_size) {
-					if (s->gzhead->hcrc && s->pending > beg)
-						strm->adler = crc32(strm->adler, s->pending_buf + beg,
-							s->pending - beg);
-					flush_pending(strm);
-					beg = s->pending;
-					if (s->pending == s->pending_buf_size) {
-						val = 1;
-						break;
-					}
-				}
-				val = s->gzhead->name[s->gzindex++];
-				put_byte(s, val);
-			} while (val != 0);
-			if (s->gzhead->hcrc && s->pending > beg)
-				strm->adler = crc32(strm->adler, s->pending_buf + beg,
-					s->pending - beg);
-			if (val == 0) {
-				s->gzindex = 0;
-				s->status = COMMENT_STATE;
-			}
-		}
-		else
-			s->status = COMMENT_STATE;
-	}
-	if (s->status == COMMENT_STATE) {
-		if (s->gzhead->comment != Z_NULL) {
-			uInt beg = s->pending;  /* start of bytes to update crc */
-			int val;
-
-			do {
-				if (s->pending == s->pending_buf_size) {
-					if (s->gzhead->hcrc && s->pending > beg)
-						strm->adler = crc32(strm->adler, s->pending_buf + beg,
-							s->pending - beg);
-					flush_pending(strm);
-					beg = s->pending;
-					if (s->pending == s->pending_buf_size) {
-						val = 1;
-						break;
-					}
-				}
-				val = s->gzhead->comment[s->gzindex++];
-				put_byte(s, val);
-			} while (val != 0);
-			if (s->gzhead->hcrc && s->pending > beg)
-				strm->adler = crc32(strm->adler, s->pending_buf + beg,
-					s->pending - beg);
-			if (val == 0)
-				s->status = HCRC_STATE;
-		}
-		else
-			s->status = HCRC_STATE;
-	}
-	if (s->status == HCRC_STATE) {
-		if (s->gzhead->hcrc) {
-			if (s->pending + 2 > s->pending_buf_size)
-				flush_pending(strm);
-			if (s->pending + 2 <= s->pending_buf_size) {
-				put_byte(s, (Byte)(strm->adler & 0xff));
-				put_byte(s, (Byte)((strm->adler >> 8) & 0xff));
-				strm->adler = crc32(0L, Z_NULL, 0);
-				s->status = BUSY_STATE;
-			}
-		}
-		else
-			s->status = BUSY_STATE;
-	}
-	#endif
-
-	/* Flush as much pending output as possible */
-	if (s->pending != 0) {
-		flush_pending(strm);
-		if (strm->avail_out == 0) {
-			/* Since avail_out is 0, deflate will be called again with
-			 * more output space, but possibly with both pending and
-			 * avail_in equal to zero. There won't be anything to do,
-			 * but this is not an error situation so make sure we
-			 * return OK instead of BUF_ERROR at next call of deflate:
-			 */
-			s->last_flush = -1;
-			return Z_OK;
-		}
-
-		/* Make sure there is something to do and avoid duplicate consecutive
-		 * flushes. For repeated and useless calls with Z_FINISH, we keep
-		 * returning Z_STREAM_END instead of Z_BUF_ERROR.
-		 */
-	}
-	else if (strm->avail_in == 0 && RANK(flush) <= RANK(old_flush) &&
-		flush != Z_FINISH) {
-		ERR_RETURN(strm, Z_BUF_ERROR);
-	}
-
-	/* User must not provide more input after the first FINISH: */
-	if (s->status == FINISH_STATE && strm->avail_in != 0) {
-		ERR_RETURN(strm, Z_BUF_ERROR);
-	}
-
-	/* Start a new block or continue the current one.
-	 */
-	if (strm->avail_in != 0 || s->lookahead != 0 ||
-		(flush != Z_NO_FLUSH && s->status != FINISH_STATE)) {
-		block_state bstate;
-
-		bstate = s->strategy == Z_HUFFMAN_ONLY ? deflate_huff(s, flush) :
-			(s->strategy == Z_RLE ? deflate_rle(s, flush) :
-				(*(configuration_table[s->level].func))(s, flush));
-
-		if (bstate == finish_started || bstate == finish_done) {
-			s->status = FINISH_STATE;
-		}
-		if (bstate == need_more || bstate == finish_started) {
-			if (strm->avail_out == 0) {
-				s->last_flush = -1; /* avoid BUF_ERROR next call, see above */
-			}
-			return Z_OK;
-			/* If flush != Z_NO_FLUSH && avail_out == 0, the next call
-			 * of deflate should use the same flush parameter to make sure
-			 * that the flush is complete. So we don't have to output an
-			 * empty block here, this will be done at next call. This also
-			 * ensures that for a very small output buffer, we emit at most
-			 * one empty block.
-			 */
-		}
-		if (bstate == block_done) {
-			if (flush == Z_PARTIAL_FLUSH) {
-				_tr_align(s);
-			}
-			else if (flush != Z_BLOCK) { /* FULL_FLUSH or SYNC_FLUSH */
-				_tr_stored_block(s, (char*)0, 0L, 0);
-				/* For a full flush, this empty block will be recognized
-				 * as a special marker by inflate_sync().
-				 */
-				if (flush == Z_FULL_FLUSH) {
-					CLEAR_HASH(s);             /* forget history */
-					if (s->lookahead == 0) {
-						s->strstart = 0;
-						s->block_start = 0L;
-						s->insert = 0;
-					}
-				}
-			}
-			flush_pending(strm);
-			if (strm->avail_out == 0) {
-				s->last_flush = -1; /* avoid BUF_ERROR at next call, see above */
-				return Z_OK;
-			}
-		}
-	}
-	Assert(strm->avail_out > 0, "bug2");
-
-	if (flush != Z_FINISH) return Z_OK;
-	if (s->wrap <= 0) return Z_STREAM_END;
-
-	/* Write the trailer */
-	#ifdef GZIP
-	if (s->wrap == 2) {
-		put_byte(s, (Byte)(strm->adler & 0xff));
-		put_byte(s, (Byte)((strm->adler >> 8) & 0xff));
-		put_byte(s, (Byte)((strm->adler >> 16) & 0xff));
-		put_byte(s, (Byte)((strm->adler >> 24) & 0xff));
-		put_byte(s, (Byte)(strm->total_in & 0xff));
-		put_byte(s, (Byte)((strm->total_in >> 8) & 0xff));
-		put_byte(s, (Byte)((strm->total_in >> 16) & 0xff));
-		put_byte(s, (Byte)((strm->total_in >> 24) & 0xff));
-	}
-	else
-		#endif
-	{
-		putShortMSB(s, (uInt)(strm->adler >> 16));
-		putShortMSB(s, (uInt)(strm->adler & 0xffff));
-	}
-	flush_pending(strm);
-	/* If avail_out is zero, the application will call deflate again
-	 * to flush the rest.
-	 */
-	if (s->wrap > 0) s->wrap = -s->wrap; /* write the trailer only once! */
-	return s->pending != 0 ? Z_OK : Z_STREAM_END;
-}
-
-/* ========================================================================= */
-int ZEXPORT deflateEnd(strm)
-z_streamp strm;
-{
-	int status;
-
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-
-	status = strm->state->status;
-	if (status != INIT_STATE &&
-		status != EXTRA_STATE &&
-		status != NAME_STATE &&
-		status != COMMENT_STATE &&
-		status != HCRC_STATE &&
-		status != BUSY_STATE &&
-		status != FINISH_STATE) {
-		return Z_STREAM_ERROR;
-	}
-
-	/* Deallocate in reverse order of allocations: */
-	TRY_FREE(strm, strm->state->pending_buf);
-	TRY_FREE(strm, strm->state->head);
-	TRY_FREE(strm, strm->state->prev);
-	TRY_FREE(strm, strm->state->window);
-
-	ZFREE(strm, strm->state);
-	strm->state = Z_NULL;
-
-	return status == BUSY_STATE ? Z_DATA_ERROR : Z_OK;
+    return status == BUSY_STATE ? Z_DATA_ERROR : Z_OK;
 }
 
 /* =========================================================================
@@ -1015,59 +1099,59 @@ z_streamp strm;
  * To simplify the source, this is not supported for 16-bit MSDOS (which
  * doesn't have enough memory anyway to duplicate compression states).
  */
-int ZEXPORT deflateCopy(dest, source)
-z_streamp dest;
-z_streamp source;
+int ZEXPORT deflateCopy (dest, source)
+    z_streamp dest;
+    z_streamp source;
 {
-	#ifdef MAXSEG_64K
-	return Z_STREAM_ERROR;
-	#else
-	deflate_state *ds;
-	deflate_state *ss;
-	ushf *overlay;
+#ifdef MAXSEG_64K
+    return Z_STREAM_ERROR;
+#else
+    deflate_state *ds;
+    deflate_state *ss;
+    ushf *overlay;
 
 
-	if (source == Z_NULL || dest == Z_NULL || source->state == Z_NULL) {
-		return Z_STREAM_ERROR;
-	}
+    if (deflateStateCheck(source) || dest == Z_NULL) {
+        return Z_STREAM_ERROR;
+    }
 
-	ss = source->state;
+    ss = source->state;
 
-	zmemcpy((voidpf)dest, (voidpf)source, sizeof(z_stream));
+    zmemcpy((voidpf)dest, (voidpf)source, sizeof(z_stream));
 
-	ds = (deflate_state *)ZALLOC(dest, 1, sizeof(deflate_state));
-	if (ds == Z_NULL) return Z_MEM_ERROR;
-	dest->state = (struct internal_state FAR *) ds;
-	zmemcpy((voidpf)ds, (voidpf)ss, sizeof(deflate_state));
-	ds->strm = dest;
+    ds = (deflate_state *) ZALLOC(dest, 1, sizeof(deflate_state));
+    if (ds == Z_NULL) return Z_MEM_ERROR;
+    dest->state = (struct internal_state FAR *) ds;
+    zmemcpy((voidpf)ds, (voidpf)ss, sizeof(deflate_state));
+    ds->strm = dest;
 
-	ds->window = (Bytef *)ZALLOC(dest, ds->w_size, 2 * sizeof(Byte));
-	ds->prev = (Posf *)ZALLOC(dest, ds->w_size, sizeof(Pos));
-	ds->head = (Posf *)ZALLOC(dest, ds->hash_size, sizeof(Pos));
-	overlay = (ushf *)ZALLOC(dest, ds->lit_bufsize, sizeof(ush) + 2);
-	ds->pending_buf = (uchf *)overlay;
+    ds->window = (Bytef *) ZALLOC(dest, ds->w_size, 2*sizeof(Byte));
+    ds->prev   = (Posf *)  ZALLOC(dest, ds->w_size, sizeof(Pos));
+    ds->head   = (Posf *)  ZALLOC(dest, ds->hash_size, sizeof(Pos));
+    overlay = (ushf *) ZALLOC(dest, ds->lit_bufsize, sizeof(ush)+2);
+    ds->pending_buf = (uchf *) overlay;
 
-	if (ds->window == Z_NULL || ds->prev == Z_NULL || ds->head == Z_NULL ||
-		ds->pending_buf == Z_NULL) {
-		deflateEnd(dest);
-		return Z_MEM_ERROR;
-	}
-	/* following zmemcpy do not work for 16-bit MSDOS */
-	zmemcpy(ds->window, ss->window, ds->w_size * 2 * sizeof(Byte));
-	zmemcpy((voidpf)ds->prev, (voidpf)ss->prev, ds->w_size * sizeof(Pos));
-	zmemcpy((voidpf)ds->head, (voidpf)ss->head, ds->hash_size * sizeof(Pos));
-	zmemcpy(ds->pending_buf, ss->pending_buf, (uInt)ds->pending_buf_size);
+    if (ds->window == Z_NULL || ds->prev == Z_NULL || ds->head == Z_NULL ||
+        ds->pending_buf == Z_NULL) {
+        deflateEnd (dest);
+        return Z_MEM_ERROR;
+    }
+    /* following zmemcpy do not work for 16-bit MSDOS */
+    zmemcpy(ds->window, ss->window, ds->w_size * 2 * sizeof(Byte));
+    zmemcpy((voidpf)ds->prev, (voidpf)ss->prev, ds->w_size * sizeof(Pos));
+    zmemcpy((voidpf)ds->head, (voidpf)ss->head, ds->hash_size * sizeof(Pos));
+    zmemcpy(ds->pending_buf, ss->pending_buf, (uInt)ds->pending_buf_size);
 
-	ds->pending_out = ds->pending_buf + (ss->pending_out - ss->pending_buf);
-	ds->d_buf = overlay + ds->lit_bufsize / sizeof(ush);
-	ds->l_buf = ds->pending_buf + (1 + sizeof(ush))*ds->lit_bufsize;
+    ds->pending_out = ds->pending_buf + (ss->pending_out - ss->pending_buf);
+    ds->d_buf = overlay + ds->lit_bufsize/sizeof(ush);
+    ds->l_buf = ds->pending_buf + (1+sizeof(ush))*ds->lit_bufsize;
 
-	ds->l_desc.dyn_tree = ds->dyn_ltree;
-	ds->d_desc.dyn_tree = ds->dyn_dtree;
-	ds->bl_desc.dyn_tree = ds->bl_tree;
+    ds->l_desc.dyn_tree = ds->dyn_ltree;
+    ds->d_desc.dyn_tree = ds->dyn_dtree;
+    ds->bl_desc.dyn_tree = ds->bl_tree;
 
-	return Z_OK;
-	#endif /* MAXSEG_64K */
+    return Z_OK;
+#endif /* MAXSEG_64K */
 }
 
 /* ===========================================================================
@@ -1077,62 +1161,62 @@ z_streamp source;
  * allocating a large strm->next_in buffer and copying from it.
  * (See also flush_pending()).
  */
-local int read_buf(strm, buf, size)
-z_streamp strm;
-Bytef *buf;
-unsigned size;
+local unsigned read_buf(strm, buf, size)
+    z_streamp strm;
+    Bytef *buf;
+    unsigned size;
 {
-	unsigned len = strm->avail_in;
+    unsigned len = strm->avail_in;
 
-	if (len > size) len = size;
-	if (len == 0) return 0;
+    if (len > size) len = size;
+    if (len == 0) return 0;
 
-	strm->avail_in -= len;
+    strm->avail_in  -= len;
 
-	zmemcpy(buf, strm->next_in, len);
-	if (strm->state->wrap == 1) {
-		strm->adler = adler32(strm->adler, buf, len);
-	}
-	#ifdef GZIP
-	else if (strm->state->wrap == 2) {
-		strm->adler = crc32(strm->adler, buf, len);
-	}
-	#endif
-	strm->next_in += len;
-	strm->total_in += len;
+    zmemcpy(buf, strm->next_in, len);
+    if (strm->state->wrap == 1) {
+        strm->adler = adler32(strm->adler, buf, len);
+    }
+#ifdef GZIP
+    else if (strm->state->wrap == 2) {
+        strm->adler = crc32(strm->adler, buf, len);
+    }
+#endif
+    strm->next_in  += len;
+    strm->total_in += len;
 
-	return (int)len;
+    return len;
 }
 
 /* ===========================================================================
  * Initialize the "longest match" routines for a new zlib stream
  */
-local void lm_init(s)
-deflate_state *s;
+local void lm_init (s)
+    deflate_state *s;
 {
-	s->window_size = (ulg)2L*s->w_size;
+    s->window_size = (ulg)2L*s->w_size;
 
-	CLEAR_HASH(s);
+    CLEAR_HASH(s);
 
-	/* Set the default configuration parameters:
-	 */
-	s->max_lazy_match = configuration_table[s->level].max_lazy;
-	s->good_match = configuration_table[s->level].good_length;
-	s->nice_match = configuration_table[s->level].nice_length;
-	s->max_chain_length = configuration_table[s->level].max_chain;
+    /* Set the default configuration parameters:
+     */
+    s->max_lazy_match   = configuration_table[s->level].max_lazy;
+    s->good_match       = configuration_table[s->level].good_length;
+    s->nice_match       = configuration_table[s->level].nice_length;
+    s->max_chain_length = configuration_table[s->level].max_chain;
 
-	s->strstart = 0;
-	s->block_start = 0L;
-	s->lookahead = 0;
-	s->insert = 0;
-	s->match_length = s->prev_length = MIN_MATCH - 1;
-	s->match_available = 0;
-	s->ins_h = 0;
-	#ifndef FASTEST
-	#ifdef ASMV
-	match_init(); /* initialize the asm code */
-	#endif
-	#endif
+    s->strstart = 0;
+    s->block_start = 0L;
+    s->lookahead = 0;
+    s->insert = 0;
+    s->match_length = s->prev_length = MIN_MATCH-1;
+    s->match_available = 0;
+    s->ins_h = 0;
+#ifndef FASTEST
+#ifdef ASMV
+    match_init(); /* initialize the asm code */
+#endif
+#endif
 }
 
 #ifndef FASTEST
@@ -1146,150 +1230,150 @@ deflate_state *s;
  * OUT assertion: the match length is not greater than s->lookahead.
  */
 #ifndef ASMV
- /* For 80x86 and 680x0, an optimized version will be provided in match.asm or
-  * match.S. The code will be functionally equivalent.
-  */
+/* For 80x86 and 680x0, an optimized version will be provided in match.asm or
+ * match.S. The code will be functionally equivalent.
+ */
 local uInt longest_match(s, cur_match)
-deflate_state *s;
-IPos cur_match;                             /* current match */
+    deflate_state *s;
+    IPos cur_match;                             /* current match */
 {
-	unsigned chain_length = s->max_chain_length;/* max hash chain length */
-	register Bytef *scan = s->window + s->strstart; /* current string */
-	register Bytef *match;                       /* matched string */
-	register int len;                           /* length of current match */
-	int best_len = s->prev_length;              /* best match length so far */
-	int nice_match = s->nice_match;             /* stop if match long enough */
-	IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
-		s->strstart - (IPos)MAX_DIST(s) : NIL;
-	/* Stop when cur_match becomes <= limit. To simplify the code,
-	 * we prevent matches with the string of window index 0.
-	 */
-	Posf *prev = s->prev;
-	uInt wmask = s->w_mask;
+    unsigned chain_length = s->max_chain_length;/* max hash chain length */
+    register Bytef *scan = s->window + s->strstart; /* current string */
+    register Bytef *match;                      /* matched string */
+    register int len;                           /* length of current match */
+    int best_len = (int)s->prev_length;         /* best match length so far */
+    int nice_match = s->nice_match;             /* stop if match long enough */
+    IPos limit = s->strstart > (IPos)MAX_DIST(s) ?
+        s->strstart - (IPos)MAX_DIST(s) : NIL;
+    /* Stop when cur_match becomes <= limit. To simplify the code,
+     * we prevent matches with the string of window index 0.
+     */
+    Posf *prev = s->prev;
+    uInt wmask = s->w_mask;
 
-	#ifdef UNALIGNED_OK
-	/* Compare two bytes at a time. Note: this is not always beneficial.
-	 * Try with and without -DUNALIGNED_OK to check.
-	 */
-	register Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
-	register ush scan_start = *(ushf*)scan;
-	register ush scan_end = *(ushf*)(scan + best_len - 1);
-	#else
-	register Bytef *strend = s->window + s->strstart + MAX_MATCH;
-	register Byte scan_end1 = scan[best_len - 1];
-	register Byte scan_end = scan[best_len];
-	#endif
+#ifdef UNALIGNED_OK
+    /* Compare two bytes at a time. Note: this is not always beneficial.
+     * Try with and without -DUNALIGNED_OK to check.
+     */
+    register Bytef *strend = s->window + s->strstart + MAX_MATCH - 1;
+    register ush scan_start = *(ushf*)scan;
+    register ush scan_end   = *(ushf*)(scan+best_len-1);
+#else
+    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    register Byte scan_end1  = scan[best_len-1];
+    register Byte scan_end   = scan[best_len];
+#endif
 
-	/* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
-	 * It is easy to get rid of this optimization if necessary.
-	 */
-	Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
+    /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
+     * It is easy to get rid of this optimization if necessary.
+     */
+    Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
 
-	/* Do not waste too much time if we already have a good match: */
-	if (s->prev_length >= s->good_match) {
-		chain_length >>= 2;
-	}
-	/* Do not look for matches beyond the end of the input. This is necessary
-	 * to make deflate deterministic.
-	 */
-	if ((uInt)nice_match > s->lookahead) nice_match = s->lookahead;
+    /* Do not waste too much time if we already have a good match: */
+    if (s->prev_length >= s->good_match) {
+        chain_length >>= 2;
+    }
+    /* Do not look for matches beyond the end of the input. This is necessary
+     * to make deflate deterministic.
+     */
+    if ((uInt)nice_match > s->lookahead) nice_match = (int)s->lookahead;
 
-	Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
+    Assert((ulg)s->strstart <= s->window_size-MIN_LOOKAHEAD, "need lookahead");
 
-	do {
-		Assert(cur_match < s->strstart, "no future");
-		match = s->window + cur_match;
+    do {
+        Assert(cur_match < s->strstart, "no future");
+        match = s->window + cur_match;
 
-		/* Skip to next match if the match length cannot increase
-		 * or if the match length is less than 2.  Note that the checks below
-		 * for insufficient lookahead only occur occasionally for performance
-		 * reasons.  Therefore uninitialized memory will be accessed, and
-		 * conditional jumps will be made that depend on those values.
-		 * However the length of the match is limited to the lookahead, so
-		 * the output of deflate is not affected by the uninitialized values.
-		 */
-		#if (defined(UNALIGNED_OK) && MAX_MATCH == 258)
-		 /* This code assumes sizeof(unsigned short) == 2. Do not use
-		  * UNALIGNED_OK if your compiler uses a different size.
-		  */
-		if (*(ushf*)(match + best_len - 1) != scan_end ||
-			*(ushf*)match != scan_start) continue;
+        /* Skip to next match if the match length cannot increase
+         * or if the match length is less than 2.  Note that the checks below
+         * for insufficient lookahead only occur occasionally for performance
+         * reasons.  Therefore uninitialized memory will be accessed, and
+         * conditional jumps will be made that depend on those values.
+         * However the length of the match is limited to the lookahead, so
+         * the output of deflate is not affected by the uninitialized values.
+         */
+#if (defined(UNALIGNED_OK) && MAX_MATCH == 258)
+        /* This code assumes sizeof(unsigned short) == 2. Do not use
+         * UNALIGNED_OK if your compiler uses a different size.
+         */
+        if (*(ushf*)(match+best_len-1) != scan_end ||
+            *(ushf*)match != scan_start) continue;
 
-		/* It is not necessary to compare scan[2] and match[2] since they are
-		 * always equal when the other bytes match, given that the hash keys
-		 * are equal and that HASH_BITS >= 8. Compare 2 bytes at a time at
-		 * strstart+3, +5, ... up to strstart+257. We check for insufficient
-		 * lookahead only every 4th comparison; the 128th check will be made
-		 * at strstart+257. If MAX_MATCH-2 is not a multiple of 8, it is
-		 * necessary to put more guard bytes at the end of the window, or
-		 * to check more often for insufficient lookahead.
-		 */
-		Assert(scan[2] == match[2], "scan[2]?");
-		scan++, match++;
-		do {
-		} while (*(ushf*)(scan += 2) == *(ushf*)(match += 2) &&
-			*(ushf*)(scan += 2) == *(ushf*)(match += 2) &&
-			*(ushf*)(scan += 2) == *(ushf*)(match += 2) &&
-			*(ushf*)(scan += 2) == *(ushf*)(match += 2) &&
-			scan < strend);
-		/* The funny "do {}" generates better code on most compilers */
+        /* It is not necessary to compare scan[2] and match[2] since they are
+         * always equal when the other bytes match, given that the hash keys
+         * are equal and that HASH_BITS >= 8. Compare 2 bytes at a time at
+         * strstart+3, +5, ... up to strstart+257. We check for insufficient
+         * lookahead only every 4th comparison; the 128th check will be made
+         * at strstart+257. If MAX_MATCH-2 is not a multiple of 8, it is
+         * necessary to put more guard bytes at the end of the window, or
+         * to check more often for insufficient lookahead.
+         */
+        Assert(scan[2] == match[2], "scan[2]?");
+        scan++, match++;
+        do {
+        } while (*(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
+                 *(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
+                 *(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
+                 *(ushf*)(scan+=2) == *(ushf*)(match+=2) &&
+                 scan < strend);
+        /* The funny "do {}" generates better code on most compilers */
 
-		/* Here, scan <= window+strstart+257 */
-		Assert(scan <= s->window + (unsigned)(s->window_size - 1), "wild scan");
-		if (*scan == *match) scan++;
+        /* Here, scan <= window+strstart+257 */
+        Assert(scan <= s->window+(unsigned)(s->window_size-1), "wild scan");
+        if (*scan == *match) scan++;
 
-		len = (MAX_MATCH - 1) - (int)(strend - scan);
-		scan = strend - (MAX_MATCH - 1);
+        len = (MAX_MATCH - 1) - (int)(strend-scan);
+        scan = strend - (MAX_MATCH-1);
 
-		#else /* UNALIGNED_OK */
+#else /* UNALIGNED_OK */
 
-		if (match[best_len] != scan_end ||
-			match[best_len - 1] != scan_end1 ||
-			*match != *scan ||
-			*++match != scan[1])      continue;
+        if (match[best_len]   != scan_end  ||
+            match[best_len-1] != scan_end1 ||
+            *match            != *scan     ||
+            *++match          != scan[1])      continue;
 
-		/* The check at best_len-1 can be removed because it will be made
-		 * again later. (This heuristic is not always a win.)
-		 * It is not necessary to compare scan[2] and match[2] since they
-		 * are always equal when the other bytes match, given that
-		 * the hash keys are equal and that HASH_BITS >= 8.
-		 */
-		scan += 2, match++;
-		Assert(*scan == *match, "match[2]?");
+        /* The check at best_len-1 can be removed because it will be made
+         * again later. (This heuristic is not always a win.)
+         * It is not necessary to compare scan[2] and match[2] since they
+         * are always equal when the other bytes match, given that
+         * the hash keys are equal and that HASH_BITS >= 8.
+         */
+        scan += 2, match++;
+        Assert(*scan == *match, "match[2]?");
 
-		/* We check for insufficient lookahead only every 8th comparison;
-		 * the 256th check will be made at strstart+258.
-		 */
-		do {
-		} while (*++scan == *++match && *++scan == *++match &&
-			*++scan == *++match && *++scan == *++match &&
-			*++scan == *++match && *++scan == *++match &&
-			*++scan == *++match && *++scan == *++match &&
-			scan < strend);
+        /* We check for insufficient lookahead only every 8th comparison;
+         * the 256th check will be made at strstart+258.
+         */
+        do {
+        } while (*++scan == *++match && *++scan == *++match &&
+                 *++scan == *++match && *++scan == *++match &&
+                 *++scan == *++match && *++scan == *++match &&
+                 *++scan == *++match && *++scan == *++match &&
+                 scan < strend);
 
-		Assert(scan <= s->window + (unsigned)(s->window_size - 1), "wild scan");
+        Assert(scan <= s->window+(unsigned)(s->window_size-1), "wild scan");
 
-		len = MAX_MATCH - (int)(strend - scan);
-		scan = strend - MAX_MATCH;
+        len = MAX_MATCH - (int)(strend - scan);
+        scan = strend - MAX_MATCH;
 
-		#endif /* UNALIGNED_OK */
+#endif /* UNALIGNED_OK */
 
-		if (len > best_len) {
-			s->match_start = cur_match;
-			best_len = len;
-			if (len >= nice_match) break;
-			#ifdef UNALIGNED_OK
-			scan_end = *(ushf*)(scan + best_len - 1);
-			#else
-			scan_end1 = scan[best_len - 1];
-			scan_end = scan[best_len];
-			#endif
-		}
-	} while ((cur_match = prev[cur_match & wmask]) > limit
-		&& --chain_length != 0);
+        if (len > best_len) {
+            s->match_start = cur_match;
+            best_len = len;
+            if (len >= nice_match) break;
+#ifdef UNALIGNED_OK
+            scan_end = *(ushf*)(scan+best_len-1);
+#else
+            scan_end1  = scan[best_len-1];
+            scan_end   = scan[best_len];
+#endif
+        }
+    } while ((cur_match = prev[cur_match & wmask]) > limit
+             && --chain_length != 0);
 
-	if ((uInt)best_len <= s->lookahead) return (uInt)best_len;
-	return s->lookahead;
+    if ((uInt)best_len <= s->lookahead) return (uInt)best_len;
+    return s->lookahead;
 }
 #endif /* ASMV */
 
@@ -1299,87 +1383,91 @@ IPos cur_match;                             /* current match */
  * Optimized version for FASTEST only
  */
 local uInt longest_match(s, cur_match)
-deflate_state *s;
-IPos cur_match;                             /* current match */
+    deflate_state *s;
+    IPos cur_match;                             /* current match */
 {
-	register Bytef *scan = s->window + s->strstart; /* current string */
-	register Bytef *match;                       /* matched string */
-	register int len;                           /* length of current match */
-	register Bytef *strend = s->window + s->strstart + MAX_MATCH;
+    register Bytef *scan = s->window + s->strstart; /* current string */
+    register Bytef *match;                       /* matched string */
+    register int len;                           /* length of current match */
+    register Bytef *strend = s->window + s->strstart + MAX_MATCH;
 
-	/* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
-	 * It is easy to get rid of this optimization if necessary.
-	 */
-	Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
+    /* The code is optimized for HASH_BITS >= 8 and MAX_MATCH-2 multiple of 16.
+     * It is easy to get rid of this optimization if necessary.
+     */
+    Assert(s->hash_bits >= 8 && MAX_MATCH == 258, "Code too clever");
 
-	Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD, "need lookahead");
+    Assert((ulg)s->strstart <= s->window_size-MIN_LOOKAHEAD, "need lookahead");
 
-	Assert(cur_match < s->strstart, "no future");
+    Assert(cur_match < s->strstart, "no future");
 
-	match = s->window + cur_match;
+    match = s->window + cur_match;
 
-	/* Return failure if the match length is less than 2:
-	 */
-	if (match[0] != scan[0] || match[1] != scan[1]) return MIN_MATCH - 1;
+    /* Return failure if the match length is less than 2:
+     */
+    if (match[0] != scan[0] || match[1] != scan[1]) return MIN_MATCH-1;
 
-	/* The check at best_len-1 can be removed because it will be made
-	 * again later. (This heuristic is not always a win.)
-	 * It is not necessary to compare scan[2] and match[2] since they
-	 * are always equal when the other bytes match, given that
-	 * the hash keys are equal and that HASH_BITS >= 8.
-	 */
-	scan += 2, match += 2;
-	Assert(*scan == *match, "match[2]?");
+    /* The check at best_len-1 can be removed because it will be made
+     * again later. (This heuristic is not always a win.)
+     * It is not necessary to compare scan[2] and match[2] since they
+     * are always equal when the other bytes match, given that
+     * the hash keys are equal and that HASH_BITS >= 8.
+     */
+    scan += 2, match += 2;
+    Assert(*scan == *match, "match[2]?");
 
-	/* We check for insufficient lookahead only every 8th comparison;
-	 * the 256th check will be made at strstart+258.
-	 */
-	do {
-	} while (*++scan == *++match && *++scan == *++match &&
-		*++scan == *++match && *++scan == *++match &&
-		*++scan == *++match && *++scan == *++match &&
-		*++scan == *++match && *++scan == *++match &&
-		scan < strend);
+    /* We check for insufficient lookahead only every 8th comparison;
+     * the 256th check will be made at strstart+258.
+     */
+    do {
+    } while (*++scan == *++match && *++scan == *++match &&
+             *++scan == *++match && *++scan == *++match &&
+             *++scan == *++match && *++scan == *++match &&
+             *++scan == *++match && *++scan == *++match &&
+             scan < strend);
 
-	Assert(scan <= s->window + (unsigned)(s->window_size - 1), "wild scan");
+    Assert(scan <= s->window+(unsigned)(s->window_size-1), "wild scan");
 
-	len = MAX_MATCH - (int)(strend - scan);
+    len = MAX_MATCH - (int)(strend - scan);
 
-	if (len < MIN_MATCH) return MIN_MATCH - 1;
+    if (len < MIN_MATCH) return MIN_MATCH - 1;
 
-	s->match_start = cur_match;
-	return (uInt)len <= s->lookahead ? (uInt)len : s->lookahead;
+    s->match_start = cur_match;
+    return (uInt)len <= s->lookahead ? (uInt)len : s->lookahead;
 }
 
 #endif /* FASTEST */
 
-#ifdef DEBUG
+#ifdef ZLIB_DEBUG
+
+#define EQUAL 0
+/* result of memcmp for equal strings */
+
 /* ===========================================================================
  * Check that the match at match_start is indeed a match.
  */
 local void check_match(s, start, match, length)
-deflate_state *s;
-IPos start, match;
-int length;
+    deflate_state *s;
+    IPos start, match;
+    int length;
 {
-	/* check that the match is indeed a match */
-	if (zmemcmp(s->window + match,
-		s->window + start, length) != EQUAL) {
-		fprintf(stderr, " start %u, match %u, length %d\n",
-			start, match, length);
-		do {
-			fprintf(stderr, "%c%c", s->window[match++], s->window[start++]);
-		} while (--length != 0);
-		z_error("invalid match");
-	}
-	if (z_verbose > 1) {
-		fprintf(stderr, "\\[%d,%d]", start - match, length);
-		do { putc(s->window[start++], stderr); } while (--length != 0);
-	}
+    /* check that the match is indeed a match */
+    if (zmemcmp(s->window + match,
+                s->window + start, length) != EQUAL) {
+        fprintf(stderr, " start %u, match %u, length %d\n",
+                start, match, length);
+        do {
+            fprintf(stderr, "%c%c", s->window[match++], s->window[start++]);
+        } while (--length != 0);
+        z_error("invalid match");
+    }
+    if (z_verbose > 1) {
+        fprintf(stderr,"\\[%d,%d]", start-match, length);
+        do { putc(s->window[start++], stderr); } while (--length != 0);
+    }
 }
 #else
 #  define check_match(s, start, match, length)
-#endif /* DEBUG */
+#endif /* ZLIB_DEBUG */
 
 /* ===========================================================================
  * Fill the window when the lookahead becomes insufficient.
@@ -1392,148 +1480,122 @@ int length;
  *    option -- not supported here).
  */
 local void fill_window(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	register unsigned n, m;
-	register Posf *p;
-	unsigned more;    /* Amount of free space at the end of the window. */
-	uInt wsize = s->w_size;
+    unsigned n;
+    unsigned more;    /* Amount of free space at the end of the window. */
+    uInt wsize = s->w_size;
 
-	Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
+    Assert(s->lookahead < MIN_LOOKAHEAD, "already enough lookahead");
 
-	do {
-		more = (unsigned)(s->window_size - (ulg)s->lookahead - (ulg)s->strstart);
+    do {
+        more = (unsigned)(s->window_size -(ulg)s->lookahead -(ulg)s->strstart);
 
-		/* Deal with !@#$% 64K limit: */
-		if (sizeof(int) <= 2) {
-			if (more == 0 && s->strstart == 0 && s->lookahead == 0) {
-				more = wsize;
+        /* Deal with !@#$% 64K limit: */
+        if (sizeof(int) <= 2) {
+            if (more == 0 && s->strstart == 0 && s->lookahead == 0) {
+                more = wsize;
 
-			}
-			else if (more == (unsigned)(-1)) {
-				/* Very unlikely, but possible on 16 bit machine if
-				 * strstart == 0 && lookahead == 1 (input done a byte at time)
-				 */
-				more--;
-			}
-		}
+            } else if (more == (unsigned)(-1)) {
+                /* Very unlikely, but possible on 16 bit machine if
+                 * strstart == 0 && lookahead == 1 (input done a byte at time)
+                 */
+                more--;
+            }
+        }
 
-		/* If the window is almost full and there is insufficient lookahead,
-		 * move the upper half to the lower one to make room in the upper half.
-		 */
-		if (s->strstart >= wsize + MAX_DIST(s)) {
+        /* If the window is almost full and there is insufficient lookahead,
+         * move the upper half to the lower one to make room in the upper half.
+         */
+        if (s->strstart >= wsize+MAX_DIST(s)) {
 
-			zmemcpy(s->window, s->window + wsize, (unsigned)wsize);
-			s->match_start -= wsize;
-			s->strstart -= wsize; /* we now have strstart >= MAX_DIST */
-			s->block_start -= (long)wsize;
+            zmemcpy(s->window, s->window+wsize, (unsigned)wsize - more);
+            s->match_start -= wsize;
+            s->strstart    -= wsize; /* we now have strstart >= MAX_DIST */
+            s->block_start -= (long) wsize;
+            slide_hash(s);
+            more += wsize;
+        }
+        if (s->strm->avail_in == 0) break;
 
-			/* Slide the hash table (could be avoided with 32 bit values
-				at the expense of memory usage). We slide even when level == 0
-				to keep the hash table consistent if we switch back to level > 0
-				later. (Using level 0 permanently is not an optimal usage of
-				zlib, so we don't care about this pathological case.)
-			 */
-			n = s->hash_size;
-			p = &s->head[n];
-			do {
-				m = *--p;
-				*p = (Pos)(m >= wsize ? m - wsize : NIL);
-			} while (--n);
+        /* If there was no sliding:
+         *    strstart <= WSIZE+MAX_DIST-1 && lookahead <= MIN_LOOKAHEAD - 1 &&
+         *    more == window_size - lookahead - strstart
+         * => more >= window_size - (MIN_LOOKAHEAD-1 + WSIZE + MAX_DIST-1)
+         * => more >= window_size - 2*WSIZE + 2
+         * In the BIG_MEM or MMAP case (not yet supported),
+         *   window_size == input_size + MIN_LOOKAHEAD  &&
+         *   strstart + s->lookahead <= input_size => more >= MIN_LOOKAHEAD.
+         * Otherwise, window_size == 2*WSIZE so more >= 2.
+         * If there was sliding, more >= WSIZE. So in all cases, more >= 2.
+         */
+        Assert(more >= 2, "more < 2");
 
-			n = wsize;
-			#ifndef FASTEST
-			p = &s->prev[n];
-			do {
-				m = *--p;
-				*p = (Pos)(m >= wsize ? m - wsize : NIL);
-				/* If n is not on any hash chain, prev[n] is garbage but
-				 * its value will never be used.
-				 */
-			} while (--n);
-			#endif
-			more += wsize;
-		}
-		if (s->strm->avail_in == 0) break;
+        n = read_buf(s->strm, s->window + s->strstart + s->lookahead, more);
+        s->lookahead += n;
 
-		/* If there was no sliding:
-		 *    strstart <= WSIZE+MAX_DIST-1 && lookahead <= MIN_LOOKAHEAD - 1 &&
-		 *    more == window_size - lookahead - strstart
-		 * => more >= window_size - (MIN_LOOKAHEAD-1 + WSIZE + MAX_DIST-1)
-		 * => more >= window_size - 2*WSIZE + 2
-		 * In the BIG_MEM or MMAP case (not yet supported),
-		 *   window_size == input_size + MIN_LOOKAHEAD  &&
-		 *   strstart + s->lookahead <= input_size => more >= MIN_LOOKAHEAD.
-		 * Otherwise, window_size == 2*WSIZE so more >= 2.
-		 * If there was sliding, more >= WSIZE. So in all cases, more >= 2.
-		 */
-		Assert(more >= 2, "more < 2");
+        /* Initialize the hash value now that we have some input: */
+        if (s->lookahead + s->insert >= MIN_MATCH) {
+            uInt str = s->strstart - s->insert;
+            s->ins_h = s->window[str];
+            UPDATE_HASH(s, s->ins_h, s->window[str + 1]);
+#if MIN_MATCH != 3
+            Call UPDATE_HASH() MIN_MATCH-3 more times
+#endif
+            while (s->insert) {
+                UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH-1]);
+#ifndef FASTEST
+                s->prev[str & s->w_mask] = s->head[s->ins_h];
+#endif
+                s->head[s->ins_h] = (Pos)str;
+                str++;
+                s->insert--;
+                if (s->lookahead + s->insert < MIN_MATCH)
+                    break;
+            }
+        }
+        /* If the whole input has less than MIN_MATCH bytes, ins_h is garbage,
+         * but this is not important since only literal bytes will be emitted.
+         */
 
-		n = read_buf(s->strm, s->window + s->strstart + s->lookahead, more);
-		s->lookahead += n;
+    } while (s->lookahead < MIN_LOOKAHEAD && s->strm->avail_in != 0);
 
-		/* Initialize the hash value now that we have some input: */
-		if (s->lookahead + s->insert >= MIN_MATCH) {
-			uInt str = s->strstart - s->insert;
-			s->ins_h = s->window[str];
-			UPDATE_HASH(s, s->ins_h, s->window[str + 1]);
-			#if MIN_MATCH != 3
-			Call UPDATE_HASH() MIN_MATCH - 3 more times
-				#endif
-				while (s->insert) {
-					UPDATE_HASH(s, s->ins_h, s->window[str + MIN_MATCH - 1]);
-					#ifndef FASTEST
-					s->prev[str & s->w_mask] = s->head[s->ins_h];
-					#endif
-					s->head[s->ins_h] = (Pos)str;
-					str++;
-					s->insert--;
-					if (s->lookahead + s->insert < MIN_MATCH)
-						break;
-				}
-		}
-		/* If the whole input has less than MIN_MATCH bytes, ins_h is garbage,
-		 * but this is not important since only literal bytes will be emitted.
-		 */
+    /* If the WIN_INIT bytes after the end of the current data have never been
+     * written, then zero those bytes in order to avoid memory check reports of
+     * the use of uninitialized (or uninitialised as Julian writes) bytes by
+     * the longest match routines.  Update the high water mark for the next
+     * time through here.  WIN_INIT is set to MAX_MATCH since the longest match
+     * routines allow scanning to strstart + MAX_MATCH, ignoring lookahead.
+     */
+    if (s->high_water < s->window_size) {
+        ulg curr = s->strstart + (ulg)(s->lookahead);
+        ulg init;
 
-	} while (s->lookahead < MIN_LOOKAHEAD && s->strm->avail_in != 0);
+        if (s->high_water < curr) {
+            /* Previous high water mark below current data -- zero WIN_INIT
+             * bytes or up to end of window, whichever is less.
+             */
+            init = s->window_size - curr;
+            if (init > WIN_INIT)
+                init = WIN_INIT;
+            zmemzero(s->window + curr, (unsigned)init);
+            s->high_water = curr + init;
+        }
+        else if (s->high_water < (ulg)curr + WIN_INIT) {
+            /* High water mark at or above current data, but below current data
+             * plus WIN_INIT -- zero out to current data plus WIN_INIT, or up
+             * to end of window, whichever is less.
+             */
+            init = (ulg)curr + WIN_INIT - s->high_water;
+            if (init > s->window_size - s->high_water)
+                init = s->window_size - s->high_water;
+            zmemzero(s->window + s->high_water, (unsigned)init);
+            s->high_water += init;
+        }
+    }
 
-	/* If the WIN_INIT bytes after the end of the current data have never been
-	 * written, then zero those bytes in order to avoid memory check reports of
-	 * the use of uninitialized (or uninitialised as Julian writes) bytes by
-	 * the longest match routines.  Update the high water mark for the next
-	 * time through here.  WIN_INIT is set to MAX_MATCH since the longest match
-	 * routines allow scanning to strstart + MAX_MATCH, ignoring lookahead.
-	 */
-	if (s->high_water < s->window_size) {
-		ulg curr = s->strstart + (ulg)(s->lookahead);
-		ulg init;
-
-		if (s->high_water < curr) {
-			/* Previous high water mark below current data -- zero WIN_INIT
-			 * bytes or up to end of window, whichever is less.
-			 */
-			init = s->window_size - curr;
-			if (init > WIN_INIT)
-				init = WIN_INIT;
-			zmemzero(s->window + curr, (unsigned)init);
-			s->high_water = curr + init;
-		}
-		else if (s->high_water < (ulg)curr + WIN_INIT) {
-			/* High water mark at or above current data, but below current data
-			 * plus WIN_INIT -- zero out to current data plus WIN_INIT, or up
-			 * to end of window, whichever is less.
-			 */
-			init = (ulg)curr + WIN_INIT - s->high_water;
-			if (init > s->window_size - s->high_water)
-				init = s->window_size - s->high_water;
-			zmemzero(s->window + s->high_water, (unsigned)init);
-			s->high_water += init;
-		}
-	}
-
-	Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD,
-		"not enough room for search");
+    Assert((ulg)s->strstart <= s->window_size - MIN_LOOKAHEAD,
+           "not enough room for search");
 }
 
 /* ===========================================================================
@@ -1551,76 +1613,205 @@ deflate_state *s;
    Tracev((stderr,"[FLUSH]")); \
 }
 
- /* Same but force premature exit if necessary. */
+/* Same but force premature exit if necessary. */
 #define FLUSH_BLOCK(s, last) { \
    FLUSH_BLOCK_ONLY(s, last); \
    if (s->strm->avail_out == 0) return (last) ? finish_started : need_more; \
 }
 
+/* Maximum stored block length in deflate format (not including header). */
+#define MAX_STORED 65535
+
+/* Minimum of a and b. */
+#define MIN(a, b) ((a) > (b) ? (b) : (a))
+
 /* ===========================================================================
  * Copy without compression as much as possible from the input stream, return
  * the current block state.
- * This function does not insert new strings in the dictionary since
- * uncompressible data is probably not useful. This function is used
- * only for the level=0 compression option.
- * NOTE: this function should be optimized to avoid extra copying from
- * window to pending_buf.
+ *
+ * In case deflateParams() is used to later switch to a non-zero compression
+ * level, s->matches (otherwise unused when storing) keeps track of the number
+ * of hash table slides to perform. If s->matches is 1, then one hash table
+ * slide will be done when switching. If s->matches is 2, the maximum value
+ * allowed here, then the hash table will be cleared, since two or more slides
+ * is the same as a clear.
+ *
+ * deflate_stored() is written to minimize the number of times an input byte is
+ * copied. It is most efficient with large input and output buffers, which
+ * maximizes the opportunites to have a single copy from next_in to next_out.
  */
 local block_state deflate_stored(s, flush)
-deflate_state *s;
-int flush;
+    deflate_state *s;
+    int flush;
 {
-	/* Stored blocks are limited to 0xffff bytes, pending_buf is limited
-	 * to pending_buf_size, and each stored block has a 5 byte header:
-	 */
-	ulg max_block_size = 0xffff;
-	ulg max_start;
+    /* Smallest worthy block size when not flushing or finishing. By default
+     * this is 32K. This can be as small as 507 bytes for memLevel == 1. For
+     * large input and output buffers, the stored block size will be larger.
+     */
+    unsigned min_block = MIN(s->pending_buf_size - 5, s->w_size);
 
-	if (max_block_size > s->pending_buf_size - 5) {
-		max_block_size = s->pending_buf_size - 5;
-	}
+    /* Copy as many min_block or larger stored blocks directly to next_out as
+     * possible. If flushing, copy the remaining available input to next_out as
+     * stored blocks, if there is enough space.
+     */
+    unsigned len, left, have, last = 0;
+    unsigned used = s->strm->avail_in;
+    do {
+        /* Set len to the maximum size block that we can copy directly with the
+         * available input data and output space. Set left to how much of that
+         * would be copied from what's left in the window.
+         */
+        len = MAX_STORED;       /* maximum deflate stored block length */
+        have = (s->bi_valid + 42) >> 3;         /* number of header bytes */
+        if (s->strm->avail_out < have)          /* need room for header */
+            break;
+            /* maximum stored block length that will fit in avail_out: */
+        have = s->strm->avail_out - have;
+        left = s->strstart - s->block_start;    /* bytes left in window */
+        if (len > (ulg)left + s->strm->avail_in)
+            len = left + s->strm->avail_in;     /* limit len to the input */
+        if (len > have)
+            len = have;                         /* limit len to the output */
 
-	/* Copy as much as possible from input to output: */
-	for (;;) {
-		/* Fill the window as much as possible: */
-		if (s->lookahead <= 1) {
+        /* If the stored block would be less than min_block in length, or if
+         * unable to copy all of the available input when flushing, then try
+         * copying to the window and the pending buffer instead. Also don't
+         * write an empty block when flushing -- deflate() does that.
+         */
+        if (len < min_block && ((len == 0 && flush != Z_FINISH) ||
+                                flush == Z_NO_FLUSH ||
+                                len != left + s->strm->avail_in))
+            break;
 
-			Assert(s->strstart < s->w_size + MAX_DIST(s) ||
-				s->block_start >= (long)s->w_size, "slide too late");
+        /* Make a dummy stored block in pending to get the header bytes,
+         * including any pending bits. This also updates the debugging counts.
+         */
+        last = flush == Z_FINISH && len == left + s->strm->avail_in ? 1 : 0;
+        _tr_stored_block(s, (char *)0, 0L, last);
 
-			fill_window(s);
-			if (s->lookahead == 0 && flush == Z_NO_FLUSH) return need_more;
+        /* Replace the lengths in the dummy stored block with len. */
+        s->pending_buf[s->pending - 4] = len;
+        s->pending_buf[s->pending - 3] = len >> 8;
+        s->pending_buf[s->pending - 2] = ~len;
+        s->pending_buf[s->pending - 1] = ~len >> 8;
 
-			if (s->lookahead == 0) break; /* flush the current block */
-		}
-		Assert(s->block_start >= 0L, "block gone");
+        /* Write the stored block header bytes. */
+        flush_pending(s->strm);
 
-		s->strstart += s->lookahead;
-		s->lookahead = 0;
+#ifdef ZLIB_DEBUG
+        /* Update debugging counts for the data about to be copied. */
+        s->compressed_len += len << 3;
+        s->bits_sent += len << 3;
+#endif
 
-		/* Emit a stored block if pending_buf will be full: */
-		max_start = s->block_start + max_block_size;
-		if (s->strstart == 0 || (ulg)s->strstart >= max_start) {
-			/* strstart == 0 is possible when wraparound on 16-bit machine */
-			s->lookahead = (uInt)(s->strstart - max_start);
-			s->strstart = (uInt)max_start;
-			FLUSH_BLOCK(s, 0);
-		}
-		/* Flush if we may have to slide, otherwise block_start may become
-		 * negative and the data will be gone:
-		 */
-		if (s->strstart - (uInt)s->block_start >= MAX_DIST(s)) {
-			FLUSH_BLOCK(s, 0);
-		}
-	}
-	s->insert = 0;
-	if (flush == Z_FINISH) {
-		FLUSH_BLOCK(s, 1);
-		return finish_done;
-	}
-	if ((long)s->strstart > s->block_start)
-		FLUSH_BLOCK(s, 0);
-	return block_done;
+        /* Copy uncompressed bytes from the window to next_out. */
+        if (left) {
+            if (left > len)
+                left = len;
+            zmemcpy(s->strm->next_out, s->window + s->block_start, left);
+            s->strm->next_out += left;
+            s->strm->avail_out -= left;
+            s->strm->total_out += left;
+            s->block_start += left;
+            len -= left;
+        }
+
+        /* Copy uncompressed bytes directly from next_in to next_out, updating
+         * the check value.
+         */
+        if (len) {
+            read_buf(s->strm, s->strm->next_out, len);
+            s->strm->next_out += len;
+            s->strm->avail_out -= len;
+            s->strm->total_out += len;
+        }
+    } while (last == 0);
+
+    /* Update the sliding window with the last s->w_size bytes of the copied
+     * data, or append all of the copied data to the existing window if less
+     * than s->w_size bytes were copied. Also update the number of bytes to
+     * insert in the hash tables, in the event that deflateParams() switches to
+     * a non-zero compression level.
+     */
+    used -= s->strm->avail_in;      /* number of input bytes directly copied */
+    if (used) {
+        /* If any input was used, then no unused input remains in the window,
+         * therefore s->block_start == s->strstart.
+         */
+        if (used >= s->w_size) {    /* supplant the previous history */
+            s->matches = 2;         /* clear hash */
+            zmemcpy(s->window, s->strm->next_in - s->w_size, s->w_size);
+            s->strstart = s->w_size;
+        }
+        else {
+            if (s->window_size - s->strstart <= used) {
+                /* Slide the window down. */
+                s->strstart -= s->w_size;
+                zmemcpy(s->window, s->window + s->w_size, s->strstart);
+                if (s->matches < 2)
+                    s->matches++;   /* add a pending slide_hash() */
+            }
+            zmemcpy(s->window + s->strstart, s->strm->next_in - used, used);
+            s->strstart += used;
+        }
+        s->block_start = s->strstart;
+        s->insert += MIN(used, s->w_size - s->insert);
+    }
+    if (s->high_water < s->strstart)
+        s->high_water = s->strstart;
+
+    /* If the last block was written to next_out, then done. */
+    if (last)
+        return finish_done;
+
+    /* If flushing and all input has been consumed, then done. */
+    if (flush != Z_NO_FLUSH && flush != Z_FINISH &&
+        s->strm->avail_in == 0 && (long)s->strstart == s->block_start)
+        return block_done;
+
+    /* Fill the window with any remaining input. */
+    have = s->window_size - s->strstart - 1;
+    if (s->strm->avail_in > have && s->block_start >= (long)s->w_size) {
+        /* Slide the window down. */
+        s->block_start -= s->w_size;
+        s->strstart -= s->w_size;
+        zmemcpy(s->window, s->window + s->w_size, s->strstart);
+        if (s->matches < 2)
+            s->matches++;           /* add a pending slide_hash() */
+        have += s->w_size;          /* more space now */
+    }
+    if (have > s->strm->avail_in)
+        have = s->strm->avail_in;
+    if (have) {
+        read_buf(s->strm, s->window + s->strstart, have);
+        s->strstart += have;
+    }
+    if (s->high_water < s->strstart)
+        s->high_water = s->strstart;
+
+    /* There was not enough avail_out to write a complete worthy or flushed
+     * stored block to next_out. Write a stored block to pending instead, if we
+     * have enough input for a worthy block, or if flushing and there is enough
+     * room for the remaining input as a stored block in the pending buffer.
+     */
+    have = (s->bi_valid + 42) >> 3;         /* number of header bytes */
+        /* maximum stored block length that will fit in pending: */
+    have = MIN(s->pending_buf_size - have, MAX_STORED);
+    min_block = MIN(have, s->w_size);
+    left = s->strstart - s->block_start;
+    if (left >= min_block ||
+        ((left || flush == Z_FINISH) && flush != Z_NO_FLUSH &&
+         s->strm->avail_in == 0 && left <= have)) {
+        len = MIN(left, have);
+        last = flush == Z_FINISH && s->strm->avail_in == 0 &&
+               len == left ? 1 : 0;
+        _tr_stored_block(s, (charf *)s->window + s->block_start, len, last);
+        s->block_start += len;
+        flush_pending(s->strm);
+    }
+
+    /* We've done all we can with the available input and output. */
+    return last ? finish_started : need_more;
 }
 
 /* ===========================================================================
@@ -1631,101 +1822,99 @@ int flush;
  * matches. It is used only for the fast compression options.
  */
 local block_state deflate_fast(s, flush)
-deflate_state *s;
-int flush;
+    deflate_state *s;
+    int flush;
 {
-	IPos hash_head;       /* head of the hash chain */
-	int bflush;           /* set if current block must be flushed */
+    IPos hash_head;       /* head of the hash chain */
+    int bflush;           /* set if current block must be flushed */
 
-	for (;;) {
-		/* Make sure that we always have enough lookahead, except
-		 * at the end of the input file. We need MAX_MATCH bytes
-		 * for the next match, plus MIN_MATCH bytes to insert the
-		 * string following the next match.
-		 */
-		if (s->lookahead < MIN_LOOKAHEAD) {
-			fill_window(s);
-			if (s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
-				return need_more;
-			}
-			if (s->lookahead == 0) break; /* flush the current block */
-		}
+    for (;;) {
+        /* Make sure that we always have enough lookahead, except
+         * at the end of the input file. We need MAX_MATCH bytes
+         * for the next match, plus MIN_MATCH bytes to insert the
+         * string following the next match.
+         */
+        if (s->lookahead < MIN_LOOKAHEAD) {
+            fill_window(s);
+            if (s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
+                return need_more;
+            }
+            if (s->lookahead == 0) break; /* flush the current block */
+        }
 
-		/* Insert the string window[strstart .. strstart+2] in the
-		 * dictionary, and set hash_head to the head of the hash chain:
-		 */
-		hash_head = NIL;
-		if (s->lookahead >= MIN_MATCH) {
-			INSERT_STRING(s, s->strstart, hash_head);
-		}
+        /* Insert the string window[strstart .. strstart+2] in the
+         * dictionary, and set hash_head to the head of the hash chain:
+         */
+        hash_head = NIL;
+        if (s->lookahead >= MIN_MATCH) {
+            INSERT_STRING(s, s->strstart, hash_head);
+        }
 
-		/* Find the longest match, discarding those <= prev_length.
-		 * At this point we have always match_length < MIN_MATCH
-		 */
-		if (hash_head != NIL && s->strstart - hash_head <= MAX_DIST(s)) {
-			/* To simplify the code, we prevent matches with the string
-			 * of window index 0 (in particular we have to avoid a match
-			 * of the string with itself at the start of the input file).
-			 */
-			s->match_length = longest_match(s, hash_head);
-			/* longest_match() sets match_start */
-		}
-		if (s->match_length >= MIN_MATCH) {
-			check_match(s, s->strstart, s->match_start, s->match_length);
+        /* Find the longest match, discarding those <= prev_length.
+         * At this point we have always match_length < MIN_MATCH
+         */
+        if (hash_head != NIL && s->strstart - hash_head <= MAX_DIST(s)) {
+            /* To simplify the code, we prevent matches with the string
+             * of window index 0 (in particular we have to avoid a match
+             * of the string with itself at the start of the input file).
+             */
+            s->match_length = longest_match (s, hash_head);
+            /* longest_match() sets match_start */
+        }
+        if (s->match_length >= MIN_MATCH) {
+            check_match(s, s->strstart, s->match_start, s->match_length);
 
-			_tr_tally_dist(s, s->strstart - s->match_start,
-				s->match_length - MIN_MATCH, bflush);
+            _tr_tally_dist(s, s->strstart - s->match_start,
+                           s->match_length - MIN_MATCH, bflush);
 
-			s->lookahead -= s->match_length;
+            s->lookahead -= s->match_length;
 
-			/* Insert new strings in the hash table only if the match length
-			 * is not too large. This saves time but degrades compression.
-			 */
-			#ifndef FASTEST
-			if (s->match_length <= s->max_insert_length &&
-				s->lookahead >= MIN_MATCH) {
-				s->match_length--; /* string at strstart already in table */
-				do {
-					s->strstart++;
-					INSERT_STRING(s, s->strstart, hash_head);
-					/* strstart never exceeds WSIZE-MAX_MATCH, so there are
-					 * always MIN_MATCH bytes ahead.
-					 */
-				} while (--s->match_length != 0);
-				s->strstart++;
-			}
-			else
-				#endif
-			{
-				s->strstart += s->match_length;
-				s->match_length = 0;
-				s->ins_h = s->window[s->strstart];
-				UPDATE_HASH(s, s->ins_h, s->window[s->strstart + 1]);
-				#if MIN_MATCH != 3
-				Call UPDATE_HASH() MIN_MATCH - 3 more times
-					#endif
-					/* If lookahead < MIN_MATCH, ins_h is garbage, but it does not
-					 * matter since it will be recomputed at next deflate call.
-					 */
-			}
-		}
-		else {
-			/* No match, output a literal byte */
-			Tracevv((stderr, "%c", s->window[s->strstart]));
-			_tr_tally_lit(s, s->window[s->strstart], bflush);
-			s->lookahead--;
-			s->strstart++;
-		}
-		if (bflush) FLUSH_BLOCK(s, 0);
-	}
-	s->insert = s->strstart < MIN_MATCH - 1 ? s->strstart : MIN_MATCH - 1;
-	if (flush == Z_FINISH) {
-		FLUSH_BLOCK(s, 1);
-		return finish_done;
-	}
-	if (s->last_lit)
-		FLUSH_BLOCK(s, 0);
-	return block_done;
+            /* Insert new strings in the hash table only if the match length
+             * is not too large. This saves time but degrades compression.
+             */
+#ifndef FASTEST
+            if (s->match_length <= s->max_insert_length &&
+                s->lookahead >= MIN_MATCH) {
+                s->match_length--; /* string at strstart already in table */
+                do {
+                    s->strstart++;
+                    INSERT_STRING(s, s->strstart, hash_head);
+                    /* strstart never exceeds WSIZE-MAX_MATCH, so there are
+                     * always MIN_MATCH bytes ahead.
+                     */
+                } while (--s->match_length != 0);
+                s->strstart++;
+            } else
+#endif
+            {
+                s->strstart += s->match_length;
+                s->match_length = 0;
+                s->ins_h = s->window[s->strstart];
+                UPDATE_HASH(s, s->ins_h, s->window[s->strstart+1]);
+#if MIN_MATCH != 3
+                Call UPDATE_HASH() MIN_MATCH-3 more times
+#endif
+                /* If lookahead < MIN_MATCH, ins_h is garbage, but it does not
+                 * matter since it will be recomputed at next deflate call.
+                 */
+            }
+        } else {
+            /* No match, output a literal byte */
+            Tracevv((stderr,"%c", s->window[s->strstart]));
+            _tr_tally_lit (s, s->window[s->strstart], bflush);
+            s->lookahead--;
+            s->strstart++;
+        }
+        if (bflush) FLUSH_BLOCK(s, 0);
+    }
+    s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;
+    if (flush == Z_FINISH) {
+        FLUSH_BLOCK(s, 1);
+        return finish_done;
+    }
+    if (s->last_lit)
+        FLUSH_BLOCK(s, 0);
+    return block_done;
 }
 
 #ifndef FASTEST
@@ -1735,130 +1924,128 @@ int flush;
  * no better match at the next window position.
  */
 local block_state deflate_slow(s, flush)
-deflate_state *s;
-int flush;
+    deflate_state *s;
+    int flush;
 {
-	IPos hash_head;          /* head of hash chain */
-	int bflush;              /* set if current block must be flushed */
+    IPos hash_head;          /* head of hash chain */
+    int bflush;              /* set if current block must be flushed */
 
-	/* Process the input block. */
-	for (;;) {
-		/* Make sure that we always have enough lookahead, except
-		 * at the end of the input file. We need MAX_MATCH bytes
-		 * for the next match, plus MIN_MATCH bytes to insert the
-		 * string following the next match.
-		 */
-		if (s->lookahead < MIN_LOOKAHEAD) {
-			fill_window(s);
-			if (s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
-				return need_more;
-			}
-			if (s->lookahead == 0) break; /* flush the current block */
-		}
+    /* Process the input block. */
+    for (;;) {
+        /* Make sure that we always have enough lookahead, except
+         * at the end of the input file. We need MAX_MATCH bytes
+         * for the next match, plus MIN_MATCH bytes to insert the
+         * string following the next match.
+         */
+        if (s->lookahead < MIN_LOOKAHEAD) {
+            fill_window(s);
+            if (s->lookahead < MIN_LOOKAHEAD && flush == Z_NO_FLUSH) {
+                return need_more;
+            }
+            if (s->lookahead == 0) break; /* flush the current block */
+        }
 
-		/* Insert the string window[strstart .. strstart+2] in the
-		 * dictionary, and set hash_head to the head of the hash chain:
-		 */
-		hash_head = NIL;
-		if (s->lookahead >= MIN_MATCH) {
-			INSERT_STRING(s, s->strstart, hash_head);
-		}
+        /* Insert the string window[strstart .. strstart+2] in the
+         * dictionary, and set hash_head to the head of the hash chain:
+         */
+        hash_head = NIL;
+        if (s->lookahead >= MIN_MATCH) {
+            INSERT_STRING(s, s->strstart, hash_head);
+        }
 
-		/* Find the longest match, discarding those <= prev_length.
-		 */
-		s->prev_length = s->match_length, s->prev_match = s->match_start;
-		s->match_length = MIN_MATCH - 1;
+        /* Find the longest match, discarding those <= prev_length.
+         */
+        s->prev_length = s->match_length, s->prev_match = s->match_start;
+        s->match_length = MIN_MATCH-1;
 
-		if (hash_head != NIL && s->prev_length < s->max_lazy_match &&
-			s->strstart - hash_head <= MAX_DIST(s)) {
-			/* To simplify the code, we prevent matches with the string
-			 * of window index 0 (in particular we have to avoid a match
-			 * of the string with itself at the start of the input file).
-			 */
-			s->match_length = longest_match(s, hash_head);
-			/* longest_match() sets match_start */
+        if (hash_head != NIL && s->prev_length < s->max_lazy_match &&
+            s->strstart - hash_head <= MAX_DIST(s)) {
+            /* To simplify the code, we prevent matches with the string
+             * of window index 0 (in particular we have to avoid a match
+             * of the string with itself at the start of the input file).
+             */
+            s->match_length = longest_match (s, hash_head);
+            /* longest_match() sets match_start */
 
-			if (s->match_length <= 5 && (s->strategy == Z_FILTERED
-				#if TOO_FAR <= 32767
-				|| (s->match_length == MIN_MATCH &&
-					s->strstart - s->match_start > TOO_FAR)
-				#endif
-				)) {
+            if (s->match_length <= 5 && (s->strategy == Z_FILTERED
+#if TOO_FAR <= 32767
+                || (s->match_length == MIN_MATCH &&
+                    s->strstart - s->match_start > TOO_FAR)
+#endif
+                )) {
 
-				/* If prev_match is also MIN_MATCH, match_start is garbage
-				 * but we will ignore the current match anyway.
-				 */
-				s->match_length = MIN_MATCH - 1;
-			}
-		}
-		/* If there was a match at the previous step and the current
-		 * match is not better, output the previous match:
-		 */
-		if (s->prev_length >= MIN_MATCH && s->match_length <= s->prev_length) {
-			uInt max_insert = s->strstart + s->lookahead - MIN_MATCH;
-			/* Do not insert strings in hash table beyond this. */
+                /* If prev_match is also MIN_MATCH, match_start is garbage
+                 * but we will ignore the current match anyway.
+                 */
+                s->match_length = MIN_MATCH-1;
+            }
+        }
+        /* If there was a match at the previous step and the current
+         * match is not better, output the previous match:
+         */
+        if (s->prev_length >= MIN_MATCH && s->match_length <= s->prev_length) {
+            uInt max_insert = s->strstart + s->lookahead - MIN_MATCH;
+            /* Do not insert strings in hash table beyond this. */
 
-			check_match(s, s->strstart - 1, s->prev_match, s->prev_length);
+            check_match(s, s->strstart-1, s->prev_match, s->prev_length);
 
-			_tr_tally_dist(s, s->strstart - 1 - s->prev_match,
-				s->prev_length - MIN_MATCH, bflush);
+            _tr_tally_dist(s, s->strstart -1 - s->prev_match,
+                           s->prev_length - MIN_MATCH, bflush);
 
-			/* Insert in hash table all strings up to the end of the match.
-			 * strstart-1 and strstart are already inserted. If there is not
-			 * enough lookahead, the last two strings are not inserted in
-			 * the hash table.
-			 */
-			s->lookahead -= s->prev_length - 1;
-			s->prev_length -= 2;
-			do {
-				if (++s->strstart <= max_insert) {
-					INSERT_STRING(s, s->strstart, hash_head);
-				}
-			} while (--s->prev_length != 0);
-			s->match_available = 0;
-			s->match_length = MIN_MATCH - 1;
-			s->strstart++;
+            /* Insert in hash table all strings up to the end of the match.
+             * strstart-1 and strstart are already inserted. If there is not
+             * enough lookahead, the last two strings are not inserted in
+             * the hash table.
+             */
+            s->lookahead -= s->prev_length-1;
+            s->prev_length -= 2;
+            do {
+                if (++s->strstart <= max_insert) {
+                    INSERT_STRING(s, s->strstart, hash_head);
+                }
+            } while (--s->prev_length != 0);
+            s->match_available = 0;
+            s->match_length = MIN_MATCH-1;
+            s->strstart++;
 
-			if (bflush) FLUSH_BLOCK(s, 0);
+            if (bflush) FLUSH_BLOCK(s, 0);
 
-		}
-		else if (s->match_available) {
-			/* If there was no match at the previous position, output a
-			 * single literal. If there was a match but the current match
-			 * is longer, truncate the previous match to a single literal.
-			 */
-			Tracevv((stderr, "%c", s->window[s->strstart - 1]));
-			_tr_tally_lit(s, s->window[s->strstart - 1], bflush);
-			if (bflush) {
-				FLUSH_BLOCK_ONLY(s, 0);
-			}
-			s->strstart++;
-			s->lookahead--;
-			if (s->strm->avail_out == 0) return need_more;
-		}
-		else {
-			/* There is no previous match to compare with, wait for
-			 * the next step to decide.
-			 */
-			s->match_available = 1;
-			s->strstart++;
-			s->lookahead--;
-		}
-	}
-	Assert(flush != Z_NO_FLUSH, "no flush?");
-	if (s->match_available) {
-		Tracevv((stderr, "%c", s->window[s->strstart - 1]));
-		_tr_tally_lit(s, s->window[s->strstart - 1], bflush);
-		s->match_available = 0;
-	}
-	s->insert = s->strstart < MIN_MATCH - 1 ? s->strstart : MIN_MATCH - 1;
-	if (flush == Z_FINISH) {
-		FLUSH_BLOCK(s, 1);
-		return finish_done;
-	}
-	if (s->last_lit)
-		FLUSH_BLOCK(s, 0);
-	return block_done;
+        } else if (s->match_available) {
+            /* If there was no match at the previous position, output a
+             * single literal. If there was a match but the current match
+             * is longer, truncate the previous match to a single literal.
+             */
+            Tracevv((stderr,"%c", s->window[s->strstart-1]));
+            _tr_tally_lit(s, s->window[s->strstart-1], bflush);
+            if (bflush) {
+                FLUSH_BLOCK_ONLY(s, 0);
+            }
+            s->strstart++;
+            s->lookahead--;
+            if (s->strm->avail_out == 0) return need_more;
+        } else {
+            /* There is no previous match to compare with, wait for
+             * the next step to decide.
+             */
+            s->match_available = 1;
+            s->strstart++;
+            s->lookahead--;
+        }
+    }
+    Assert (flush != Z_NO_FLUSH, "no flush?");
+    if (s->match_available) {
+        Tracevv((stderr,"%c", s->window[s->strstart-1]));
+        _tr_tally_lit(s, s->window[s->strstart-1], bflush);
+        s->match_available = 0;
+    }
+    s->insert = s->strstart < MIN_MATCH-1 ? s->strstart : MIN_MATCH-1;
+    if (flush == Z_FINISH) {
+        FLUSH_BLOCK(s, 1);
+        return finish_done;
+    }
+    if (s->last_lit)
+        FLUSH_BLOCK(s, 0);
+    return block_done;
 }
 #endif /* FASTEST */
 
@@ -1868,73 +2055,72 @@ int flush;
  * deflate switches away from Z_RLE.)
  */
 local block_state deflate_rle(s, flush)
-deflate_state *s;
-int flush;
+    deflate_state *s;
+    int flush;
 {
-	int bflush;             /* set if current block must be flushed */
-	uInt prev;              /* byte at distance one to match */
-	Bytef *scan, *strend;   /* scan goes up to strend for length of run */
+    int bflush;             /* set if current block must be flushed */
+    uInt prev;              /* byte at distance one to match */
+    Bytef *scan, *strend;   /* scan goes up to strend for length of run */
 
-	for (;;) {
-		/* Make sure that we always have enough lookahead, except
-		 * at the end of the input file. We need MAX_MATCH bytes
-		 * for the longest run, plus one for the unrolled loop.
-		 */
-		if (s->lookahead <= MAX_MATCH) {
-			fill_window(s);
-			if (s->lookahead <= MAX_MATCH && flush == Z_NO_FLUSH) {
-				return need_more;
-			}
-			if (s->lookahead == 0) break; /* flush the current block */
-		}
+    for (;;) {
+        /* Make sure that we always have enough lookahead, except
+         * at the end of the input file. We need MAX_MATCH bytes
+         * for the longest run, plus one for the unrolled loop.
+         */
+        if (s->lookahead <= MAX_MATCH) {
+            fill_window(s);
+            if (s->lookahead <= MAX_MATCH && flush == Z_NO_FLUSH) {
+                return need_more;
+            }
+            if (s->lookahead == 0) break; /* flush the current block */
+        }
 
-		/* See how many times the previous byte repeats */
-		s->match_length = 0;
-		if (s->lookahead >= MIN_MATCH && s->strstart > 0) {
-			scan = s->window + s->strstart - 1;
-			prev = *scan;
-			if (prev == *++scan && prev == *++scan && prev == *++scan) {
-				strend = s->window + s->strstart + MAX_MATCH;
-				do {
-				} while (prev == *++scan && prev == *++scan &&
-					prev == *++scan && prev == *++scan &&
-					prev == *++scan && prev == *++scan &&
-					prev == *++scan && prev == *++scan &&
-					scan < strend);
-				s->match_length = MAX_MATCH - (int)(strend - scan);
-				if (s->match_length > s->lookahead)
-					s->match_length = s->lookahead;
-			}
-			Assert(scan <= s->window + (uInt)(s->window_size - 1), "wild scan");
-		}
+        /* See how many times the previous byte repeats */
+        s->match_length = 0;
+        if (s->lookahead >= MIN_MATCH && s->strstart > 0) {
+            scan = s->window + s->strstart - 1;
+            prev = *scan;
+            if (prev == *++scan && prev == *++scan && prev == *++scan) {
+                strend = s->window + s->strstart + MAX_MATCH;
+                do {
+                } while (prev == *++scan && prev == *++scan &&
+                         prev == *++scan && prev == *++scan &&
+                         prev == *++scan && prev == *++scan &&
+                         prev == *++scan && prev == *++scan &&
+                         scan < strend);
+                s->match_length = MAX_MATCH - (uInt)(strend - scan);
+                if (s->match_length > s->lookahead)
+                    s->match_length = s->lookahead;
+            }
+            Assert(scan <= s->window+(uInt)(s->window_size-1), "wild scan");
+        }
 
-		/* Emit match if have run of MIN_MATCH or longer, else emit literal */
-		if (s->match_length >= MIN_MATCH) {
-			check_match(s, s->strstart, s->strstart - 1, s->match_length);
+        /* Emit match if have run of MIN_MATCH or longer, else emit literal */
+        if (s->match_length >= MIN_MATCH) {
+            check_match(s, s->strstart, s->strstart - 1, s->match_length);
 
-			_tr_tally_dist(s, 1, s->match_length - MIN_MATCH, bflush);
+            _tr_tally_dist(s, 1, s->match_length - MIN_MATCH, bflush);
 
-			s->lookahead -= s->match_length;
-			s->strstart += s->match_length;
-			s->match_length = 0;
-		}
-		else {
-			/* No match, output a literal byte */
-			Tracevv((stderr, "%c", s->window[s->strstart]));
-			_tr_tally_lit(s, s->window[s->strstart], bflush);
-			s->lookahead--;
-			s->strstart++;
-		}
-		if (bflush) FLUSH_BLOCK(s, 0);
-	}
-	s->insert = 0;
-	if (flush == Z_FINISH) {
-		FLUSH_BLOCK(s, 1);
-		return finish_done;
-	}
-	if (s->last_lit)
-		FLUSH_BLOCK(s, 0);
-	return block_done;
+            s->lookahead -= s->match_length;
+            s->strstart += s->match_length;
+            s->match_length = 0;
+        } else {
+            /* No match, output a literal byte */
+            Tracevv((stderr,"%c", s->window[s->strstart]));
+            _tr_tally_lit (s, s->window[s->strstart], bflush);
+            s->lookahead--;
+            s->strstart++;
+        }
+        if (bflush) FLUSH_BLOCK(s, 0);
+    }
+    s->insert = 0;
+    if (flush == Z_FINISH) {
+        FLUSH_BLOCK(s, 1);
+        return finish_done;
+    }
+    if (s->last_lit)
+        FLUSH_BLOCK(s, 0);
+    return block_done;
 }
 
 /* ===========================================================================
@@ -1942,36 +2128,36 @@ int flush;
  * (It will be regenerated if this run of deflate switches away from Huffman.)
  */
 local block_state deflate_huff(s, flush)
-deflate_state *s;
-int flush;
+    deflate_state *s;
+    int flush;
 {
-	int bflush;             /* set if current block must be flushed */
+    int bflush;             /* set if current block must be flushed */
 
-	for (;;) {
-		/* Make sure that we have a literal to write. */
-		if (s->lookahead == 0) {
-			fill_window(s);
-			if (s->lookahead == 0) {
-				if (flush == Z_NO_FLUSH)
-					return need_more;
-				break;      /* flush the current block */
-			}
-		}
+    for (;;) {
+        /* Make sure that we have a literal to write. */
+        if (s->lookahead == 0) {
+            fill_window(s);
+            if (s->lookahead == 0) {
+                if (flush == Z_NO_FLUSH)
+                    return need_more;
+                break;      /* flush the current block */
+            }
+        }
 
-		/* Output a literal byte */
-		s->match_length = 0;
-		Tracevv((stderr, "%c", s->window[s->strstart]));
-		_tr_tally_lit(s, s->window[s->strstart], bflush);
-		s->lookahead--;
-		s->strstart++;
-		if (bflush) FLUSH_BLOCK(s, 0);
-	}
-	s->insert = 0;
-	if (flush == Z_FINISH) {
-		FLUSH_BLOCK(s, 1);
-		return finish_done;
-	}
-	if (s->last_lit)
-		FLUSH_BLOCK(s, 0);
-	return block_done;
+        /* Output a literal byte */
+        s->match_length = 0;
+        Tracevv((stderr,"%c", s->window[s->strstart]));
+        _tr_tally_lit (s, s->window[s->strstart], bflush);
+        s->lookahead--;
+        s->strstart++;
+        if (bflush) FLUSH_BLOCK(s, 0);
+    }
+    s->insert = 0;
+    if (flush == Z_FINISH) {
+        FLUSH_BLOCK(s, 1);
+        return finish_done;
+    }
+    if (s->last_lit)
+        FLUSH_BLOCK(s, 0);
+    return block_done;
 }

--- a/libs/zlib/src/deflate.h
+++ b/libs/zlib/src/deflate.h
@@ -1,5 +1,5 @@
 /* deflate.h -- internal compression state
- * Copyright (C) 1995-2012 Jean-loup Gailly
+ * Copyright (C) 1995-2016 Jean-loup Gailly
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -51,13 +51,16 @@
 #define Buf_size 16
 /* size of bit buffer in bi_buf */
 
-#define INIT_STATE    42
-#define EXTRA_STATE   69
-#define NAME_STATE    73
-#define COMMENT_STATE 91
-#define HCRC_STATE   103
-#define BUSY_STATE   113
-#define FINISH_STATE 666
+#define INIT_STATE    42    /* zlib header -> BUSY_STATE */
+#ifdef GZIP
+#  define GZIP_STATE  57    /* gzip header -> BUSY_STATE | EXTRA_STATE */
+#endif
+#define EXTRA_STATE   69    /* gzip extra block -> NAME_STATE */
+#define NAME_STATE    73    /* gzip file name -> COMMENT_STATE */
+#define COMMENT_STATE 91    /* gzip comment -> HCRC_STATE */
+#define HCRC_STATE   103    /* gzip header CRC -> BUSY_STATE */
+#define BUSY_STATE   113    /* deflate -> FINISH_STATE */
+#define FINISH_STATE 666    /* stream complete */
 /* Stream status */
 
 
@@ -83,7 +86,7 @@ typedef struct static_tree_desc_s  static_tree_desc;
 typedef struct tree_desc_s {
     ct_data *dyn_tree;           /* the dynamic tree */
     int     max_code;            /* largest code with non zero frequency */
-    static_tree_desc *stat_desc; /* the corresponding static tree */
+    const static_tree_desc *stat_desc;  /* the corresponding static tree */
 } FAR tree_desc;
 
 typedef ush Pos;
@@ -100,10 +103,10 @@ typedef struct internal_state {
     Bytef *pending_buf;  /* output still pending */
     ulg   pending_buf_size; /* size of pending_buf */
     Bytef *pending_out;  /* next pending byte to output to the stream */
-    uInt   pending;      /* nb of bytes in the pending buffer */
+    ulg   pending;       /* nb of bytes in the pending buffer */
     int   wrap;          /* bit 0 true for zlib, bit 1 true for gzip */
     gz_headerp  gzhead;  /* gzip header information to write */
-    uInt   gzindex;      /* where in extra, name, or comment */
+    ulg   gzindex;       /* where in extra, name, or comment */
     Byte  method;        /* can only be DEFLATED */
     int   last_flush;    /* value of flush param for previous deflate call */
 
@@ -249,7 +252,7 @@ typedef struct internal_state {
     uInt matches;       /* number of string matches in current block */
     uInt insert;        /* bytes at end of window left to insert */
 
-#ifdef DEBUG
+#ifdef ZLIB_DEBUG
     ulg compressed_len; /* total bit length of compressed file mod 2^32 */
     ulg bits_sent;      /* bit length of compressed data sent mod 2^32 */
 #endif
@@ -275,7 +278,7 @@ typedef struct internal_state {
 /* Output a byte on the stream.
  * IN assertion: there is enough room in pending_buf.
  */
-#define put_byte(s, c) {s->pending_buf[s->pending++] = (c);}
+#define put_byte(s, c) {s->pending_buf[s->pending++] = (Bytef)(c);}
 
 
 #define MIN_LOOKAHEAD (MAX_MATCH+MIN_MATCH+1)
@@ -309,7 +312,7 @@ void ZLIB_INTERNAL _tr_stored_block OF((deflate_state *s, charf *buf,
  * used.
  */
 
-#ifndef DEBUG
+#ifndef ZLIB_DEBUG
 /* Inline versions of _tr_tally for speed: */
 
 #if defined(GEN_TREES_H) || !defined(STDC)
@@ -328,8 +331,8 @@ void ZLIB_INTERNAL _tr_stored_block OF((deflate_state *s, charf *buf,
     flush = (s->last_lit == s->lit_bufsize-1); \
    }
 # define _tr_tally_dist(s, distance, length, flush) \
-  { uch len = (length); \
-    ush dist = (distance); \
+  { uch len = (uch)(length); \
+    ush dist = (ush)(distance); \
     s->d_buf[s->last_lit] = dist; \
     s->l_buf[s->last_lit++] = len; \
     dist--; \

--- a/libs/zlib/src/gzclose.c
+++ b/libs/zlib/src/gzclose.c
@@ -5,21 +5,21 @@
 
 #include "gzguts.h"
 
- /* gzclose() is in a separate file so that it is linked in only if it is used.
-	 That way the other gzclose functions can be used instead to avoid linking in
-	 unneeded compression or decompression routines. */
+/* gzclose() is in a separate file so that it is linked in only if it is used.
+   That way the other gzclose functions can be used instead to avoid linking in
+   unneeded compression or decompression routines. */
 int ZEXPORT gzclose(file)
-gzFile file;
+    gzFile file;
 {
-	#ifndef NO_GZCOMPRESS
-	gz_statep state;
+#ifndef NO_GZCOMPRESS
+    gz_statep state;
 
-	if (file == NULL)
-		return Z_STREAM_ERROR;
-	state = (gz_statep)file;
+    if (file == NULL)
+        return Z_STREAM_ERROR;
+    state = (gz_statep)file;
 
-	return state->mode == GZ_READ ? gzclose_r(file) : gzclose_w(file);
-	#else
-	return gzclose_r(file);
-	#endif
+    return state->mode == GZ_READ ? gzclose_r(file) : gzclose_w(file);
+#else
+    return gzclose_r(file);
+#endif
 }

--- a/libs/zlib/src/gzguts.h
+++ b/libs/zlib/src/gzguts.h
@@ -1,5 +1,5 @@
 /* gzguts.h -- zlib internal header definitions for gz* operations
- * Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013 Mark Adler
+ * Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013, 2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -25,6 +25,10 @@
 #  include <stdlib.h>
 #  include <limits.h>
 #endif
+
+#ifndef _POSIX_SOURCE
+#  define _POSIX_SOURCE
+#endif
 #include <fcntl.h>
 
 #ifdef _WIN32
@@ -33,6 +37,10 @@
 
 #if defined(__TURBOC__) || defined(_MSC_VER) || defined(_WIN32)
 #  include <io.h>
+#endif
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  define WIDECHAR
 #endif
 
 #ifdef WINAPI_FAMILY
@@ -95,18 +103,19 @@
 #  endif
 #endif
 
-/* unlike snprintf (which is required in C99, yet still not supported by
-   Microsoft more than a decade later!), _snprintf does not guarantee null
-   termination of the result -- however this is only used in gzlib.c where
+/* unlike snprintf (which is required in C99), _snprintf does not guarantee
+   null termination of the result -- however this is only used in gzlib.c where
    the result is assured to fit in the space provided */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #  define snprintf _snprintf
 #endif
 
 #ifndef local
 #  define local static
 #endif
-/* compile with -Dlocal if your debugger can't find static symbols */
+/* since "static" is used to mean two completely different things in C, we
+   define "local" for the non-static meaning of "static", for readability
+   (compile with -Dlocal if your debugger can't find static symbols) */
 
 /* gz* functions always use library allocation functions */
 #ifndef STDC
@@ -170,7 +179,7 @@ typedef struct {
     char *path;             /* path or fd for error messages */
     unsigned size;          /* buffer size, zero if not allocated yet */
     unsigned want;          /* requested buffer size, default is GZBUFSIZE */
-    unsigned char *in;      /* input buffer */
+    unsigned char *in;      /* input buffer (double-sized when writing) */
     unsigned char *out;     /* output buffer (double-sized when reading) */
     int direct;             /* 0 if processing gzip, 1 if transparent */
         /* just for reading */

--- a/libs/zlib/src/gzlib.c
+++ b/libs/zlib/src/gzlib.c
@@ -1,11 +1,11 @@
 /* gzlib.c -- zlib functions common to reading and writing gzip files
- * Copyright (C) 2004, 2010, 2011, 2012, 2013 Mark Adler
+ * Copyright (C) 2004-2017 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
 #include "gzguts.h"
 
-#if defined(_WIN32) && !defined(__BORLANDC__)
+#if defined(_WIN32) && !defined(__BORLANDC__) && !defined(__MINGW32__)
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
@@ -73,562 +73,565 @@ char ZLIB_INTERNAL *gz_strwinerror (error)
 
 /* Reset gzip file state */
 local void gz_reset(state)
-gz_statep state;
+    gz_statep state;
 {
-	state->x.have = 0;              /* no output data available */
-	if (state->mode == GZ_READ) {   /* for reading ... */
-		state->eof = 0;             /* not at end of file */
-		state->past = 0;            /* have not read past end yet */
-		state->how = LOOK;          /* look for gzip header */
-	}
-	state->seek = 0;                /* no seek request pending */
-	gz_error(state, Z_OK, NULL);    /* clear error */
-	state->x.pos = 0;               /* no uncompressed data yet */
-	state->strm.avail_in = 0;       /* no input data yet */
+    state->x.have = 0;              /* no output data available */
+    if (state->mode == GZ_READ) {   /* for reading ... */
+        state->eof = 0;             /* not at end of file */
+        state->past = 0;            /* have not read past end yet */
+        state->how = LOOK;          /* look for gzip header */
+    }
+    state->seek = 0;                /* no seek request pending */
+    gz_error(state, Z_OK, NULL);    /* clear error */
+    state->x.pos = 0;               /* no uncompressed data yet */
+    state->strm.avail_in = 0;       /* no input data yet */
 }
 
 /* Open a gzip file either by name or file descriptor. */
 local gzFile gz_open(path, fd, mode)
-const void *path;
-int fd;
-const char *mode;
+    const void *path;
+    int fd;
+    const char *mode;
 {
-	gz_statep state;
-	size_t len;
-	int oflag;
-	#ifdef O_CLOEXEC
-	int cloexec = 0;
-	#endif
-	#ifdef O_EXCL
-	int exclusive = 0;
-	#endif
+    gz_statep state;
+    z_size_t len;
+    int oflag;
+#ifdef O_CLOEXEC
+    int cloexec = 0;
+#endif
+#ifdef O_EXCL
+    int exclusive = 0;
+#endif
 
-	/* check input */
-	if (path == NULL)
-		return NULL;
+    /* check input */
+    if (path == NULL)
+        return NULL;
 
-	/* allocate gzFile structure to return */
-	state = (gz_statep)malloc(sizeof(gz_state));
-	if (state == NULL)
-		return NULL;
-	state->size = 0;            /* no buffers allocated yet */
-	state->want = GZBUFSIZE;    /* requested buffer size */
-	state->msg = NULL;          /* no error message yet */
+    /* allocate gzFile structure to return */
+    state = (gz_statep)malloc(sizeof(gz_state));
+    if (state == NULL)
+        return NULL;
+    state->size = 0;            /* no buffers allocated yet */
+    state->want = GZBUFSIZE;    /* requested buffer size */
+    state->msg = NULL;          /* no error message yet */
 
-	/* interpret mode */
-	state->mode = GZ_NONE;
-	state->level = Z_DEFAULT_COMPRESSION;
-	state->strategy = Z_DEFAULT_STRATEGY;
-	state->direct = 0;
-	while (*mode) {
-		if (*mode >= '0' && *mode <= '9')
-			state->level = *mode - '0';
-		else
-			switch (*mode) {
-			case 'r':
-				state->mode = GZ_READ;
-				break;
-				#ifndef NO_GZCOMPRESS
-			case 'w':
-				state->mode = GZ_WRITE;
-				break;
-			case 'a':
-				state->mode = GZ_APPEND;
-				break;
-				#endif
-			case '+':       /* can't read and write at the same time */
-				free(state);
-				return NULL;
-			case 'b':       /* ignore -- will request binary anyway */
-				break;
-				#ifdef O_CLOEXEC
-			case 'e':
-				cloexec = 1;
-				break;
-				#endif
-				#ifdef O_EXCL
-			case 'x':
-				exclusive = 1;
-				break;
-				#endif
-			case 'f':
-				state->strategy = Z_FILTERED;
-				break;
-			case 'h':
-				state->strategy = Z_HUFFMAN_ONLY;
-				break;
-			case 'R':
-				state->strategy = Z_RLE;
-				break;
-			case 'F':
-				state->strategy = Z_FIXED;
-				break;
-			case 'T':
-				state->direct = 1;
-				break;
-			default:        /* could consider as an error, but just ignore */
-				;
-			}
-		mode++;
-	}
+    /* interpret mode */
+    state->mode = GZ_NONE;
+    state->level = Z_DEFAULT_COMPRESSION;
+    state->strategy = Z_DEFAULT_STRATEGY;
+    state->direct = 0;
+    while (*mode) {
+        if (*mode >= '0' && *mode <= '9')
+            state->level = *mode - '0';
+        else
+            switch (*mode) {
+            case 'r':
+                state->mode = GZ_READ;
+                break;
+#ifndef NO_GZCOMPRESS
+            case 'w':
+                state->mode = GZ_WRITE;
+                break;
+            case 'a':
+                state->mode = GZ_APPEND;
+                break;
+#endif
+            case '+':       /* can't read and write at the same time */
+                free(state);
+                return NULL;
+            case 'b':       /* ignore -- will request binary anyway */
+                break;
+#ifdef O_CLOEXEC
+            case 'e':
+                cloexec = 1;
+                break;
+#endif
+#ifdef O_EXCL
+            case 'x':
+                exclusive = 1;
+                break;
+#endif
+            case 'f':
+                state->strategy = Z_FILTERED;
+                break;
+            case 'h':
+                state->strategy = Z_HUFFMAN_ONLY;
+                break;
+            case 'R':
+                state->strategy = Z_RLE;
+                break;
+            case 'F':
+                state->strategy = Z_FIXED;
+                break;
+            case 'T':
+                state->direct = 1;
+                break;
+            default:        /* could consider as an error, but just ignore */
+                ;
+            }
+        mode++;
+    }
 
-	/* must provide an "r", "w", or "a" */
-	if (state->mode == GZ_NONE) {
-		free(state);
-		return NULL;
-	}
+    /* must provide an "r", "w", or "a" */
+    if (state->mode == GZ_NONE) {
+        free(state);
+        return NULL;
+    }
 
-	/* can't force transparent read */
-	if (state->mode == GZ_READ) {
-		if (state->direct) {
-			free(state);
-			return NULL;
-		}
-		state->direct = 1;      /* for empty file */
-	}
+    /* can't force transparent read */
+    if (state->mode == GZ_READ) {
+        if (state->direct) {
+            free(state);
+            return NULL;
+        }
+        state->direct = 1;      /* for empty file */
+    }
 
-	/* save the path name for error messages */
-	#ifdef _WIN32
-	if (fd == -2) {
-		len = wcstombs(NULL, path, 0);
-		if (len == (size_t)-1)
-			len = 0;
-	}
-	else
-		#endif
-		len = strlen((const char *)path);
-	state->path = (char *)malloc(len + 1);
-	if (state->path == NULL) {
-		free(state);
-		return NULL;
-	}
-	#ifdef _WIN32
-	if (fd == -2)
-		if (len)
-			wcstombs(state->path, path, len + 1);
-		else
-			*(state->path) = 0;
-	else
-		#endif
-		#if !defined(NO_snprintf) && !defined(NO_vsnprintf)
-		snprintf(state->path, len + 1, "%s", (const char *)path);
-	#else
-		strcpy(state->path, path);
-	#endif
+    /* save the path name for error messages */
+#ifdef WIDECHAR
+    if (fd == -2) {
+        len = wcstombs(NULL, path, 0);
+        if (len == (z_size_t)-1)
+            len = 0;
+    }
+    else
+#endif
+        len = strlen((const char *)path);
+    state->path = (char *)malloc(len + 1);
+    if (state->path == NULL) {
+        free(state);
+        return NULL;
+    }
+#ifdef WIDECHAR
+    if (fd == -2)
+        if (len)
+            wcstombs(state->path, path, len + 1);
+        else
+            *(state->path) = 0;
+    else
+#endif
+#if !defined(NO_snprintf) && !defined(NO_vsnprintf)
+        (void)snprintf(state->path, len + 1, "%s", (const char *)path);
+#else
+        strcpy(state->path, path);
+#endif
 
-	/* compute the flags for open() */
-	oflag =
-		#ifdef O_LARGEFILE
-		O_LARGEFILE |
-		#endif
-		#ifdef O_BINARY
-		O_BINARY |
-		#endif
-		#ifdef O_CLOEXEC
-		(cloexec ? O_CLOEXEC : 0) |
-		#endif
-		(state->mode == GZ_READ ?
-			O_RDONLY :
-			(O_WRONLY | O_CREAT |
-				#ifdef O_EXCL
-				(exclusive ? O_EXCL : 0) |
-				#endif
-				(state->mode == GZ_WRITE ?
-					O_TRUNC :
-					O_APPEND)));
+    /* compute the flags for open() */
+    oflag =
+#ifdef O_LARGEFILE
+        O_LARGEFILE |
+#endif
+#ifdef O_BINARY
+        O_BINARY |
+#endif
+#ifdef O_CLOEXEC
+        (cloexec ? O_CLOEXEC : 0) |
+#endif
+        (state->mode == GZ_READ ?
+         O_RDONLY :
+         (O_WRONLY | O_CREAT |
+#ifdef O_EXCL
+          (exclusive ? O_EXCL : 0) |
+#endif
+          (state->mode == GZ_WRITE ?
+           O_TRUNC :
+           O_APPEND)));
 
-	/* open the file with the appropriate flags (or just use fd) */
-	state->fd = fd > -1 ? fd : (
-		#ifdef _WIN32
-		fd == -2 ? _wopen(path, oflag, 0666) :
-		#endif
-		open((const char *)path, oflag, 0666));
-	if (state->fd == -1) {
-		free(state->path);
-		free(state);
-		return NULL;
-	}
-	if (state->mode == GZ_APPEND)
-		state->mode = GZ_WRITE;         /* simplify later checks */
+    /* open the file with the appropriate flags (or just use fd) */
+    state->fd = fd > -1 ? fd : (
+#ifdef WIDECHAR
+        fd == -2 ? _wopen(path, oflag, 0666) :
+#endif
+        open((const char *)path, oflag, 0666));
+    if (state->fd == -1) {
+        free(state->path);
+        free(state);
+        return NULL;
+    }
+    if (state->mode == GZ_APPEND) {
+        LSEEK(state->fd, 0, SEEK_END);  /* so gzoffset() is correct */
+        state->mode = GZ_WRITE;         /* simplify later checks */
+    }
 
-  /* save the current position for rewinding (only if reading) */
-	if (state->mode == GZ_READ) {
-		state->start = LSEEK(state->fd, 0, SEEK_CUR);
-		if (state->start == -1) state->start = 0;
-	}
+    /* save the current position for rewinding (only if reading) */
+    if (state->mode == GZ_READ) {
+        state->start = LSEEK(state->fd, 0, SEEK_CUR);
+        if (state->start == -1) state->start = 0;
+    }
 
-	/* initialize stream */
-	gz_reset(state);
+    /* initialize stream */
+    gz_reset(state);
 
-	/* return stream */
-	return (gzFile)state;
+    /* return stream */
+    return (gzFile)state;
 }
 
 /* -- see zlib.h -- */
 gzFile ZEXPORT gzopen(path, mode)
-const char *path;
-const char *mode;
+    const char *path;
+    const char *mode;
 {
-	return gz_open(path, -1, mode);
+    return gz_open(path, -1, mode);
 }
 
 /* -- see zlib.h -- */
 gzFile ZEXPORT gzopen64(path, mode)
-const char *path;
-const char *mode;
+    const char *path;
+    const char *mode;
 {
-	return gz_open(path, -1, mode);
+    return gz_open(path, -1, mode);
 }
 
 /* -- see zlib.h -- */
 gzFile ZEXPORT gzdopen(fd, mode)
-int fd;
-const char *mode;
+    int fd;
+    const char *mode;
 {
-	char *path;         /* identifier for error messages */
-	gzFile gz;
+    char *path;         /* identifier for error messages */
+    gzFile gz;
 
-	if (fd == -1 || (path = (char *)malloc(7 + 3 * sizeof(int))) == NULL)
-		return NULL;
-	#if !defined(NO_snprintf) && !defined(NO_vsnprintf)
-	snprintf(path, 7 + 3 * sizeof(int), "<fd:%d>", fd); /* for debugging */
-	#else
-	sprintf(path, "<fd:%d>", fd);   /* for debugging */
-	#endif
-	gz = gz_open(path, fd, mode);
-	free(path);
-	return gz;
+    if (fd == -1 || (path = (char *)malloc(7 + 3 * sizeof(int))) == NULL)
+        return NULL;
+#if !defined(NO_snprintf) && !defined(NO_vsnprintf)
+    (void)snprintf(path, 7 + 3 * sizeof(int), "<fd:%d>", fd);
+#else
+    sprintf(path, "<fd:%d>", fd);   /* for debugging */
+#endif
+    gz = gz_open(path, fd, mode);
+    free(path);
+    return gz;
 }
 
 /* -- see zlib.h -- */
-#ifdef _WIN32
+#ifdef WIDECHAR
 gzFile ZEXPORT gzopen_w(path, mode)
-const wchar_t *path;
-const char *mode;
+    const wchar_t *path;
+    const char *mode;
 {
-	return gz_open(path, -2, mode);
+    return gz_open(path, -2, mode);
 }
 #endif
 
 /* -- see zlib.h -- */
 int ZEXPORT gzbuffer(file, size)
-gzFile file;
-unsigned size;
+    gzFile file;
+    unsigned size;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure and check integrity */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	if (state->mode != GZ_READ && state->mode != GZ_WRITE)
-		return -1;
+    /* get internal structure and check integrity */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
+    if (state->mode != GZ_READ && state->mode != GZ_WRITE)
+        return -1;
 
-	/* make sure we haven't already allocated memory */
-	if (state->size != 0)
-		return -1;
+    /* make sure we haven't already allocated memory */
+    if (state->size != 0)
+        return -1;
 
-	/* check and set requested size */
-	if (size < 2)
-		size = 2;               /* need two bytes to check magic header */
-	state->want = size;
-	return 0;
+    /* check and set requested size */
+    if ((size << 1) < size)
+        return -1;              /* need to be able to double it */
+    if (size < 2)
+        size = 2;               /* need two bytes to check magic header */
+    state->want = size;
+    return 0;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzrewind(file)
-gzFile file;
+    gzFile file;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
+    /* get internal structure */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
 
-	/* check that we're reading and that there's no error */
-	if (state->mode != GZ_READ ||
-		(state->err != Z_OK && state->err != Z_BUF_ERROR))
-		return -1;
+    /* check that we're reading and that there's no error */
+    if (state->mode != GZ_READ ||
+            (state->err != Z_OK && state->err != Z_BUF_ERROR))
+        return -1;
 
-	/* back up and start over */
-	if (LSEEK(state->fd, state->start, SEEK_SET) == -1)
-		return -1;
-	gz_reset(state);
-	return 0;
+    /* back up and start over */
+    if (LSEEK(state->fd, state->start, SEEK_SET) == -1)
+        return -1;
+    gz_reset(state);
+    return 0;
 }
 
 /* -- see zlib.h -- */
 z_off64_t ZEXPORT gzseek64(file, offset, whence)
-gzFile file;
-z_off64_t offset;
-int whence;
+    gzFile file;
+    z_off64_t offset;
+    int whence;
 {
-	unsigned n;
-	z_off64_t ret;
-	gz_statep state;
+    unsigned n;
+    z_off64_t ret;
+    gz_statep state;
 
-	/* get internal structure and check integrity */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	if (state->mode != GZ_READ && state->mode != GZ_WRITE)
-		return -1;
+    /* get internal structure and check integrity */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
+    if (state->mode != GZ_READ && state->mode != GZ_WRITE)
+        return -1;
 
-	/* check that there's no error */
-	if (state->err != Z_OK && state->err != Z_BUF_ERROR)
-		return -1;
+    /* check that there's no error */
+    if (state->err != Z_OK && state->err != Z_BUF_ERROR)
+        return -1;
 
-	/* can only seek from start or relative to current position */
-	if (whence != SEEK_SET && whence != SEEK_CUR)
-		return -1;
+    /* can only seek from start or relative to current position */
+    if (whence != SEEK_SET && whence != SEEK_CUR)
+        return -1;
 
-	/* normalize offset to a SEEK_CUR specification */
-	if (whence == SEEK_SET)
-		offset -= state->x.pos;
-	else if (state->seek)
-		offset += state->skip;
-	state->seek = 0;
+    /* normalize offset to a SEEK_CUR specification */
+    if (whence == SEEK_SET)
+        offset -= state->x.pos;
+    else if (state->seek)
+        offset += state->skip;
+    state->seek = 0;
 
-	/* if within raw area while reading, just go there */
-	if (state->mode == GZ_READ && state->how == COPY &&
-		state->x.pos + offset >= 0) {
-		ret = LSEEK(state->fd, offset - state->x.have, SEEK_CUR);
-		if (ret == -1)
-			return -1;
-		state->x.have = 0;
-		state->eof = 0;
-		state->past = 0;
-		state->seek = 0;
-		gz_error(state, Z_OK, NULL);
-		state->strm.avail_in = 0;
-		state->x.pos += offset;
-		return state->x.pos;
-	}
+    /* if within raw area while reading, just go there */
+    if (state->mode == GZ_READ && state->how == COPY &&
+            state->x.pos + offset >= 0) {
+        ret = LSEEK(state->fd, offset - state->x.have, SEEK_CUR);
+        if (ret == -1)
+            return -1;
+        state->x.have = 0;
+        state->eof = 0;
+        state->past = 0;
+        state->seek = 0;
+        gz_error(state, Z_OK, NULL);
+        state->strm.avail_in = 0;
+        state->x.pos += offset;
+        return state->x.pos;
+    }
 
-	/* calculate skip amount, rewinding if needed for back seek when reading */
-	if (offset < 0) {
-		if (state->mode != GZ_READ)         /* writing -- can't go backwards */
-			return -1;
-		offset += state->x.pos;
-		if (offset < 0)                     /* before start of file! */
-			return -1;
-		if (gzrewind(file) == -1)           /* rewind, then skip to offset */
-			return -1;
-	}
+    /* calculate skip amount, rewinding if needed for back seek when reading */
+    if (offset < 0) {
+        if (state->mode != GZ_READ)         /* writing -- can't go backwards */
+            return -1;
+        offset += state->x.pos;
+        if (offset < 0)                     /* before start of file! */
+            return -1;
+        if (gzrewind(file) == -1)           /* rewind, then skip to offset */
+            return -1;
+    }
 
-	/* if reading, skip what's in output buffer (one less gzgetc() check) */
-	if (state->mode == GZ_READ) {
-		n = GT_OFF(state->x.have) || (z_off64_t)state->x.have > offset ?
-			(unsigned)offset : state->x.have;
-		state->x.have -= n;
-		state->x.next += n;
-		state->x.pos += n;
-		offset -= n;
-	}
+    /* if reading, skip what's in output buffer (one less gzgetc() check) */
+    if (state->mode == GZ_READ) {
+        n = GT_OFF(state->x.have) || (z_off64_t)state->x.have > offset ?
+            (unsigned)offset : state->x.have;
+        state->x.have -= n;
+        state->x.next += n;
+        state->x.pos += n;
+        offset -= n;
+    }
 
-	/* request skip (if not zero) */
-	if (offset) {
-		state->seek = 1;
-		state->skip = offset;
-	}
-	return state->x.pos + offset;
+    /* request skip (if not zero) */
+    if (offset) {
+        state->seek = 1;
+        state->skip = offset;
+    }
+    return state->x.pos + offset;
 }
 
 /* -- see zlib.h -- */
 z_off_t ZEXPORT gzseek(file, offset, whence)
-gzFile file;
-z_off_t offset;
-int whence;
+    gzFile file;
+    z_off_t offset;
+    int whence;
 {
-	z_off64_t ret;
+    z_off64_t ret;
 
-	ret = gzseek64(file, (z_off64_t)offset, whence);
-	return ret == (z_off_t)ret ? (z_off_t)ret : -1;
+    ret = gzseek64(file, (z_off64_t)offset, whence);
+    return ret == (z_off_t)ret ? (z_off_t)ret : -1;
 }
 
 /* -- see zlib.h -- */
 z_off64_t ZEXPORT gztell64(file)
-gzFile file;
+    gzFile file;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure and check integrity */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	if (state->mode != GZ_READ && state->mode != GZ_WRITE)
-		return -1;
+    /* get internal structure and check integrity */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
+    if (state->mode != GZ_READ && state->mode != GZ_WRITE)
+        return -1;
 
-	/* return position */
-	return state->x.pos + (state->seek ? state->skip : 0);
+    /* return position */
+    return state->x.pos + (state->seek ? state->skip : 0);
 }
 
 /* -- see zlib.h -- */
 z_off_t ZEXPORT gztell(file)
-gzFile file;
+    gzFile file;
 {
-	z_off64_t ret;
+    z_off64_t ret;
 
-	ret = gztell64(file);
-	return ret == (z_off_t)ret ? (z_off_t)ret : -1;
+    ret = gztell64(file);
+    return ret == (z_off_t)ret ? (z_off_t)ret : -1;
 }
 
 /* -- see zlib.h -- */
 z_off64_t ZEXPORT gzoffset64(file)
-gzFile file;
+    gzFile file;
 {
-	z_off64_t offset;
-	gz_statep state;
+    z_off64_t offset;
+    gz_statep state;
 
-	/* get internal structure and check integrity */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	if (state->mode != GZ_READ && state->mode != GZ_WRITE)
-		return -1;
+    /* get internal structure and check integrity */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
+    if (state->mode != GZ_READ && state->mode != GZ_WRITE)
+        return -1;
 
-	/* compute and return effective offset in file */
-	offset = LSEEK(state->fd, 0, SEEK_CUR);
-	if (offset == -1)
-		return -1;
-	if (state->mode == GZ_READ)             /* reading */
-		offset -= state->strm.avail_in;     /* don't count buffered input */
-	return offset;
+    /* compute and return effective offset in file */
+    offset = LSEEK(state->fd, 0, SEEK_CUR);
+    if (offset == -1)
+        return -1;
+    if (state->mode == GZ_READ)             /* reading */
+        offset -= state->strm.avail_in;     /* don't count buffered input */
+    return offset;
 }
 
 /* -- see zlib.h -- */
 z_off_t ZEXPORT gzoffset(file)
-gzFile file;
+    gzFile file;
 {
-	z_off64_t ret;
+    z_off64_t ret;
 
-	ret = gzoffset64(file);
-	return ret == (z_off_t)ret ? (z_off_t)ret : -1;
+    ret = gzoffset64(file);
+    return ret == (z_off_t)ret ? (z_off_t)ret : -1;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzeof(file)
-gzFile file;
+    gzFile file;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure and check integrity */
-	if (file == NULL)
-		return 0;
-	state = (gz_statep)file;
-	if (state->mode != GZ_READ && state->mode != GZ_WRITE)
-		return 0;
+    /* get internal structure and check integrity */
+    if (file == NULL)
+        return 0;
+    state = (gz_statep)file;
+    if (state->mode != GZ_READ && state->mode != GZ_WRITE)
+        return 0;
 
-	/* return end-of-file state */
-	return state->mode == GZ_READ ? state->past : 0;
+    /* return end-of-file state */
+    return state->mode == GZ_READ ? state->past : 0;
 }
 
 /* -- see zlib.h -- */
 const char * ZEXPORT gzerror(file, errnum)
-gzFile file;
-int *errnum;
+    gzFile file;
+    int *errnum;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure and check integrity */
-	if (file == NULL)
-		return NULL;
-	state = (gz_statep)file;
-	if (state->mode != GZ_READ && state->mode != GZ_WRITE)
-		return NULL;
+    /* get internal structure and check integrity */
+    if (file == NULL)
+        return NULL;
+    state = (gz_statep)file;
+    if (state->mode != GZ_READ && state->mode != GZ_WRITE)
+        return NULL;
 
-	/* return error information */
-	if (errnum != NULL)
-		*errnum = state->err;
-	return state->err == Z_MEM_ERROR ? "out of memory" :
-		(state->msg == NULL ? "" : state->msg);
+    /* return error information */
+    if (errnum != NULL)
+        *errnum = state->err;
+    return state->err == Z_MEM_ERROR ? "out of memory" :
+                                       (state->msg == NULL ? "" : state->msg);
 }
 
 /* -- see zlib.h -- */
 void ZEXPORT gzclearerr(file)
-gzFile file;
+    gzFile file;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure and check integrity */
-	if (file == NULL)
-		return;
-	state = (gz_statep)file;
-	if (state->mode != GZ_READ && state->mode != GZ_WRITE)
-		return;
+    /* get internal structure and check integrity */
+    if (file == NULL)
+        return;
+    state = (gz_statep)file;
+    if (state->mode != GZ_READ && state->mode != GZ_WRITE)
+        return;
 
-	/* clear error and end-of-file */
-	if (state->mode == GZ_READ) {
-		state->eof = 0;
-		state->past = 0;
-	}
-	gz_error(state, Z_OK, NULL);
+    /* clear error and end-of-file */
+    if (state->mode == GZ_READ) {
+        state->eof = 0;
+        state->past = 0;
+    }
+    gz_error(state, Z_OK, NULL);
 }
 
 /* Create an error message in allocated memory and set state->err and
-	state->msg accordingly.  Free any previous error message already there.  Do
-	not try to free or allocate space if the error is Z_MEM_ERROR (out of
-	memory).  Simply save the error message as a static string.  If there is an
-	allocation failure constructing the error message, then convert the error to
-	out of memory. */
+   state->msg accordingly.  Free any previous error message already there.  Do
+   not try to free or allocate space if the error is Z_MEM_ERROR (out of
+   memory).  Simply save the error message as a static string.  If there is an
+   allocation failure constructing the error message, then convert the error to
+   out of memory. */
 void ZLIB_INTERNAL gz_error(state, err, msg)
-gz_statep state;
-int err;
-const char *msg;
+    gz_statep state;
+    int err;
+    const char *msg;
 {
-	/* free previously allocated message and clear */
-	if (state->msg != NULL) {
-		if (state->err != Z_MEM_ERROR)
-			free(state->msg);
-		state->msg = NULL;
-	}
+    /* free previously allocated message and clear */
+    if (state->msg != NULL) {
+        if (state->err != Z_MEM_ERROR)
+            free(state->msg);
+        state->msg = NULL;
+    }
 
-	/* if fatal, set state->x.have to 0 so that the gzgetc() macro fails */
-	if (err != Z_OK && err != Z_BUF_ERROR)
-		state->x.have = 0;
+    /* if fatal, set state->x.have to 0 so that the gzgetc() macro fails */
+    if (err != Z_OK && err != Z_BUF_ERROR)
+        state->x.have = 0;
 
-	/* set error code, and if no message, then done */
-	state->err = err;
-	if (msg == NULL)
-		return;
+    /* set error code, and if no message, then done */
+    state->err = err;
+    if (msg == NULL)
+        return;
 
-	/* for an out of memory error, return literal string when requested */
-	if (err == Z_MEM_ERROR)
-		return;
+    /* for an out of memory error, return literal string when requested */
+    if (err == Z_MEM_ERROR)
+        return;
 
-	/* construct error message with path */
-	if ((state->msg = (char *)malloc(strlen(state->path) + strlen(msg) + 3)) ==
-		NULL) {
-		state->err = Z_MEM_ERROR;
-		return;
-	}
-	#if !defined(NO_snprintf) && !defined(NO_vsnprintf)
-	snprintf(state->msg, strlen(state->path) + strlen(msg) + 3,
-		"%s%s%s", state->path, ": ", msg);
-	#else
-	strcpy(state->msg, state->path);
-	strcat(state->msg, ": ");
-	strcat(state->msg, msg);
-	#endif
-	return;
+    /* construct error message with path */
+    if ((state->msg = (char *)malloc(strlen(state->path) + strlen(msg) + 3)) ==
+            NULL) {
+        state->err = Z_MEM_ERROR;
+        return;
+    }
+#if !defined(NO_snprintf) && !defined(NO_vsnprintf)
+    (void)snprintf(state->msg, strlen(state->path) + strlen(msg) + 3,
+                   "%s%s%s", state->path, ": ", msg);
+#else
+    strcpy(state->msg, state->path);
+    strcat(state->msg, ": ");
+    strcat(state->msg, msg);
+#endif
 }
 
 #ifndef INT_MAX
 /* portably return maximum value for an int (when limits.h presumed not
-	available) -- we need to do this to cover cases where 2's complement not
-	used, since C standard permits 1's complement and sign-bit representations,
-	otherwise we could just use ((unsigned)-1) >> 1 */
+   available) -- we need to do this to cover cases where 2's complement not
+   used, since C standard permits 1's complement and sign-bit representations,
+   otherwise we could just use ((unsigned)-1) >> 1 */
 unsigned ZLIB_INTERNAL gz_intmax()
 {
-	unsigned p, q;
+    unsigned p, q;
 
-	p = 1;
-	do {
-		q = p;
-		p <<= 1;
-		p++;
-	} while (p > q);
-	return q >> 1;
+    p = 1;
+    do {
+        q = p;
+        p <<= 1;
+        p++;
+    } while (p > q);
+    return q >> 1;
 }
 #endif

--- a/libs/zlib/src/gzread.c
+++ b/libs/zlib/src/gzread.c
@@ -1,381 +1,441 @@
 /* gzread.c -- zlib functions for reading gzip files
- * Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013 Mark Adler
+ * Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013, 2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
 #include "gzguts.h"
 
- /* Local functions */
+/* Local functions */
 local int gz_load OF((gz_statep, unsigned char *, unsigned, unsigned *));
 local int gz_avail OF((gz_statep));
 local int gz_look OF((gz_statep));
 local int gz_decomp OF((gz_statep));
 local int gz_fetch OF((gz_statep));
 local int gz_skip OF((gz_statep, z_off64_t));
+local z_size_t gz_read OF((gz_statep, voidp, z_size_t));
 
 /* Use read() to load a buffer -- return -1 on error, otherwise 0.  Read from
-	state->fd, and update state->eof, state->err, and state->msg as appropriate.
-	This function needs to loop on read(), since read() is not guaranteed to
-	read the number of bytes requested, depending on the type of descriptor. */
+   state->fd, and update state->eof, state->err, and state->msg as appropriate.
+   This function needs to loop on read(), since read() is not guaranteed to
+   read the number of bytes requested, depending on the type of descriptor. */
 local int gz_load(state, buf, len, have)
-gz_statep state;
-unsigned char *buf;
-unsigned len;
-unsigned *have;
+    gz_statep state;
+    unsigned char *buf;
+    unsigned len;
+    unsigned *have;
 {
-	int ret;
+    int ret;
+    unsigned get, max = ((unsigned)-1 >> 2) + 1;
 
-	*have = 0;
-	do {
-		ret = read(state->fd, buf + *have, len - *have);
-		if (ret <= 0)
-			break;
-		*have += ret;
-	} while (*have < len);
-	if (ret < 0) {
-		gz_error(state, Z_ERRNO, zstrerror());
-		return -1;
-	}
-	if (ret == 0)
-		state->eof = 1;
-	return 0;
+    *have = 0;
+    do {
+        get = len - *have;
+        if (get > max)
+            get = max;
+        ret = read(state->fd, buf + *have, get);
+        if (ret <= 0)
+            break;
+        *have += (unsigned)ret;
+    } while (*have < len);
+    if (ret < 0) {
+        gz_error(state, Z_ERRNO, zstrerror());
+        return -1;
+    }
+    if (ret == 0)
+        state->eof = 1;
+    return 0;
 }
 
 /* Load up input buffer and set eof flag if last data loaded -- return -1 on
-	error, 0 otherwise.  Note that the eof flag is set when the end of the input
-	file is reached, even though there may be unused data in the buffer.  Once
-	that data has been used, no more attempts will be made to read the file.
-	If strm->avail_in != 0, then the current data is moved to the beginning of
-	the input buffer, and then the remainder of the buffer is loaded with the
-	available data from the input file. */
+   error, 0 otherwise.  Note that the eof flag is set when the end of the input
+   file is reached, even though there may be unused data in the buffer.  Once
+   that data has been used, no more attempts will be made to read the file.
+   If strm->avail_in != 0, then the current data is moved to the beginning of
+   the input buffer, and then the remainder of the buffer is loaded with the
+   available data from the input file. */
 local int gz_avail(state)
-gz_statep state;
+    gz_statep state;
 {
-	unsigned got;
-	z_streamp strm = &(state->strm);
+    unsigned got;
+    z_streamp strm = &(state->strm);
 
-	if (state->err != Z_OK && state->err != Z_BUF_ERROR)
-		return -1;
-	if (state->eof == 0) {
-		if (strm->avail_in) {       /* copy what's there to the start */
-			unsigned char *p = state->in;
-			unsigned const char *q = strm->next_in;
-			unsigned n = strm->avail_in;
-			do {
-				*p++ = *q++;
-			} while (--n);
-		}
-		if (gz_load(state, state->in + strm->avail_in,
-			state->size - strm->avail_in, &got) == -1)
-			return -1;
-		strm->avail_in += got;
-		strm->next_in = state->in;
-	}
-	return 0;
+    if (state->err != Z_OK && state->err != Z_BUF_ERROR)
+        return -1;
+    if (state->eof == 0) {
+        if (strm->avail_in) {       /* copy what's there to the start */
+            unsigned char *p = state->in;
+            unsigned const char *q = strm->next_in;
+            unsigned n = strm->avail_in;
+            do {
+                *p++ = *q++;
+            } while (--n);
+        }
+        if (gz_load(state, state->in + strm->avail_in,
+                    state->size - strm->avail_in, &got) == -1)
+            return -1;
+        strm->avail_in += got;
+        strm->next_in = state->in;
+    }
+    return 0;
 }
 
 /* Look for gzip header, set up for inflate or copy.  state->x.have must be 0.
-	If this is the first time in, allocate required memory.  state->how will be
-	left unchanged if there is no more input data available, will be set to COPY
-	if there is no gzip header and direct copying will be performed, or it will
-	be set to GZIP for decompression.  If direct copying, then leftover input
-	data from the input buffer will be copied to the output buffer.  In that
-	case, all further file reads will be directly to either the output buffer or
-	a user buffer.  If decompressing, the inflate state will be initialized.
-	gz_look() will return 0 on success or -1 on failure. */
+   If this is the first time in, allocate required memory.  state->how will be
+   left unchanged if there is no more input data available, will be set to COPY
+   if there is no gzip header and direct copying will be performed, or it will
+   be set to GZIP for decompression.  If direct copying, then leftover input
+   data from the input buffer will be copied to the output buffer.  In that
+   case, all further file reads will be directly to either the output buffer or
+   a user buffer.  If decompressing, the inflate state will be initialized.
+   gz_look() will return 0 on success or -1 on failure. */
 local int gz_look(state)
-gz_statep state;
+    gz_statep state;
 {
-	z_streamp strm = &(state->strm);
+    z_streamp strm = &(state->strm);
 
-	/* allocate read buffers and inflate memory */
-	if (state->size == 0) {
-		/* allocate buffers */
-		state->in = (unsigned char *)malloc(state->want);
-		state->out = (unsigned char *)malloc(state->want << 1);
-		if (state->in == NULL || state->out == NULL) {
-			if (state->out != NULL)
-				free(state->out);
-			if (state->in != NULL)
-				free(state->in);
-			gz_error(state, Z_MEM_ERROR, "out of memory");
-			return -1;
-		}
-		state->size = state->want;
+    /* allocate read buffers and inflate memory */
+    if (state->size == 0) {
+        /* allocate buffers */
+        state->in = (unsigned char *)malloc(state->want);
+        state->out = (unsigned char *)malloc(state->want << 1);
+        if (state->in == NULL || state->out == NULL) {
+            free(state->out);
+            free(state->in);
+            gz_error(state, Z_MEM_ERROR, "out of memory");
+            return -1;
+        }
+        state->size = state->want;
 
-		/* allocate inflate memory */
-		state->strm.zalloc = Z_NULL;
-		state->strm.zfree = Z_NULL;
-		state->strm.opaque = Z_NULL;
-		state->strm.avail_in = 0;
-		state->strm.next_in = Z_NULL;
-		if (inflateInit2(&(state->strm), 15 + 16) != Z_OK) {    /* gunzip */
-			free(state->out);
-			free(state->in);
-			state->size = 0;
-			gz_error(state, Z_MEM_ERROR, "out of memory");
-			return -1;
-		}
-	}
+        /* allocate inflate memory */
+        state->strm.zalloc = Z_NULL;
+        state->strm.zfree = Z_NULL;
+        state->strm.opaque = Z_NULL;
+        state->strm.avail_in = 0;
+        state->strm.next_in = Z_NULL;
+        if (inflateInit2(&(state->strm), 15 + 16) != Z_OK) {    /* gunzip */
+            free(state->out);
+            free(state->in);
+            state->size = 0;
+            gz_error(state, Z_MEM_ERROR, "out of memory");
+            return -1;
+        }
+    }
 
-	/* get at least the magic bytes in the input buffer */
-	if (strm->avail_in < 2) {
-		if (gz_avail(state) == -1)
-			return -1;
-		if (strm->avail_in == 0)
-			return 0;
-	}
+    /* get at least the magic bytes in the input buffer */
+    if (strm->avail_in < 2) {
+        if (gz_avail(state) == -1)
+            return -1;
+        if (strm->avail_in == 0)
+            return 0;
+    }
 
-	/* look for gzip magic bytes -- if there, do gzip decoding (note: there is
-		a logical dilemma here when considering the case of a partially written
-		gzip file, to wit, if a single 31 byte is written, then we cannot tell
-		whether this is a single-byte file, or just a partially written gzip
-		file -- for here we assume that if a gzip file is being written, then
-		the header will be written in a single operation, so that reading a
-		single byte is sufficient indication that it is not a gzip file) */
-	if (strm->avail_in > 1 &&
-		strm->next_in[0] == 31 && strm->next_in[1] == 139) {
-		inflateReset(strm);
-		state->how = GZIP;
-		state->direct = 0;
-		return 0;
-	}
+    /* look for gzip magic bytes -- if there, do gzip decoding (note: there is
+       a logical dilemma here when considering the case of a partially written
+       gzip file, to wit, if a single 31 byte is written, then we cannot tell
+       whether this is a single-byte file, or just a partially written gzip
+       file -- for here we assume that if a gzip file is being written, then
+       the header will be written in a single operation, so that reading a
+       single byte is sufficient indication that it is not a gzip file) */
+    if (strm->avail_in > 1 &&
+            strm->next_in[0] == 31 && strm->next_in[1] == 139) {
+        inflateReset(strm);
+        state->how = GZIP;
+        state->direct = 0;
+        return 0;
+    }
 
-	/* no gzip header -- if we were decoding gzip before, then this is trailing
-		garbage.  Ignore the trailing garbage and finish. */
-	if (state->direct == 0) {
-		strm->avail_in = 0;
-		state->eof = 1;
-		state->x.have = 0;
-		return 0;
-	}
+    /* no gzip header -- if we were decoding gzip before, then this is trailing
+       garbage.  Ignore the trailing garbage and finish. */
+    if (state->direct == 0) {
+        strm->avail_in = 0;
+        state->eof = 1;
+        state->x.have = 0;
+        return 0;
+    }
 
-	/* doing raw i/o, copy any leftover input to output -- this assumes that
-		the output buffer is larger than the input buffer, which also assures
-		space for gzungetc() */
-	state->x.next = state->out;
-	if (strm->avail_in) {
-		memcpy(state->x.next, strm->next_in, strm->avail_in);
-		state->x.have = strm->avail_in;
-		strm->avail_in = 0;
-	}
-	state->how = COPY;
-	state->direct = 1;
-	return 0;
+    /* doing raw i/o, copy any leftover input to output -- this assumes that
+       the output buffer is larger than the input buffer, which also assures
+       space for gzungetc() */
+    state->x.next = state->out;
+    if (strm->avail_in) {
+        memcpy(state->x.next, strm->next_in, strm->avail_in);
+        state->x.have = strm->avail_in;
+        strm->avail_in = 0;
+    }
+    state->how = COPY;
+    state->direct = 1;
+    return 0;
 }
 
 /* Decompress from input to the provided next_out and avail_out in the state.
-	On return, state->x.have and state->x.next point to the just decompressed
-	data.  If the gzip stream completes, state->how is reset to LOOK to look for
-	the next gzip stream or raw data, once state->x.have is depleted.  Returns 0
-	on success, -1 on failure. */
+   On return, state->x.have and state->x.next point to the just decompressed
+   data.  If the gzip stream completes, state->how is reset to LOOK to look for
+   the next gzip stream or raw data, once state->x.have is depleted.  Returns 0
+   on success, -1 on failure. */
 local int gz_decomp(state)
-gz_statep state;
+    gz_statep state;
 {
-	int ret = Z_OK;
-	unsigned had;
-	z_streamp strm = &(state->strm);
+    int ret = Z_OK;
+    unsigned had;
+    z_streamp strm = &(state->strm);
 
-	/* fill output buffer up to end of deflate stream */
-	had = strm->avail_out;
-	do {
-		/* get more input for inflate() */
-		if (strm->avail_in == 0 && gz_avail(state) == -1)
-			return -1;
-		if (strm->avail_in == 0) {
-			gz_error(state, Z_BUF_ERROR, "unexpected end of file");
-			break;
-		}
+    /* fill output buffer up to end of deflate stream */
+    had = strm->avail_out;
+    do {
+        /* get more input for inflate() */
+        if (strm->avail_in == 0 && gz_avail(state) == -1)
+            return -1;
+        if (strm->avail_in == 0) {
+            gz_error(state, Z_BUF_ERROR, "unexpected end of file");
+            break;
+        }
 
-		/* decompress and handle errors */
-		ret = inflate(strm, Z_NO_FLUSH);
-		if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT) {
-			gz_error(state, Z_STREAM_ERROR,
-				"internal error: inflate stream corrupt");
-			return -1;
-		}
-		if (ret == Z_MEM_ERROR) {
-			gz_error(state, Z_MEM_ERROR, "out of memory");
-			return -1;
-		}
-		if (ret == Z_DATA_ERROR) {              /* deflate stream invalid */
-			gz_error(state, Z_DATA_ERROR,
-				strm->msg == NULL ? "compressed data error" : strm->msg);
-			return -1;
-		}
-	} while (strm->avail_out && ret != Z_STREAM_END);
+        /* decompress and handle errors */
+        ret = inflate(strm, Z_NO_FLUSH);
+        if (ret == Z_STREAM_ERROR || ret == Z_NEED_DICT) {
+            gz_error(state, Z_STREAM_ERROR,
+                     "internal error: inflate stream corrupt");
+            return -1;
+        }
+        if (ret == Z_MEM_ERROR) {
+            gz_error(state, Z_MEM_ERROR, "out of memory");
+            return -1;
+        }
+        if (ret == Z_DATA_ERROR) {              /* deflate stream invalid */
+            gz_error(state, Z_DATA_ERROR,
+                     strm->msg == NULL ? "compressed data error" : strm->msg);
+            return -1;
+        }
+    } while (strm->avail_out && ret != Z_STREAM_END);
 
-	/* update available output */
-	state->x.have = had - strm->avail_out;
-	state->x.next = strm->next_out - state->x.have;
+    /* update available output */
+    state->x.have = had - strm->avail_out;
+    state->x.next = strm->next_out - state->x.have;
 
-	/* if the gzip stream completed successfully, look for another */
-	if (ret == Z_STREAM_END)
-		state->how = LOOK;
+    /* if the gzip stream completed successfully, look for another */
+    if (ret == Z_STREAM_END)
+        state->how = LOOK;
 
-	/* good decompression */
-	return 0;
+    /* good decompression */
+    return 0;
 }
 
 /* Fetch data and put it in the output buffer.  Assumes state->x.have is 0.
-	Data is either copied from the input file or decompressed from the input
-	file depending on state->how.  If state->how is LOOK, then a gzip header is
-	looked for to determine whether to copy or decompress.  Returns -1 on error,
-	otherwise 0.  gz_fetch() will leave state->how as COPY or GZIP unless the
-	end of the input file has been reached and all data has been processed.  */
+   Data is either copied from the input file or decompressed from the input
+   file depending on state->how.  If state->how is LOOK, then a gzip header is
+   looked for to determine whether to copy or decompress.  Returns -1 on error,
+   otherwise 0.  gz_fetch() will leave state->how as COPY or GZIP unless the
+   end of the input file has been reached and all data has been processed.  */
 local int gz_fetch(state)
-gz_statep state;
+    gz_statep state;
 {
-	z_streamp strm = &(state->strm);
+    z_streamp strm = &(state->strm);
 
-	do {
-		switch (state->how) {
-		case LOOK:      /* -> LOOK, COPY (only if never GZIP), or GZIP */
-			if (gz_look(state) == -1)
-				return -1;
-			if (state->how == LOOK)
-				return 0;
-			break;
-		case COPY:      /* -> COPY */
-			if (gz_load(state, state->out, state->size << 1, &(state->x.have))
-				== -1)
-				return -1;
-			state->x.next = state->out;
-			return 0;
-		case GZIP:      /* -> GZIP or LOOK (if end of gzip stream) */
-			strm->avail_out = state->size << 1;
-			strm->next_out = state->out;
-			if (gz_decomp(state) == -1)
-				return -1;
-		}
-	} while (state->x.have == 0 && (!state->eof || strm->avail_in));
-	return 0;
+    do {
+        switch(state->how) {
+        case LOOK:      /* -> LOOK, COPY (only if never GZIP), or GZIP */
+            if (gz_look(state) == -1)
+                return -1;
+            if (state->how == LOOK)
+                return 0;
+            break;
+        case COPY:      /* -> COPY */
+            if (gz_load(state, state->out, state->size << 1, &(state->x.have))
+                    == -1)
+                return -1;
+            state->x.next = state->out;
+            return 0;
+        case GZIP:      /* -> GZIP or LOOK (if end of gzip stream) */
+            strm->avail_out = state->size << 1;
+            strm->next_out = state->out;
+            if (gz_decomp(state) == -1)
+                return -1;
+        }
+    } while (state->x.have == 0 && (!state->eof || strm->avail_in));
+    return 0;
 }
 
 /* Skip len uncompressed bytes of output.  Return -1 on error, 0 on success. */
 local int gz_skip(state, len)
-gz_statep state;
-z_off64_t len;
+    gz_statep state;
+    z_off64_t len;
 {
-	unsigned n;
+    unsigned n;
 
-	/* skip over len bytes or reach end-of-file, whichever comes first */
-	while (len)
-		/* skip over whatever is in output buffer */
-		if (state->x.have) {
-			n = GT_OFF(state->x.have) || (z_off64_t)state->x.have > len ?
-				(unsigned)len : state->x.have;
-			state->x.have -= n;
-			state->x.next += n;
-			state->x.pos += n;
-			len -= n;
-		}
+    /* skip over len bytes or reach end-of-file, whichever comes first */
+    while (len)
+        /* skip over whatever is in output buffer */
+        if (state->x.have) {
+            n = GT_OFF(state->x.have) || (z_off64_t)state->x.have > len ?
+                (unsigned)len : state->x.have;
+            state->x.have -= n;
+            state->x.next += n;
+            state->x.pos += n;
+            len -= n;
+        }
 
-	/* output buffer empty -- return if we're at the end of the input */
-		else if (state->eof && state->strm.avail_in == 0)
-			break;
+        /* output buffer empty -- return if we're at the end of the input */
+        else if (state->eof && state->strm.avail_in == 0)
+            break;
 
-	/* need more data to skip -- load up output buffer */
-		else {
-			/* get more output, looking for header if required */
-			if (gz_fetch(state) == -1)
-				return -1;
-		}
-		return 0;
+        /* need more data to skip -- load up output buffer */
+        else {
+            /* get more output, looking for header if required */
+            if (gz_fetch(state) == -1)
+                return -1;
+        }
+    return 0;
+}
+
+/* Read len bytes into buf from file, or less than len up to the end of the
+   input.  Return the number of bytes read.  If zero is returned, either the
+   end of file was reached, or there was an error.  state->err must be
+   consulted in that case to determine which. */
+local z_size_t gz_read(state, buf, len)
+    gz_statep state;
+    voidp buf;
+    z_size_t len;
+{
+    z_size_t got;
+    unsigned n;
+
+    /* if len is zero, avoid unnecessary operations */
+    if (len == 0)
+        return 0;
+
+    /* process a skip request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_skip(state, state->skip) == -1)
+            return 0;
+    }
+
+    /* get len bytes to buf, or less than len if at the end */
+    got = 0;
+    do {
+        /* set n to the maximum amount of len that fits in an unsigned int */
+        n = -1;
+        if (n > len)
+            n = len;
+
+        /* first just try copying data from the output buffer */
+        if (state->x.have) {
+            if (state->x.have < n)
+                n = state->x.have;
+            memcpy(buf, state->x.next, n);
+            state->x.next += n;
+            state->x.have -= n;
+        }
+
+        /* output buffer empty -- return if we're at the end of the input */
+        else if (state->eof && state->strm.avail_in == 0) {
+            state->past = 1;        /* tried to read past end */
+            break;
+        }
+
+        /* need output data -- for small len or new stream load up our output
+           buffer */
+        else if (state->how == LOOK || n < (state->size << 1)) {
+            /* get more output, looking for header if required */
+            if (gz_fetch(state) == -1)
+                return 0;
+            continue;       /* no progress yet -- go back to copy above */
+            /* the copy above assures that we will leave with space in the
+               output buffer, allowing at least one gzungetc() to succeed */
+        }
+
+        /* large len -- read directly into user buffer */
+        else if (state->how == COPY) {      /* read directly */
+            if (gz_load(state, (unsigned char *)buf, n, &n) == -1)
+                return 0;
+        }
+
+        /* large len -- decompress directly into user buffer */
+        else {  /* state->how == GZIP */
+            state->strm.avail_out = n;
+            state->strm.next_out = (unsigned char *)buf;
+            if (gz_decomp(state) == -1)
+                return 0;
+            n = state->x.have;
+            state->x.have = 0;
+        }
+
+        /* update progress */
+        len -= n;
+        buf = (char *)buf + n;
+        got += n;
+        state->x.pos += n;
+    } while (len);
+
+    /* return number of bytes read into user buffer */
+    return got;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzread(file, buf, len)
-gzFile file;
-voidp buf;
-unsigned len;
+    gzFile file;
+    voidp buf;
+    unsigned len;
 {
-	unsigned got, n;
-	gz_statep state;
-	z_streamp strm;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	strm = &(state->strm);
+    /* get internal structure */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
 
-	/* check that we're reading and that there's no (serious) error */
-	if (state->mode != GZ_READ ||
-		(state->err != Z_OK && state->err != Z_BUF_ERROR))
-		return -1;
+    /* check that we're reading and that there's no (serious) error */
+    if (state->mode != GZ_READ ||
+            (state->err != Z_OK && state->err != Z_BUF_ERROR))
+        return -1;
 
-	/* since an int is returned, make sure len fits in one, otherwise return
-		with an error (this avoids the flaw in the interface) */
-	if ((int)len < 0) {
-		gz_error(state, Z_DATA_ERROR, "requested length does not fit in int");
-		return -1;
-	}
+    /* since an int is returned, make sure len fits in one, otherwise return
+       with an error (this avoids a flaw in the interface) */
+    if ((int)len < 0) {
+        gz_error(state, Z_STREAM_ERROR, "request does not fit in an int");
+        return -1;
+    }
 
-	/* if len is zero, avoid unnecessary operations */
-	if (len == 0)
-		return 0;
+    /* read len or fewer bytes to buf */
+    len = gz_read(state, buf, len);
 
-	/* process a skip request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_skip(state, state->skip) == -1)
-			return -1;
-	}
+    /* check for an error */
+    if (len == 0 && state->err != Z_OK && state->err != Z_BUF_ERROR)
+        return -1;
 
-	/* get len bytes to buf, or less than len if at the end */
-	got = 0;
-	do {
-		/* first just try copying data from the output buffer */
-		if (state->x.have) {
-			n = state->x.have > len ? len : state->x.have;
-			memcpy(buf, state->x.next, n);
-			state->x.next += n;
-			state->x.have -= n;
-		}
+    /* return the number of bytes read (this is assured to fit in an int) */
+    return (int)len;
+}
 
-		/* output buffer empty -- return if we're at the end of the input */
-		else if (state->eof && strm->avail_in == 0) {
-			state->past = 1;        /* tried to read past end */
-			break;
-		}
+/* -- see zlib.h -- */
+z_size_t ZEXPORT gzfread(buf, size, nitems, file)
+    voidp buf;
+    z_size_t size;
+    z_size_t nitems;
+    gzFile file;
+{
+    z_size_t len;
+    gz_statep state;
 
-		/* need output data -- for small len or new stream load up our output
-			buffer */
-		else if (state->how == LOOK || len < (state->size << 1)) {
-			/* get more output, looking for header if required */
-			if (gz_fetch(state) == -1)
-				return -1;
-			continue;       /* no progress yet -- go back to copy above */
-			/* the copy above assures that we will leave with space in the
-				output buffer, allowing at least one gzungetc() to succeed */
-		}
+    /* get internal structure */
+    if (file == NULL)
+        return 0;
+    state = (gz_statep)file;
 
-		/* large len -- read directly into user buffer */
-		else if (state->how == COPY) {      /* read directly */
-			if (gz_load(state, (unsigned char *)buf, len, &n) == -1)
-				return -1;
-		}
+    /* check that we're reading and that there's no (serious) error */
+    if (state->mode != GZ_READ ||
+            (state->err != Z_OK && state->err != Z_BUF_ERROR))
+        return 0;
 
-		/* large len -- decompress directly into user buffer */
-		else {  /* state->how == GZIP */
-			strm->avail_out = len;
-			strm->next_out = (unsigned char *)buf;
-			if (gz_decomp(state) == -1)
-				return -1;
-			n = state->x.have;
-			state->x.have = 0;
-		}
+    /* compute bytes to read -- error on overflow */
+    len = nitems * size;
+    if (size && len / size != nitems) {
+        gz_error(state, Z_STREAM_ERROR, "request does not fit in a size_t");
+        return 0;
+    }
 
-		/* update progress */
-		len -= n;
-		buf = (char *)buf + n;
-		got += n;
-		state->x.pos += n;
-	} while (len);
-
-	/* return number of bytes read into user buffer (will fit in int) */
-	return (int)got;
+    /* read len or fewer bytes to buf, return the number of full items read */
+    return len ? gz_read(state, buf, len) / size : 0;
 }
 
 /* -- see zlib.h -- */
@@ -385,210 +445,210 @@ unsigned len;
 #  undef gzgetc
 #endif
 int ZEXPORT gzgetc(file)
-gzFile file;
+    gzFile file;
 {
-	int ret;
-	unsigned char buf[1];
-	gz_statep state;
+    int ret;
+    unsigned char buf[1];
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
+    /* get internal structure */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
 
-	/* check that we're reading and that there's no (serious) error */
-	if (state->mode != GZ_READ ||
-		(state->err != Z_OK && state->err != Z_BUF_ERROR))
-		return -1;
+    /* check that we're reading and that there's no (serious) error */
+    if (state->mode != GZ_READ ||
+        (state->err != Z_OK && state->err != Z_BUF_ERROR))
+        return -1;
 
-	/* try output buffer (no need to check for skip request) */
-	if (state->x.have) {
-		state->x.have--;
-		state->x.pos++;
-		return *(state->x.next)++;
-	}
+    /* try output buffer (no need to check for skip request) */
+    if (state->x.have) {
+        state->x.have--;
+        state->x.pos++;
+        return *(state->x.next)++;
+    }
 
-	/* nothing there -- try gzread() */
-	ret = gzread(file, buf, 1);
-	return ret < 1 ? -1 : buf[0];
+    /* nothing there -- try gz_read() */
+    ret = gz_read(state, buf, 1);
+    return ret < 1 ? -1 : buf[0];
 }
 
 int ZEXPORT gzgetc_(file)
 gzFile file;
 {
-	return gzgetc(file);
+    return gzgetc(file);
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzungetc(c, file)
-int c;
-gzFile file;
+    int c;
+    gzFile file;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
+    /* get internal structure */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
 
-	/* check that we're reading and that there's no (serious) error */
-	if (state->mode != GZ_READ ||
-		(state->err != Z_OK && state->err != Z_BUF_ERROR))
-		return -1;
+    /* check that we're reading and that there's no (serious) error */
+    if (state->mode != GZ_READ ||
+        (state->err != Z_OK && state->err != Z_BUF_ERROR))
+        return -1;
 
-	/* process a skip request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_skip(state, state->skip) == -1)
-			return -1;
-	}
+    /* process a skip request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_skip(state, state->skip) == -1)
+            return -1;
+    }
 
-	/* can't push EOF */
-	if (c < 0)
-		return -1;
+    /* can't push EOF */
+    if (c < 0)
+        return -1;
 
-	/* if output buffer empty, put byte at end (allows more pushing) */
-	if (state->x.have == 0) {
-		state->x.have = 1;
-		state->x.next = state->out + (state->size << 1) - 1;
-		state->x.next[0] = c;
-		state->x.pos--;
-		state->past = 0;
-		return c;
-	}
+    /* if output buffer empty, put byte at end (allows more pushing) */
+    if (state->x.have == 0) {
+        state->x.have = 1;
+        state->x.next = state->out + (state->size << 1) - 1;
+        state->x.next[0] = (unsigned char)c;
+        state->x.pos--;
+        state->past = 0;
+        return c;
+    }
 
-	/* if no room, give up (must have already done a gzungetc()) */
-	if (state->x.have == (state->size << 1)) {
-		gz_error(state, Z_DATA_ERROR, "out of room to push characters");
-		return -1;
-	}
+    /* if no room, give up (must have already done a gzungetc()) */
+    if (state->x.have == (state->size << 1)) {
+        gz_error(state, Z_DATA_ERROR, "out of room to push characters");
+        return -1;
+    }
 
-	/* slide output data if needed and insert byte before existing data */
-	if (state->x.next == state->out) {
-		unsigned char *src = state->out + state->x.have;
-		unsigned char *dest = state->out + (state->size << 1);
-		while (src > state->out)
-			*--dest = *--src;
-		state->x.next = dest;
-	}
-	state->x.have++;
-	state->x.next--;
-	state->x.next[0] = c;
-	state->x.pos--;
-	state->past = 0;
-	return c;
+    /* slide output data if needed and insert byte before existing data */
+    if (state->x.next == state->out) {
+        unsigned char *src = state->out + state->x.have;
+        unsigned char *dest = state->out + (state->size << 1);
+        while (src > state->out)
+            *--dest = *--src;
+        state->x.next = dest;
+    }
+    state->x.have++;
+    state->x.next--;
+    state->x.next[0] = (unsigned char)c;
+    state->x.pos--;
+    state->past = 0;
+    return c;
 }
 
 /* -- see zlib.h -- */
 char * ZEXPORT gzgets(file, buf, len)
-gzFile file;
-char *buf;
-int len;
+    gzFile file;
+    char *buf;
+    int len;
 {
-	unsigned left, n;
-	char *str;
-	unsigned char *eol;
-	gz_statep state;
+    unsigned left, n;
+    char *str;
+    unsigned char *eol;
+    gz_statep state;
 
-	/* check parameters and get internal structure */
-	if (file == NULL || buf == NULL || len < 1)
-		return NULL;
-	state = (gz_statep)file;
+    /* check parameters and get internal structure */
+    if (file == NULL || buf == NULL || len < 1)
+        return NULL;
+    state = (gz_statep)file;
 
-	/* check that we're reading and that there's no (serious) error */
-	if (state->mode != GZ_READ ||
-		(state->err != Z_OK && state->err != Z_BUF_ERROR))
-		return NULL;
+    /* check that we're reading and that there's no (serious) error */
+    if (state->mode != GZ_READ ||
+        (state->err != Z_OK && state->err != Z_BUF_ERROR))
+        return NULL;
 
-	/* process a skip request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_skip(state, state->skip) == -1)
-			return NULL;
-	}
+    /* process a skip request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_skip(state, state->skip) == -1)
+            return NULL;
+    }
 
-	/* copy output bytes up to new line or len - 1, whichever comes first --
-		append a terminating zero to the string (we don't check for a zero in
-		the contents, let the user worry about that) */
-	str = buf;
-	left = (unsigned)len - 1;
-	if (left) do {
-		/* assure that something is in the output buffer */
-		if (state->x.have == 0 && gz_fetch(state) == -1)
-			return NULL;                /* error */
-		if (state->x.have == 0) {       /* end of file */
-			state->past = 1;            /* read past end */
-			break;                      /* return what we have */
-		}
+    /* copy output bytes up to new line or len - 1, whichever comes first --
+       append a terminating zero to the string (we don't check for a zero in
+       the contents, let the user worry about that) */
+    str = buf;
+    left = (unsigned)len - 1;
+    if (left) do {
+        /* assure that something is in the output buffer */
+        if (state->x.have == 0 && gz_fetch(state) == -1)
+            return NULL;                /* error */
+        if (state->x.have == 0) {       /* end of file */
+            state->past = 1;            /* read past end */
+            break;                      /* return what we have */
+        }
 
-		/* look for end-of-line in current output buffer */
-		n = state->x.have > left ? left : state->x.have;
-		eol = (unsigned char *)memchr(state->x.next, '\n', n);
-		if (eol != NULL)
-			n = (unsigned)(eol - state->x.next) + 1;
+        /* look for end-of-line in current output buffer */
+        n = state->x.have > left ? left : state->x.have;
+        eol = (unsigned char *)memchr(state->x.next, '\n', n);
+        if (eol != NULL)
+            n = (unsigned)(eol - state->x.next) + 1;
 
-		/* copy through end-of-line, or remainder if not found */
-		memcpy(buf, state->x.next, n);
-		state->x.have -= n;
-		state->x.next += n;
-		state->x.pos += n;
-		left -= n;
-		buf += n;
-	} while (left && eol == NULL);
+        /* copy through end-of-line, or remainder if not found */
+        memcpy(buf, state->x.next, n);
+        state->x.have -= n;
+        state->x.next += n;
+        state->x.pos += n;
+        left -= n;
+        buf += n;
+    } while (left && eol == NULL);
 
-	/* return terminated string, or if nothing, end of file */
-	if (buf == str)
-		return NULL;
-	buf[0] = 0;
-	return str;
+    /* return terminated string, or if nothing, end of file */
+    if (buf == str)
+        return NULL;
+    buf[0] = 0;
+    return str;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzdirect(file)
-gzFile file;
+    gzFile file;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return 0;
-	state = (gz_statep)file;
+    /* get internal structure */
+    if (file == NULL)
+        return 0;
+    state = (gz_statep)file;
 
-	/* if the state is not known, but we can find out, then do so (this is
-		mainly for right after a gzopen() or gzdopen()) */
-	if (state->mode == GZ_READ && state->how == LOOK && state->x.have == 0)
-		(void)gz_look(state);
+    /* if the state is not known, but we can find out, then do so (this is
+       mainly for right after a gzopen() or gzdopen()) */
+    if (state->mode == GZ_READ && state->how == LOOK && state->x.have == 0)
+        (void)gz_look(state);
 
-	/* return 1 if transparent, 0 if processing a gzip stream */
-	return state->direct;
+    /* return 1 if transparent, 0 if processing a gzip stream */
+    return state->direct;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzclose_r(file)
-gzFile file;
+    gzFile file;
 {
-	int ret, err;
-	gz_statep state;
+    int ret, err;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return Z_STREAM_ERROR;
-	state = (gz_statep)file;
+    /* get internal structure */
+    if (file == NULL)
+        return Z_STREAM_ERROR;
+    state = (gz_statep)file;
 
-	/* check that we're reading */
-	if (state->mode != GZ_READ)
-		return Z_STREAM_ERROR;
+    /* check that we're reading */
+    if (state->mode != GZ_READ)
+        return Z_STREAM_ERROR;
 
-	/* free memory and close file */
-	if (state->size) {
-		inflateEnd(&(state->strm));
-		free(state->out);
-		free(state->in);
-	}
-	err = state->err == Z_BUF_ERROR ? Z_BUF_ERROR : Z_OK;
-	gz_error(state, Z_OK, NULL);
-	free(state->path);
-	ret = close(state->fd);
-	free(state);
-	return ret ? Z_ERRNO : err;
+    /* free memory and close file */
+    if (state->size) {
+        inflateEnd(&(state->strm));
+        free(state->out);
+        free(state->in);
+    }
+    err = state->err == Z_BUF_ERROR ? Z_BUF_ERROR : Z_OK;
+    gz_error(state, Z_OK, NULL);
+    free(state->path);
+    ret = close(state->fd);
+    free(state);
+    return ret ? Z_ERRNO : err;
 }

--- a/libs/zlib/src/gzwrite.c
+++ b/libs/zlib/src/gzwrite.c
@@ -1,306 +1,375 @@
 /* gzwrite.c -- zlib functions for writing gzip files
- * Copyright (C) 2004, 2005, 2010, 2011, 2012, 2013 Mark Adler
+ * Copyright (C) 2004-2017 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
 #include "gzguts.h"
 
- /* Local functions */
+/* Local functions */
 local int gz_init OF((gz_statep));
 local int gz_comp OF((gz_statep, int));
 local int gz_zero OF((gz_statep, z_off64_t));
+local z_size_t gz_write OF((gz_statep, voidpc, z_size_t));
 
 /* Initialize state for writing a gzip file.  Mark initialization by setting
-	state->size to non-zero.  Return -1 on failure or 0 on success. */
+   state->size to non-zero.  Return -1 on a memory allocation failure, or 0 on
+   success. */
 local int gz_init(state)
-gz_statep state;
+    gz_statep state;
 {
-	int ret;
-	z_streamp strm = &(state->strm);
+    int ret;
+    z_streamp strm = &(state->strm);
 
-	/* allocate input buffer */
-	state->in = (unsigned char *)malloc(state->want);
-	if (state->in == NULL) {
-		gz_error(state, Z_MEM_ERROR, "out of memory");
-		return -1;
-	}
+    /* allocate input buffer (double size for gzprintf) */
+    state->in = (unsigned char *)malloc(state->want << 1);
+    if (state->in == NULL) {
+        gz_error(state, Z_MEM_ERROR, "out of memory");
+        return -1;
+    }
 
-	/* only need output buffer and deflate state if compressing */
-	if (!state->direct) {
-		/* allocate output buffer */
-		state->out = (unsigned char *)malloc(state->want);
-		if (state->out == NULL) {
-			free(state->in);
-			gz_error(state, Z_MEM_ERROR, "out of memory");
-			return -1;
-		}
+    /* only need output buffer and deflate state if compressing */
+    if (!state->direct) {
+        /* allocate output buffer */
+        state->out = (unsigned char *)malloc(state->want);
+        if (state->out == NULL) {
+            free(state->in);
+            gz_error(state, Z_MEM_ERROR, "out of memory");
+            return -1;
+        }
 
-		/* allocate deflate memory, set up for gzip compression */
-		strm->zalloc = Z_NULL;
-		strm->zfree = Z_NULL;
-		strm->opaque = Z_NULL;
-		ret = deflateInit2(strm, state->level, Z_DEFLATED,
-			MAX_WBITS + 16, DEF_MEM_LEVEL, state->strategy);
-		if (ret != Z_OK) {
-			free(state->out);
-			free(state->in);
-			gz_error(state, Z_MEM_ERROR, "out of memory");
-			return -1;
-		}
-	}
+        /* allocate deflate memory, set up for gzip compression */
+        strm->zalloc = Z_NULL;
+        strm->zfree = Z_NULL;
+        strm->opaque = Z_NULL;
+        ret = deflateInit2(strm, state->level, Z_DEFLATED,
+                           MAX_WBITS + 16, DEF_MEM_LEVEL, state->strategy);
+        if (ret != Z_OK) {
+            free(state->out);
+            free(state->in);
+            gz_error(state, Z_MEM_ERROR, "out of memory");
+            return -1;
+        }
+        strm->next_in = NULL;
+    }
 
-	/* mark state as initialized */
-	state->size = state->want;
+    /* mark state as initialized */
+    state->size = state->want;
 
-	/* initialize write buffer if compressing */
-	if (!state->direct) {
-		strm->avail_out = state->size;
-		strm->next_out = state->out;
-		state->x.next = strm->next_out;
-	}
-	return 0;
+    /* initialize write buffer if compressing */
+    if (!state->direct) {
+        strm->avail_out = state->size;
+        strm->next_out = state->out;
+        state->x.next = strm->next_out;
+    }
+    return 0;
 }
 
 /* Compress whatever is at avail_in and next_in and write to the output file.
-	Return -1 if there is an error writing to the output file, otherwise 0.
-	flush is assumed to be a valid deflate() flush value.  If flush is Z_FINISH,
-	then the deflate() state is reset to start a new gzip stream.  If gz->direct
-	is true, then simply write to the output file without compressing, and
-	ignore flush. */
+   Return -1 if there is an error writing to the output file or if gz_init()
+   fails to allocate memory, otherwise 0.  flush is assumed to be a valid
+   deflate() flush value.  If flush is Z_FINISH, then the deflate() state is
+   reset to start a new gzip stream.  If gz->direct is true, then simply write
+   to the output file without compressing, and ignore flush. */
 local int gz_comp(state, flush)
-gz_statep state;
-int flush;
+    gz_statep state;
+    int flush;
 {
-	int ret, got;
-	unsigned have;
-	z_streamp strm = &(state->strm);
+    int ret, writ;
+    unsigned have, put, max = ((unsigned)-1 >> 2) + 1;
+    z_streamp strm = &(state->strm);
 
-	/* allocate memory if this is the first time through */
-	if (state->size == 0 && gz_init(state) == -1)
-		return -1;
+    /* allocate memory if this is the first time through */
+    if (state->size == 0 && gz_init(state) == -1)
+        return -1;
 
-	/* write directly if requested */
-	if (state->direct) {
-		got = write(state->fd, strm->next_in, strm->avail_in);
-		if (got < 0 || (unsigned)got != strm->avail_in) {
-			gz_error(state, Z_ERRNO, zstrerror());
-			return -1;
-		}
-		strm->avail_in = 0;
-		return 0;
-	}
+    /* write directly if requested */
+    if (state->direct) {
+        while (strm->avail_in) {
+            put = strm->avail_in > max ? max : strm->avail_in;
+            writ = write(state->fd, strm->next_in, put);
+            if (writ < 0) {
+                gz_error(state, Z_ERRNO, zstrerror());
+                return -1;
+            }
+            strm->avail_in -= (unsigned)writ;
+            strm->next_in += writ;
+        }
+        return 0;
+    }
 
-	/* run deflate() on provided input until it produces no more output */
-	ret = Z_OK;
-	do {
-		/* write out current buffer contents if full, or if flushing, but if
-			doing Z_FINISH then don't write until we get to Z_STREAM_END */
-		if (strm->avail_out == 0 || (flush != Z_NO_FLUSH &&
-			(flush != Z_FINISH || ret == Z_STREAM_END))) {
-			have = (unsigned)(strm->next_out - state->x.next);
-			if (have && ((got = write(state->fd, state->x.next, have)) < 0 ||
-				(unsigned)got != have)) {
-				gz_error(state, Z_ERRNO, zstrerror());
-				return -1;
-			}
-			if (strm->avail_out == 0) {
-				strm->avail_out = state->size;
-				strm->next_out = state->out;
-			}
-			state->x.next = strm->next_out;
-		}
+    /* run deflate() on provided input until it produces no more output */
+    ret = Z_OK;
+    do {
+        /* write out current buffer contents if full, or if flushing, but if
+           doing Z_FINISH then don't write until we get to Z_STREAM_END */
+        if (strm->avail_out == 0 || (flush != Z_NO_FLUSH &&
+            (flush != Z_FINISH || ret == Z_STREAM_END))) {
+            while (strm->next_out > state->x.next) {
+                put = strm->next_out - state->x.next > (int)max ? max :
+                      (unsigned)(strm->next_out - state->x.next);
+                writ = write(state->fd, state->x.next, put);
+                if (writ < 0) {
+                    gz_error(state, Z_ERRNO, zstrerror());
+                    return -1;
+                }
+                state->x.next += writ;
+            }
+            if (strm->avail_out == 0) {
+                strm->avail_out = state->size;
+                strm->next_out = state->out;
+                state->x.next = state->out;
+            }
+        }
 
-		/* compress */
-		have = strm->avail_out;
-		ret = deflate(strm, flush);
-		if (ret == Z_STREAM_ERROR) {
-			gz_error(state, Z_STREAM_ERROR,
-				"internal error: deflate stream corrupt");
-			return -1;
-		}
-		have -= strm->avail_out;
-	} while (have);
+        /* compress */
+        have = strm->avail_out;
+        ret = deflate(strm, flush);
+        if (ret == Z_STREAM_ERROR) {
+            gz_error(state, Z_STREAM_ERROR,
+                      "internal error: deflate stream corrupt");
+            return -1;
+        }
+        have -= strm->avail_out;
+    } while (have);
 
-	/* if that completed a deflate stream, allow another to start */
-	if (flush == Z_FINISH)
-		deflateReset(strm);
+    /* if that completed a deflate stream, allow another to start */
+    if (flush == Z_FINISH)
+        deflateReset(strm);
 
-	/* all done, no errors */
-	return 0;
+    /* all done, no errors */
+    return 0;
 }
 
-/* Compress len zeros to output.  Return -1 on error, 0 on success. */
+/* Compress len zeros to output.  Return -1 on a write error or memory
+   allocation failure by gz_comp(), or 0 on success. */
 local int gz_zero(state, len)
-gz_statep state;
-z_off64_t len;
+    gz_statep state;
+    z_off64_t len;
 {
-	int first;
-	unsigned n;
-	z_streamp strm = &(state->strm);
+    int first;
+    unsigned n;
+    z_streamp strm = &(state->strm);
 
-	/* consume whatever's left in the input buffer */
-	if (strm->avail_in && gz_comp(state, Z_NO_FLUSH) == -1)
-		return -1;
+    /* consume whatever's left in the input buffer */
+    if (strm->avail_in && gz_comp(state, Z_NO_FLUSH) == -1)
+        return -1;
 
-	/* compress len zeros (len guaranteed > 0) */
-	first = 1;
-	while (len) {
-		n = GT_OFF(state->size) || (z_off64_t)state->size > len ?
-			(unsigned)len : state->size;
-		if (first) {
-			memset(state->in, 0, n);
-			first = 0;
-		}
-		strm->avail_in = n;
-		strm->next_in = state->in;
-		state->x.pos += n;
-		if (gz_comp(state, Z_NO_FLUSH) == -1)
-			return -1;
-		len -= n;
-	}
-	return 0;
+    /* compress len zeros (len guaranteed > 0) */
+    first = 1;
+    while (len) {
+        n = GT_OFF(state->size) || (z_off64_t)state->size > len ?
+            (unsigned)len : state->size;
+        if (first) {
+            memset(state->in, 0, n);
+            first = 0;
+        }
+        strm->avail_in = n;
+        strm->next_in = state->in;
+        state->x.pos += n;
+        if (gz_comp(state, Z_NO_FLUSH) == -1)
+            return -1;
+        len -= n;
+    }
+    return 0;
+}
+
+/* Write len bytes from buf to file.  Return the number of bytes written.  If
+   the returned value is less than len, then there was an error. */
+local z_size_t gz_write(state, buf, len)
+    gz_statep state;
+    voidpc buf;
+    z_size_t len;
+{
+    z_size_t put = len;
+
+    /* if len is zero, avoid unnecessary operations */
+    if (len == 0)
+        return 0;
+
+    /* allocate memory if this is the first time through */
+    if (state->size == 0 && gz_init(state) == -1)
+        return 0;
+
+    /* check for seek request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_zero(state, state->skip) == -1)
+            return 0;
+    }
+
+    /* for small len, copy to input buffer, otherwise compress directly */
+    if (len < state->size) {
+        /* copy to input buffer, compress when full */
+        do {
+            unsigned have, copy;
+
+            if (state->strm.avail_in == 0)
+                state->strm.next_in = state->in;
+            have = (unsigned)((state->strm.next_in + state->strm.avail_in) -
+                              state->in);
+            copy = state->size - have;
+            if (copy > len)
+                copy = len;
+            memcpy(state->in + have, buf, copy);
+            state->strm.avail_in += copy;
+            state->x.pos += copy;
+            buf = (const char *)buf + copy;
+            len -= copy;
+            if (len && gz_comp(state, Z_NO_FLUSH) == -1)
+                return 0;
+        } while (len);
+    }
+    else {
+        /* consume whatever's left in the input buffer */
+        if (state->strm.avail_in && gz_comp(state, Z_NO_FLUSH) == -1)
+            return 0;
+
+        /* directly compress user buffer to file */
+        state->strm.next_in = (z_const Bytef *)buf;
+        do {
+            unsigned n = (unsigned)-1;
+            if (n > len)
+                n = len;
+            state->strm.avail_in = n;
+            state->x.pos += n;
+            if (gz_comp(state, Z_NO_FLUSH) == -1)
+                return 0;
+            len -= n;
+        } while (len);
+    }
+
+    /* input was all buffered or compressed */
+    return put;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzwrite(file, buf, len)
-gzFile file;
-voidpc buf;
-unsigned len;
+    gzFile file;
+    voidpc buf;
+    unsigned len;
 {
-	unsigned put = len;
-	gz_statep state;
-	z_streamp strm;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return 0;
-	state = (gz_statep)file;
-	strm = &(state->strm);
+    /* get internal structure */
+    if (file == NULL)
+        return 0;
+    state = (gz_statep)file;
 
-	/* check that we're writing and that there's no error */
-	if (state->mode != GZ_WRITE || state->err != Z_OK)
-		return 0;
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return 0;
 
-	/* since an int is returned, make sure len fits in one, otherwise return
-		with an error (this avoids the flaw in the interface) */
-	if ((int)len < 0) {
-		gz_error(state, Z_DATA_ERROR, "requested length does not fit in int");
-		return 0;
-	}
+    /* since an int is returned, make sure len fits in one, otherwise return
+       with an error (this avoids a flaw in the interface) */
+    if ((int)len < 0) {
+        gz_error(state, Z_DATA_ERROR, "requested length does not fit in int");
+        return 0;
+    }
 
-	/* if len is zero, avoid unnecessary operations */
-	if (len == 0)
-		return 0;
+    /* write len bytes from buf (the return value will fit in an int) */
+    return (int)gz_write(state, buf, len);
+}
 
-	/* allocate memory if this is the first time through */
-	if (state->size == 0 && gz_init(state) == -1)
-		return 0;
+/* -- see zlib.h -- */
+z_size_t ZEXPORT gzfwrite(buf, size, nitems, file)
+    voidpc buf;
+    z_size_t size;
+    z_size_t nitems;
+    gzFile file;
+{
+    z_size_t len;
+    gz_statep state;
 
-	/* check for seek request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_zero(state, state->skip) == -1)
-			return 0;
-	}
+    /* get internal structure */
+    if (file == NULL)
+        return 0;
+    state = (gz_statep)file;
 
-	/* for small len, copy to input buffer, otherwise compress directly */
-	if (len < state->size) {
-		/* copy to input buffer, compress when full */
-		do {
-			unsigned have, copy;
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return 0;
 
-			if (strm->avail_in == 0)
-				strm->next_in = state->in;
-			have = (unsigned)((strm->next_in + strm->avail_in) - state->in);
-			copy = state->size - have;
-			if (copy > len)
-				copy = len;
-			memcpy(state->in + have, buf, copy);
-			strm->avail_in += copy;
-			state->x.pos += copy;
-			buf = (const char *)buf + copy;
-			len -= copy;
-			if (len && gz_comp(state, Z_NO_FLUSH) == -1)
-				return 0;
-		} while (len);
-	}
-	else {
-		/* consume whatever's left in the input buffer */
-		if (strm->avail_in && gz_comp(state, Z_NO_FLUSH) == -1)
-			return 0;
+    /* compute bytes to read -- error on overflow */
+    len = nitems * size;
+    if (size && len / size != nitems) {
+        gz_error(state, Z_STREAM_ERROR, "request does not fit in a size_t");
+        return 0;
+    }
 
-		/* directly compress user buffer to file */
-		strm->avail_in = len;
-		strm->next_in = (z_const Bytef *)buf;
-		state->x.pos += len;
-		if (gz_comp(state, Z_NO_FLUSH) == -1)
-			return 0;
-	}
-
-	/* input was all buffered or compressed (put will fit in int) */
-	return (int)put;
+    /* write len bytes to buf, return the number of full items written */
+    return len ? gz_write(state, buf, len) / size : 0;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzputc(file, c)
-gzFile file;
-int c;
+    gzFile file;
+    int c;
 {
-	unsigned have;
-	unsigned char buf[1];
-	gz_statep state;
-	z_streamp strm;
+    unsigned have;
+    unsigned char buf[1];
+    gz_statep state;
+    z_streamp strm;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	strm = &(state->strm);
+    /* get internal structure */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
+    strm = &(state->strm);
 
-	/* check that we're writing and that there's no error */
-	if (state->mode != GZ_WRITE || state->err != Z_OK)
-		return -1;
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return -1;
 
-	/* check for seek request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_zero(state, state->skip) == -1)
-			return -1;
-	}
+    /* check for seek request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_zero(state, state->skip) == -1)
+            return -1;
+    }
 
-	/* try writing to input buffer for speed (state->size == 0 if buffer not
-		initialized) */
-	if (state->size) {
-		if (strm->avail_in == 0)
-			strm->next_in = state->in;
-		have = (unsigned)((strm->next_in + strm->avail_in) - state->in);
-		if (have < state->size) {
-			state->in[have] = c;
-			strm->avail_in++;
-			state->x.pos++;
-			return c & 0xff;
-		}
-	}
+    /* try writing to input buffer for speed (state->size == 0 if buffer not
+       initialized) */
+    if (state->size) {
+        if (strm->avail_in == 0)
+            strm->next_in = state->in;
+        have = (unsigned)((strm->next_in + strm->avail_in) - state->in);
+        if (have < state->size) {
+            state->in[have] = (unsigned char)c;
+            strm->avail_in++;
+            state->x.pos++;
+            return c & 0xff;
+        }
+    }
 
-	/* no room in buffer or not initialized, use gz_write() */
-	buf[0] = c;
-	if (gzwrite(file, buf, 1) != 1)
-		return -1;
-	return c & 0xff;
+    /* no room in buffer or not initialized, use gz_write() */
+    buf[0] = (unsigned char)c;
+    if (gz_write(state, buf, 1) != 1)
+        return -1;
+    return c & 0xff;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzputs(file, str)
-gzFile file;
-const char *str;
+    gzFile file;
+    const char *str;
 {
-	int ret;
-	unsigned len;
+    int ret;
+    z_size_t len;
+    gz_statep state;
 
-	/* write string */
-	len = (unsigned)strlen(str);
-	ret = gzwrite(file, str, len);
-	return ret == 0 && len != 0 ? -1 : ret;
+    /* get internal structure */
+    if (file == NULL)
+        return -1;
+    state = (gz_statep)file;
+
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return -1;
+
+    /* write string */
+    len = strlen(str);
+    ret = gz_write(state, str, len);
+    return ret == 0 && len != 0 ? -1 : ret;
 }
 
 #if defined(STDC) || defined(Z_HAVE_STDARG_H)
@@ -309,269 +378,288 @@ const char *str;
 /* -- see zlib.h -- */
 int ZEXPORTVA gzvprintf(gzFile file, const char *format, va_list va)
 {
-	int size, len;
-	gz_statep state;
-	z_streamp strm;
+    int len;
+    unsigned left;
+    char *next;
+    gz_statep state;
+    z_streamp strm;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	strm = &(state->strm);
+    /* get internal structure */
+    if (file == NULL)
+        return Z_STREAM_ERROR;
+    state = (gz_statep)file;
+    strm = &(state->strm);
 
-	/* check that we're writing and that there's no error */
-	if (state->mode != GZ_WRITE || state->err != Z_OK)
-		return 0;
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return Z_STREAM_ERROR;
 
-	/* make sure we have some buffer space */
-	if (state->size == 0 && gz_init(state) == -1)
-		return 0;
+    /* make sure we have some buffer space */
+    if (state->size == 0 && gz_init(state) == -1)
+        return state->err;
 
-	/* check for seek request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_zero(state, state->skip) == -1)
-			return 0;
-	}
+    /* check for seek request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_zero(state, state->skip) == -1)
+            return state->err;
+    }
 
-	/* consume whatever's left in the input buffer */
-	if (strm->avail_in && gz_comp(state, Z_NO_FLUSH) == -1)
-		return 0;
+    /* do the printf() into the input buffer, put length in len -- the input
+       buffer is double-sized just for this function, so there is guaranteed to
+       be state->size bytes available after the current contents */
+    if (strm->avail_in == 0)
+        strm->next_in = state->in;
+    next = (char *)(state->in + (strm->next_in - state->in) + strm->avail_in);
+    next[state->size - 1] = 0;
+#ifdef NO_vsnprintf
+#  ifdef HAS_vsprintf_void
+    (void)vsprintf(next, format, va);
+    for (len = 0; len < state->size; len++)
+        if (next[len] == 0) break;
+#  else
+    len = vsprintf(next, format, va);
+#  endif
+#else
+#  ifdef HAS_vsnprintf_void
+    (void)vsnprintf(next, state->size, format, va);
+    len = strlen(next);
+#  else
+    len = vsnprintf(next, state->size, format, va);
+#  endif
+#endif
 
-	/* do the printf() into the input buffer, put length in len */
-	size = (int)(state->size);
-	state->in[size - 1] = 0;
-	#ifdef NO_vsnprintf
-	#  ifdef HAS_vsprintf_void
-	(void)vsprintf((char *)(state->in), format, va);
-	for (len = 0; len < size; len++)
-		if (state->in[len] == 0) break;
-	#  else
-	len = vsprintf((char *)(state->in), format, va);
-	#  endif
-	#else
-	#  ifdef HAS_vsnprintf_void
-	(void)vsnprintf((char *)(state->in), size, format, va);
-	len = strlen((char *)(state->in));
-	#  else
-	len = vsnprintf((char *)(state->in), size, format, va);
-	#  endif
-	#endif
+    /* check that printf() results fit in buffer */
+    if (len == 0 || (unsigned)len >= state->size || next[state->size - 1] != 0)
+        return 0;
 
-	/* check that printf() results fit in buffer */
-	if (len <= 0 || len >= (int)size || state->in[size - 1] != 0)
-		return 0;
-
-	/* update buffer and position, defer compression until needed */
-	strm->avail_in = (unsigned)len;
-	strm->next_in = state->in;
-	state->x.pos += len;
-	return len;
+    /* update buffer and position, compress first half if past that */
+    strm->avail_in += (unsigned)len;
+    state->x.pos += len;
+    if (strm->avail_in >= state->size) {
+        left = strm->avail_in - state->size;
+        strm->avail_in = state->size;
+        if (gz_comp(state, Z_NO_FLUSH) == -1)
+            return state->err;
+        memcpy(state->in, state->in + state->size, left);
+        strm->next_in = state->in;
+        strm->avail_in = left;
+    }
+    return len;
 }
 
 int ZEXPORTVA gzprintf(gzFile file, const char *format, ...)
 {
-	va_list va;
-	int ret;
+    va_list va;
+    int ret;
 
-	va_start(va, format);
-	ret = gzvprintf(file, format, va);
-	va_end(va);
-	return ret;
+    va_start(va, format);
+    ret = gzvprintf(file, format, va);
+    va_end(va);
+    return ret;
 }
 
 #else /* !STDC && !Z_HAVE_STDARG_H */
 
 /* -- see zlib.h -- */
-int ZEXPORTVA gzprintf(file, format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
-	a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
-	gzFile file;
-const char *format;
-int a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
-a11, a12, a13, a14, a15, a16, a17, a18, a19, a20;
+int ZEXPORTVA gzprintf (file, format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
+                       a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
+    gzFile file;
+    const char *format;
+    int a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
+        a11, a12, a13, a14, a15, a16, a17, a18, a19, a20;
 {
-	int size, len;
-	gz_statep state;
-	z_streamp strm;
+    unsigned len, left;
+    char *next;
+    gz_statep state;
+    z_streamp strm;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
-	strm = &(state->strm);
+    /* get internal structure */
+    if (file == NULL)
+        return Z_STREAM_ERROR;
+    state = (gz_statep)file;
+    strm = &(state->strm);
 
-	/* check that can really pass pointer in ints */
-	if (sizeof(int) != sizeof(void *))
-		return 0;
+    /* check that can really pass pointer in ints */
+    if (sizeof(int) != sizeof(void *))
+        return Z_STREAM_ERROR;
 
-	/* check that we're writing and that there's no error */
-	if (state->mode != GZ_WRITE || state->err != Z_OK)
-		return 0;
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return Z_STREAM_ERROR;
 
-	/* make sure we have some buffer space */
-	if (state->size == 0 && gz_init(state) == -1)
-		return 0;
+    /* make sure we have some buffer space */
+    if (state->size == 0 && gz_init(state) == -1)
+        return state->error;
 
-	/* check for seek request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_zero(state, state->skip) == -1)
-			return 0;
-	}
+    /* check for seek request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_zero(state, state->skip) == -1)
+            return state->error;
+    }
 
-	/* consume whatever's left in the input buffer */
-	if (strm->avail_in && gz_comp(state, Z_NO_FLUSH) == -1)
-		return 0;
+    /* do the printf() into the input buffer, put length in len -- the input
+       buffer is double-sized just for this function, so there is guaranteed to
+       be state->size bytes available after the current contents */
+    if (strm->avail_in == 0)
+        strm->next_in = state->in;
+    next = (char *)(strm->next_in + strm->avail_in);
+    next[state->size - 1] = 0;
+#ifdef NO_snprintf
+#  ifdef HAS_sprintf_void
+    sprintf(next, format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
+            a13, a14, a15, a16, a17, a18, a19, a20);
+    for (len = 0; len < size; len++)
+        if (next[len] == 0)
+            break;
+#  else
+    len = sprintf(next, format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11,
+                  a12, a13, a14, a15, a16, a17, a18, a19, a20);
+#  endif
+#else
+#  ifdef HAS_snprintf_void
+    snprintf(next, state->size, format, a1, a2, a3, a4, a5, a6, a7, a8, a9,
+             a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20);
+    len = strlen(next);
+#  else
+    len = snprintf(next, state->size, format, a1, a2, a3, a4, a5, a6, a7, a8,
+                   a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20);
+#  endif
+#endif
 
-	/* do the printf() into the input buffer, put length in len */
-	size = (int)(state->size);
-	state->in[size - 1] = 0;
-	#ifdef NO_snprintf
-	#  ifdef HAS_sprintf_void
-	sprintf((char *)(state->in), format, a1, a2, a3, a4, a5, a6, a7, a8,
-		a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20);
-	for (len = 0; len < size; len++)
-		if (state->in[len] == 0) break;
-	#  else
-	len = sprintf((char *)(state->in), format, a1, a2, a3, a4, a5, a6, a7, a8,
-		a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20);
-	#  endif
-	#else
-	#  ifdef HAS_snprintf_void
-	snprintf((char *)(state->in), size, format, a1, a2, a3, a4, a5, a6, a7, a8,
-		a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20);
-	len = strlen((char *)(state->in));
-	#  else
-	len = snprintf((char *)(state->in), size, format, a1, a2, a3, a4, a5, a6,
-		a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18,
-		a19, a20);
-	#  endif
-	#endif
+    /* check that printf() results fit in buffer */
+    if (len == 0 || len >= state->size || next[state->size - 1] != 0)
+        return 0;
 
-	/* check that printf() results fit in buffer */
-	if (len <= 0 || len >= (int)size || state->in[size - 1] != 0)
-		return 0;
-
-	/* update buffer and position, defer compression until needed */
-	strm->avail_in = (unsigned)len;
-	strm->next_in = state->in;
-	state->x.pos += len;
-	return len;
+    /* update buffer and position, compress first half if past that */
+    strm->avail_in += len;
+    state->x.pos += len;
+    if (strm->avail_in >= state->size) {
+        left = strm->avail_in - state->size;
+        strm->avail_in = state->size;
+        if (gz_comp(state, Z_NO_FLUSH) == -1)
+            return state->err;
+        memcpy(state->in, state->in + state->size, left);
+        strm->next_in = state->in;
+        strm->avail_in = left;
+    }
+    return (int)len;
 }
 
 #endif
 
 /* -- see zlib.h -- */
 int ZEXPORT gzflush(file, flush)
-gzFile file;
-int flush;
+    gzFile file;
+    int flush;
 {
-	gz_statep state;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return -1;
-	state = (gz_statep)file;
+    /* get internal structure */
+    if (file == NULL)
+        return Z_STREAM_ERROR;
+    state = (gz_statep)file;
 
-	/* check that we're writing and that there's no error */
-	if (state->mode != GZ_WRITE || state->err != Z_OK)
-		return Z_STREAM_ERROR;
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return Z_STREAM_ERROR;
 
-	/* check flush parameter */
-	if (flush < 0 || flush > Z_FINISH)
-		return Z_STREAM_ERROR;
+    /* check flush parameter */
+    if (flush < 0 || flush > Z_FINISH)
+        return Z_STREAM_ERROR;
 
-	/* check for seek request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_zero(state, state->skip) == -1)
-			return -1;
-	}
+    /* check for seek request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_zero(state, state->skip) == -1)
+            return state->err;
+    }
 
-	/* compress remaining data with requested flush */
-	gz_comp(state, flush);
-	return state->err;
+    /* compress remaining data with requested flush */
+    (void)gz_comp(state, flush);
+    return state->err;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzsetparams(file, level, strategy)
-gzFile file;
-int level;
-int strategy;
+    gzFile file;
+    int level;
+    int strategy;
 {
-	gz_statep state;
-	z_streamp strm;
+    gz_statep state;
+    z_streamp strm;
 
-	/* get internal structure */
-	if (file == NULL)
-		return Z_STREAM_ERROR;
-	state = (gz_statep)file;
-	strm = &(state->strm);
+    /* get internal structure */
+    if (file == NULL)
+        return Z_STREAM_ERROR;
+    state = (gz_statep)file;
+    strm = &(state->strm);
 
-	/* check that we're writing and that there's no error */
-	if (state->mode != GZ_WRITE || state->err != Z_OK)
-		return Z_STREAM_ERROR;
+    /* check that we're writing and that there's no error */
+    if (state->mode != GZ_WRITE || state->err != Z_OK)
+        return Z_STREAM_ERROR;
 
-	/* if no change is requested, then do nothing */
-	if (level == state->level && strategy == state->strategy)
-		return Z_OK;
+    /* if no change is requested, then do nothing */
+    if (level == state->level && strategy == state->strategy)
+        return Z_OK;
 
-	/* check for seek request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_zero(state, state->skip) == -1)
-			return -1;
-	}
+    /* check for seek request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_zero(state, state->skip) == -1)
+            return state->err;
+    }
 
-	/* change compression parameters for subsequent input */
-	if (state->size) {
-		/* flush previous input with previous parameters before changing */
-		if (strm->avail_in && gz_comp(state, Z_PARTIAL_FLUSH) == -1)
-			return state->err;
-		deflateParams(strm, level, strategy);
-	}
-	state->level = level;
-	state->strategy = strategy;
-	return Z_OK;
+    /* change compression parameters for subsequent input */
+    if (state->size) {
+        /* flush previous input with previous parameters before changing */
+        if (strm->avail_in && gz_comp(state, Z_BLOCK) == -1)
+            return state->err;
+        deflateParams(strm, level, strategy);
+    }
+    state->level = level;
+    state->strategy = strategy;
+    return Z_OK;
 }
 
 /* -- see zlib.h -- */
 int ZEXPORT gzclose_w(file)
-gzFile file;
+    gzFile file;
 {
-	int ret = Z_OK;
-	gz_statep state;
+    int ret = Z_OK;
+    gz_statep state;
 
-	/* get internal structure */
-	if (file == NULL)
-		return Z_STREAM_ERROR;
-	state = (gz_statep)file;
+    /* get internal structure */
+    if (file == NULL)
+        return Z_STREAM_ERROR;
+    state = (gz_statep)file;
 
-	/* check that we're writing */
-	if (state->mode != GZ_WRITE)
-		return Z_STREAM_ERROR;
+    /* check that we're writing */
+    if (state->mode != GZ_WRITE)
+        return Z_STREAM_ERROR;
 
-	/* check for seek request */
-	if (state->seek) {
-		state->seek = 0;
-		if (gz_zero(state, state->skip) == -1)
-			ret = state->err;
-	}
+    /* check for seek request */
+    if (state->seek) {
+        state->seek = 0;
+        if (gz_zero(state, state->skip) == -1)
+            ret = state->err;
+    }
 
-	/* flush, free memory, and close file */
-	if (gz_comp(state, Z_FINISH) == -1)
-		ret = state->err;
-	if (state->size) {
-		if (!state->direct) {
-			(void)deflateEnd(&(state->strm));
-			free(state->out);
-		}
-		free(state->in);
-	}
-	gz_error(state, Z_OK, NULL);
-	free(state->path);
-	if (close(state->fd) == -1)
-		ret = Z_ERRNO;
-	free(state);
-	return ret;
+    /* flush, free memory, and close file */
+    if (gz_comp(state, Z_FINISH) == -1)
+        ret = state->err;
+    if (state->size) {
+        if (!state->direct) {
+            (void)deflateEnd(&(state->strm));
+            free(state->out);
+        }
+        free(state->in);
+    }
+    gz_error(state, Z_OK, NULL);
+    free(state->path);
+    if (close(state->fd) == -1)
+        ret = Z_ERRNO;
+    free(state);
+    return ret;
 }

--- a/libs/zlib/src/infback.c
+++ b/libs/zlib/src/infback.c
@@ -1,5 +1,5 @@
 /* infback.c -- inflate using a call-back interface
- * Copyright (C) 1995-2011 Mark Adler
+ * Copyright (C) 1995-2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -15,15 +15,15 @@
 #include "inflate.h"
 #include "inffast.h"
 
- /* function prototypes */
+/* function prototypes */
 local void fixedtables OF((struct inflate_state FAR *state));
 
 /*
-	strm provides memory allocation functions in zalloc and zfree, or
-	Z_NULL to use the library memory allocation functions.
+   strm provides memory allocation functions in zalloc and zfree, or
+   Z_NULL to use the library memory allocation functions.
 
-	windowBits is in the range 8..15, and window is a user-supplied
-	window and output buffer that is 2**windowBits bytes.
+   windowBits is in the range 8..15, and window is a user-supplied
+   window and output buffer that is 2**windowBits bytes.
  */
 int ZEXPORT inflateBackInit_(strm, windowBits, window, version, stream_size)
 z_streamp strm;
@@ -32,94 +32,94 @@ unsigned char FAR *window;
 const char *version;
 int stream_size;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	if (version == Z_NULL || version[0] != ZLIB_VERSION[0] ||
-		stream_size != (int)(sizeof(z_stream)))
-		return Z_VERSION_ERROR;
-	if (strm == Z_NULL || window == Z_NULL ||
-		windowBits < 8 || windowBits > 15)
-		return Z_STREAM_ERROR;
-	strm->msg = Z_NULL;                 /* in case we return an error */
-	if (strm->zalloc == (alloc_func)0) {
-		#ifdef Z_SOLO
-		return Z_STREAM_ERROR;
-		#else
-		strm->zalloc = zcalloc;
-		strm->opaque = (voidpf)0;
-		#endif
-	}
-	if (strm->zfree == (free_func)0)
-		#ifdef Z_SOLO
-		return Z_STREAM_ERROR;
-	#else
-		strm->zfree = zcfree;
-	#endif
-	state = (struct inflate_state FAR *)ZALLOC(strm, 1,
-		sizeof(struct inflate_state));
-	if (state == Z_NULL) return Z_MEM_ERROR;
-	Tracev((stderr, "inflate: allocated\n"));
-	strm->state = (struct internal_state FAR *)state;
-	state->dmax = 32768U;
-	state->wbits = windowBits;
-	state->wsize = 1U << windowBits;
-	state->window = window;
-	state->wnext = 0;
-	state->whave = 0;
-	return Z_OK;
+    if (version == Z_NULL || version[0] != ZLIB_VERSION[0] ||
+        stream_size != (int)(sizeof(z_stream)))
+        return Z_VERSION_ERROR;
+    if (strm == Z_NULL || window == Z_NULL ||
+        windowBits < 8 || windowBits > 15)
+        return Z_STREAM_ERROR;
+    strm->msg = Z_NULL;                 /* in case we return an error */
+    if (strm->zalloc == (alloc_func)0) {
+#ifdef Z_SOLO
+        return Z_STREAM_ERROR;
+#else
+        strm->zalloc = zcalloc;
+        strm->opaque = (voidpf)0;
+#endif
+    }
+    if (strm->zfree == (free_func)0)
+#ifdef Z_SOLO
+        return Z_STREAM_ERROR;
+#else
+    strm->zfree = zcfree;
+#endif
+    state = (struct inflate_state FAR *)ZALLOC(strm, 1,
+                                               sizeof(struct inflate_state));
+    if (state == Z_NULL) return Z_MEM_ERROR;
+    Tracev((stderr, "inflate: allocated\n"));
+    strm->state = (struct internal_state FAR *)state;
+    state->dmax = 32768U;
+    state->wbits = (uInt)windowBits;
+    state->wsize = 1U << windowBits;
+    state->window = window;
+    state->wnext = 0;
+    state->whave = 0;
+    return Z_OK;
 }
 
 /*
-	Return state with length and distance decoding tables and index sizes set to
-	fixed code decoding.  Normally this returns fixed tables from inffixed.h.
-	If BUILDFIXED is defined, then instead this routine builds the tables the
-	first time it's called, and returns those tables the first time and
-	thereafter.  This reduces the size of the code by about 2K bytes, in
-	exchange for a little execution time.  However, BUILDFIXED should not be
-	used for threaded applications, since the rewriting of the tables and virgin
-	may not be thread-safe.
+   Return state with length and distance decoding tables and index sizes set to
+   fixed code decoding.  Normally this returns fixed tables from inffixed.h.
+   If BUILDFIXED is defined, then instead this routine builds the tables the
+   first time it's called, and returns those tables the first time and
+   thereafter.  This reduces the size of the code by about 2K bytes, in
+   exchange for a little execution time.  However, BUILDFIXED should not be
+   used for threaded applications, since the rewriting of the tables and virgin
+   may not be thread-safe.
  */
 local void fixedtables(state)
 struct inflate_state FAR *state;
 {
-	#ifdef BUILDFIXED
-	static int virgin = 1;
-	static code *lenfix, *distfix;
-	static code fixed[544];
+#ifdef BUILDFIXED
+    static int virgin = 1;
+    static code *lenfix, *distfix;
+    static code fixed[544];
 
-	/* build fixed huffman tables if first call (may not be thread safe) */
-	if (virgin) {
-		unsigned sym, bits;
-		static code *next;
+    /* build fixed huffman tables if first call (may not be thread safe) */
+    if (virgin) {
+        unsigned sym, bits;
+        static code *next;
 
-		/* literal/length table */
-		sym = 0;
-		while (sym < 144) state->lens[sym++] = 8;
-		while (sym < 256) state->lens[sym++] = 9;
-		while (sym < 280) state->lens[sym++] = 7;
-		while (sym < 288) state->lens[sym++] = 8;
-		next = fixed;
-		lenfix = next;
-		bits = 9;
-		inflate_table(LENS, state->lens, 288, &(next), &(bits), state->work);
+        /* literal/length table */
+        sym = 0;
+        while (sym < 144) state->lens[sym++] = 8;
+        while (sym < 256) state->lens[sym++] = 9;
+        while (sym < 280) state->lens[sym++] = 7;
+        while (sym < 288) state->lens[sym++] = 8;
+        next = fixed;
+        lenfix = next;
+        bits = 9;
+        inflate_table(LENS, state->lens, 288, &(next), &(bits), state->work);
 
-		/* distance table */
-		sym = 0;
-		while (sym < 32) state->lens[sym++] = 5;
-		distfix = next;
-		bits = 5;
-		inflate_table(DISTS, state->lens, 32, &(next), &(bits), state->work);
+        /* distance table */
+        sym = 0;
+        while (sym < 32) state->lens[sym++] = 5;
+        distfix = next;
+        bits = 5;
+        inflate_table(DISTS, state->lens, 32, &(next), &(bits), state->work);
 
-		/* do this just once */
-		virgin = 0;
-	}
-	#else /* !BUILDFIXED */
-	#   include "inffixed.h"
-	#endif /* BUILDFIXED */
-	state->lencode = lenfix;
-	state->lenbits = 9;
-	state->distcode = distfix;
-	state->distbits = 5;
+        /* do this just once */
+        virgin = 0;
+    }
+#else /* !BUILDFIXED */
+#   include "inffixed.h"
+#endif /* BUILDFIXED */
+    state->lencode = lenfix;
+    state->lenbits = 9;
+    state->distcode = distfix;
+    state->distbits = 5;
 }
 
 /* Macros for inflateBack(): */
@@ -154,7 +154,7 @@ struct inflate_state FAR *state;
     } while (0)
 
 /* Assure that some input is available.  If input is requested, but denied,
-	then return a Z_BUF_ERROR from inflateBack(). */
+   then return a Z_BUF_ERROR from inflateBack(). */
 #define PULL() \
     do { \
         if (have == 0) { \
@@ -167,8 +167,8 @@ struct inflate_state FAR *state;
         } \
     } while (0)
 
-	/* Get a byte of input into the bit accumulator, or return from inflateBack()
-		with an error if there is no input available. */
+/* Get a byte of input into the bit accumulator, or return from inflateBack()
+   with an error if there is no input available. */
 #define PULLBYTE() \
     do { \
         PULL(); \
@@ -177,16 +177,16 @@ struct inflate_state FAR *state;
         bits += 8; \
     } while (0)
 
-		/* Assure that there are at least n bits in the bit accumulator.  If there is
-			not enough available input to do that, then return from inflateBack() with
-			an error. */
+/* Assure that there are at least n bits in the bit accumulator.  If there is
+   not enough available input to do that, then return from inflateBack() with
+   an error. */
 #define NEEDBITS(n) \
     do { \
         while (bits < (unsigned)(n)) \
             PULLBYTE(); \
     } while (0)
 
-			/* Return the low n bits of the bit accumulator (n < 16) */
+/* Return the low n bits of the bit accumulator (n < 16) */
 #define BITS(n) \
     ((unsigned)hold & ((1U << (n)) - 1))
 
@@ -205,8 +205,8 @@ struct inflate_state FAR *state;
     } while (0)
 
 /* Assure that some output space is available, by writing out the window
-	if it's full.  If the write fails, return from inflateBack() with a
-	Z_BUF_ERROR. */
+   if it's full.  If the write fails, return from inflateBack() with a
+   Z_BUF_ERROR. */
 #define ROOM() \
     do { \
         if (left == 0) { \
@@ -220,33 +220,33 @@ struct inflate_state FAR *state;
         } \
     } while (0)
 
-	/*
-		strm provides the memory allocation functions and window buffer on input,
-		and provides information on the unused input on return.  For Z_DATA_ERROR
-		returns, strm will also provide an error message.
+/*
+   strm provides the memory allocation functions and window buffer on input,
+   and provides information on the unused input on return.  For Z_DATA_ERROR
+   returns, strm will also provide an error message.
 
-		in() and out() are the call-back input and output functions.  When
-		inflateBack() needs more input, it calls in().  When inflateBack() has
-		filled the window with output, or when it completes with data in the
-		window, it calls out() to write out the data.  The application must not
-		change the provided input until in() is called again or inflateBack()
-		returns.  The application must not change the window/output buffer until
-		inflateBack() returns.
+   in() and out() are the call-back input and output functions.  When
+   inflateBack() needs more input, it calls in().  When inflateBack() has
+   filled the window with output, or when it completes with data in the
+   window, it calls out() to write out the data.  The application must not
+   change the provided input until in() is called again or inflateBack()
+   returns.  The application must not change the window/output buffer until
+   inflateBack() returns.
 
-		in() and out() are called with a descriptor parameter provided in the
-		inflateBack() call.  This parameter can be a structure that provides the
-		information required to do the read or write, as well as accumulated
-		information on the input and output such as totals and check values.
+   in() and out() are called with a descriptor parameter provided in the
+   inflateBack() call.  This parameter can be a structure that provides the
+   information required to do the read or write, as well as accumulated
+   information on the input and output such as totals and check values.
 
-		in() should return zero on failure.  out() should return non-zero on
-		failure.  If either in() or out() fails, than inflateBack() returns a
-		Z_BUF_ERROR.  strm->next_in can be checked for Z_NULL to see whether it
-		was in() or out() that caused in the error.  Otherwise,  inflateBack()
-		returns Z_STREAM_END on success, Z_DATA_ERROR for an deflate format
-		error, or Z_MEM_ERROR if it could not allocate memory for the state.
-		inflateBack() can also return Z_STREAM_ERROR if the input parameters
-		are not correct, i.e. strm is Z_NULL or the state was not initialized.
-	 */
+   in() should return zero on failure.  out() should return non-zero on
+   failure.  If either in() or out() fails, than inflateBack() returns a
+   Z_BUF_ERROR.  strm->next_in can be checked for Z_NULL to see whether it
+   was in() or out() that caused in the error.  Otherwise,  inflateBack()
+   returns Z_STREAM_END on success, Z_DATA_ERROR for an deflate format
+   error, or Z_MEM_ERROR if it could not allocate memory for the state.
+   inflateBack() can also return Z_STREAM_ERROR if the input parameters
+   are not correct, i.e. strm is Z_NULL or the state was not initialized.
+ */
 int ZEXPORT inflateBack(strm, in, in_desc, out, out_desc)
 z_streamp strm;
 in_func in;
@@ -254,387 +254,387 @@ void FAR *in_desc;
 out_func out;
 void FAR *out_desc;
 {
-	struct inflate_state FAR *state;
-	z_const unsigned char FAR *next;    /* next input */
-	unsigned char FAR *put;     /* next output */
-	unsigned have, left;        /* available input and output */
-	unsigned long hold;         /* bit buffer */
-	unsigned bits;              /* bits in bit buffer */
-	unsigned copy;              /* number of stored or match bytes to copy */
-	unsigned char FAR *from;    /* where to copy match bytes from */
-	code here;                  /* current decoding table entry */
-	code last;                  /* parent table entry */
-	unsigned len;               /* length to copy for repeats, bits to drop */
-	int ret;                    /* return code */
-	static const unsigned short order[19] = /* permutation of code lengths */
-	{ 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
+    struct inflate_state FAR *state;
+    z_const unsigned char FAR *next;    /* next input */
+    unsigned char FAR *put;     /* next output */
+    unsigned have, left;        /* available input and output */
+    unsigned long hold;         /* bit buffer */
+    unsigned bits;              /* bits in bit buffer */
+    unsigned copy;              /* number of stored or match bytes to copy */
+    unsigned char FAR *from;    /* where to copy match bytes from */
+    code here;                  /* current decoding table entry */
+    code last;                  /* parent table entry */
+    unsigned len;               /* length to copy for repeats, bits to drop */
+    int ret;                    /* return code */
+    static const unsigned short order[19] = /* permutation of code lengths */
+        {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
 
-	/* Check that the strm exists and that the state was initialized */
-	if (strm == Z_NULL || strm->state == Z_NULL)
-		return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
+    /* Check that the strm exists and that the state was initialized */
+    if (strm == Z_NULL || strm->state == Z_NULL)
+        return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
 
-	/* Reset the state */
-	strm->msg = Z_NULL;
-	state->mode = TYPE;
-	state->last = 0;
-	state->whave = 0;
-	next = strm->next_in;
-	have = next != Z_NULL ? strm->avail_in : 0;
-	hold = 0;
-	bits = 0;
-	put = state->window;
-	left = state->wsize;
+    /* Reset the state */
+    strm->msg = Z_NULL;
+    state->mode = TYPE;
+    state->last = 0;
+    state->whave = 0;
+    next = strm->next_in;
+    have = next != Z_NULL ? strm->avail_in : 0;
+    hold = 0;
+    bits = 0;
+    put = state->window;
+    left = state->wsize;
 
-	/* Inflate until end of block marked as last */
-	for (;;)
-		switch (state->mode) {
-		case TYPE:
-			/* determine and dispatch block type */
-			if (state->last) {
-				BYTEBITS();
-				state->mode = DONE;
-				break;
-			}
-			NEEDBITS(3);
-			state->last = BITS(1);
-			DROPBITS(1);
-			switch (BITS(2)) {
-			case 0:                             /* stored block */
-				Tracev((stderr, "inflate:     stored block%s\n",
-					state->last ? " (last)" : ""));
-				state->mode = STORED;
-				break;
-			case 1:                             /* fixed block */
-				fixedtables(state);
-				Tracev((stderr, "inflate:     fixed codes block%s\n",
-					state->last ? " (last)" : ""));
-				state->mode = LEN;              /* decode codes */
-				break;
-			case 2:                             /* dynamic block */
-				Tracev((stderr, "inflate:     dynamic codes block%s\n",
-					state->last ? " (last)" : ""));
-				state->mode = TABLE;
-				break;
-			case 3:
-				strm->msg = (char *)"invalid block type";
-				state->mode = BAD;
-			}
-			DROPBITS(2);
-			break;
+    /* Inflate until end of block marked as last */
+    for (;;)
+        switch (state->mode) {
+        case TYPE:
+            /* determine and dispatch block type */
+            if (state->last) {
+                BYTEBITS();
+                state->mode = DONE;
+                break;
+            }
+            NEEDBITS(3);
+            state->last = BITS(1);
+            DROPBITS(1);
+            switch (BITS(2)) {
+            case 0:                             /* stored block */
+                Tracev((stderr, "inflate:     stored block%s\n",
+                        state->last ? " (last)" : ""));
+                state->mode = STORED;
+                break;
+            case 1:                             /* fixed block */
+                fixedtables(state);
+                Tracev((stderr, "inflate:     fixed codes block%s\n",
+                        state->last ? " (last)" : ""));
+                state->mode = LEN;              /* decode codes */
+                break;
+            case 2:                             /* dynamic block */
+                Tracev((stderr, "inflate:     dynamic codes block%s\n",
+                        state->last ? " (last)" : ""));
+                state->mode = TABLE;
+                break;
+            case 3:
+                strm->msg = (char *)"invalid block type";
+                state->mode = BAD;
+            }
+            DROPBITS(2);
+            break;
 
-		case STORED:
-			/* get and verify stored block length */
-			BYTEBITS();                         /* go to byte boundary */
-			NEEDBITS(32);
-			if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
-				strm->msg = (char *)"invalid stored block lengths";
-				state->mode = BAD;
-				break;
-			}
-			state->length = (unsigned)hold & 0xffff;
-			Tracev((stderr, "inflate:       stored length %u\n",
-				state->length));
-			INITBITS();
+        case STORED:
+            /* get and verify stored block length */
+            BYTEBITS();                         /* go to byte boundary */
+            NEEDBITS(32);
+            if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
+                strm->msg = (char *)"invalid stored block lengths";
+                state->mode = BAD;
+                break;
+            }
+            state->length = (unsigned)hold & 0xffff;
+            Tracev((stderr, "inflate:       stored length %u\n",
+                    state->length));
+            INITBITS();
 
-			/* copy stored block from input to output */
-			while (state->length != 0) {
-				copy = state->length;
-				PULL();
-				ROOM();
-				if (copy > have) copy = have;
-				if (copy > left) copy = left;
-				zmemcpy(put, next, copy);
-				have -= copy;
-				next += copy;
-				left -= copy;
-				put += copy;
-				state->length -= copy;
-			}
-			Tracev((stderr, "inflate:       stored end\n"));
-			state->mode = TYPE;
-			break;
+            /* copy stored block from input to output */
+            while (state->length != 0) {
+                copy = state->length;
+                PULL();
+                ROOM();
+                if (copy > have) copy = have;
+                if (copy > left) copy = left;
+                zmemcpy(put, next, copy);
+                have -= copy;
+                next += copy;
+                left -= copy;
+                put += copy;
+                state->length -= copy;
+            }
+            Tracev((stderr, "inflate:       stored end\n"));
+            state->mode = TYPE;
+            break;
 
-		case TABLE:
-			/* get dynamic table entries descriptor */
-			NEEDBITS(14);
-			state->nlen = BITS(5) + 257;
-			DROPBITS(5);
-			state->ndist = BITS(5) + 1;
-			DROPBITS(5);
-			state->ncode = BITS(4) + 4;
-			DROPBITS(4);
-			#ifndef PKZIP_BUG_WORKAROUND
-			if (state->nlen > 286 || state->ndist > 30) {
-				strm->msg = (char *)"too many length or distance symbols";
-				state->mode = BAD;
-				break;
-			}
-			#endif
-			Tracev((stderr, "inflate:       table sizes ok\n"));
+        case TABLE:
+            /* get dynamic table entries descriptor */
+            NEEDBITS(14);
+            state->nlen = BITS(5) + 257;
+            DROPBITS(5);
+            state->ndist = BITS(5) + 1;
+            DROPBITS(5);
+            state->ncode = BITS(4) + 4;
+            DROPBITS(4);
+#ifndef PKZIP_BUG_WORKAROUND
+            if (state->nlen > 286 || state->ndist > 30) {
+                strm->msg = (char *)"too many length or distance symbols";
+                state->mode = BAD;
+                break;
+            }
+#endif
+            Tracev((stderr, "inflate:       table sizes ok\n"));
 
-			/* get code length code lengths (not a typo) */
-			state->have = 0;
-			while (state->have < state->ncode) {
-				NEEDBITS(3);
-				state->lens[order[state->have++]] = (unsigned short)BITS(3);
-				DROPBITS(3);
-			}
-			while (state->have < 19)
-				state->lens[order[state->have++]] = 0;
-			state->next = state->codes;
-			state->lencode = (code const FAR *)(state->next);
-			state->lenbits = 7;
-			ret = inflate_table(CODES, state->lens, 19, &(state->next),
-				&(state->lenbits), state->work);
-			if (ret) {
-				strm->msg = (char *)"invalid code lengths set";
-				state->mode = BAD;
-				break;
-			}
-			Tracev((stderr, "inflate:       code lengths ok\n"));
+            /* get code length code lengths (not a typo) */
+            state->have = 0;
+            while (state->have < state->ncode) {
+                NEEDBITS(3);
+                state->lens[order[state->have++]] = (unsigned short)BITS(3);
+                DROPBITS(3);
+            }
+            while (state->have < 19)
+                state->lens[order[state->have++]] = 0;
+            state->next = state->codes;
+            state->lencode = (code const FAR *)(state->next);
+            state->lenbits = 7;
+            ret = inflate_table(CODES, state->lens, 19, &(state->next),
+                                &(state->lenbits), state->work);
+            if (ret) {
+                strm->msg = (char *)"invalid code lengths set";
+                state->mode = BAD;
+                break;
+            }
+            Tracev((stderr, "inflate:       code lengths ok\n"));
 
-			/* get length and distance code code lengths */
-			state->have = 0;
-			while (state->have < state->nlen + state->ndist) {
-				for (;;) {
-					here = state->lencode[BITS(state->lenbits)];
-					if ((unsigned)(here.bits) <= bits) break;
-					PULLBYTE();
-				}
-				if (here.val < 16) {
-					DROPBITS(here.bits);
-					state->lens[state->have++] = here.val;
-				}
-				else {
-					if (here.val == 16) {
-						NEEDBITS(here.bits + 2);
-						DROPBITS(here.bits);
-						if (state->have == 0) {
-							strm->msg = (char *)"invalid bit length repeat";
-							state->mode = BAD;
-							break;
-						}
-						len = (unsigned)(state->lens[state->have - 1]);
-						copy = 3 + BITS(2);
-						DROPBITS(2);
-					}
-					else if (here.val == 17) {
-						NEEDBITS(here.bits + 3);
-						DROPBITS(here.bits);
-						len = 0;
-						copy = 3 + BITS(3);
-						DROPBITS(3);
-					}
-					else {
-						NEEDBITS(here.bits + 7);
-						DROPBITS(here.bits);
-						len = 0;
-						copy = 11 + BITS(7);
-						DROPBITS(7);
-					}
-					if (state->have + copy > state->nlen + state->ndist) {
-						strm->msg = (char *)"invalid bit length repeat";
-						state->mode = BAD;
-						break;
-					}
-					while (copy--)
-						state->lens[state->have++] = (unsigned short)len;
-				}
-			}
+            /* get length and distance code code lengths */
+            state->have = 0;
+            while (state->have < state->nlen + state->ndist) {
+                for (;;) {
+                    here = state->lencode[BITS(state->lenbits)];
+                    if ((unsigned)(here.bits) <= bits) break;
+                    PULLBYTE();
+                }
+                if (here.val < 16) {
+                    DROPBITS(here.bits);
+                    state->lens[state->have++] = here.val;
+                }
+                else {
+                    if (here.val == 16) {
+                        NEEDBITS(here.bits + 2);
+                        DROPBITS(here.bits);
+                        if (state->have == 0) {
+                            strm->msg = (char *)"invalid bit length repeat";
+                            state->mode = BAD;
+                            break;
+                        }
+                        len = (unsigned)(state->lens[state->have - 1]);
+                        copy = 3 + BITS(2);
+                        DROPBITS(2);
+                    }
+                    else if (here.val == 17) {
+                        NEEDBITS(here.bits + 3);
+                        DROPBITS(here.bits);
+                        len = 0;
+                        copy = 3 + BITS(3);
+                        DROPBITS(3);
+                    }
+                    else {
+                        NEEDBITS(here.bits + 7);
+                        DROPBITS(here.bits);
+                        len = 0;
+                        copy = 11 + BITS(7);
+                        DROPBITS(7);
+                    }
+                    if (state->have + copy > state->nlen + state->ndist) {
+                        strm->msg = (char *)"invalid bit length repeat";
+                        state->mode = BAD;
+                        break;
+                    }
+                    while (copy--)
+                        state->lens[state->have++] = (unsigned short)len;
+                }
+            }
 
-			/* handle error breaks in while */
-			if (state->mode == BAD) break;
+            /* handle error breaks in while */
+            if (state->mode == BAD) break;
 
-			/* check for end-of-block code (better have one) */
-			if (state->lens[256] == 0) {
-				strm->msg = (char *)"invalid code -- missing end-of-block";
-				state->mode = BAD;
-				break;
-			}
+            /* check for end-of-block code (better have one) */
+            if (state->lens[256] == 0) {
+                strm->msg = (char *)"invalid code -- missing end-of-block";
+                state->mode = BAD;
+                break;
+            }
 
-			/* build code tables -- note: do not change the lenbits or distbits
-				values here (9 and 6) without reading the comments in inftrees.h
-				concerning the ENOUGH constants, which depend on those values */
-			state->next = state->codes;
-			state->lencode = (code const FAR *)(state->next);
-			state->lenbits = 9;
-			ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
-				&(state->lenbits), state->work);
-			if (ret) {
-				strm->msg = (char *)"invalid literal/lengths set";
-				state->mode = BAD;
-				break;
-			}
-			state->distcode = (code const FAR *)(state->next);
-			state->distbits = 6;
-			ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
-				&(state->next), &(state->distbits), state->work);
-			if (ret) {
-				strm->msg = (char *)"invalid distances set";
-				state->mode = BAD;
-				break;
-			}
-			Tracev((stderr, "inflate:       codes ok\n"));
-			state->mode = LEN;
+            /* build code tables -- note: do not change the lenbits or distbits
+               values here (9 and 6) without reading the comments in inftrees.h
+               concerning the ENOUGH constants, which depend on those values */
+            state->next = state->codes;
+            state->lencode = (code const FAR *)(state->next);
+            state->lenbits = 9;
+            ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
+                                &(state->lenbits), state->work);
+            if (ret) {
+                strm->msg = (char *)"invalid literal/lengths set";
+                state->mode = BAD;
+                break;
+            }
+            state->distcode = (code const FAR *)(state->next);
+            state->distbits = 6;
+            ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
+                            &(state->next), &(state->distbits), state->work);
+            if (ret) {
+                strm->msg = (char *)"invalid distances set";
+                state->mode = BAD;
+                break;
+            }
+            Tracev((stderr, "inflate:       codes ok\n"));
+            state->mode = LEN;
 
-		case LEN:
-			/* use inflate_fast() if we have enough input and output */
-			if (have >= 6 && left >= 258) {
-				RESTORE();
-				if (state->whave < state->wsize)
-					state->whave = state->wsize - left;
-				inflate_fast(strm, state->wsize);
-				LOAD();
-				break;
-			}
+        case LEN:
+            /* use inflate_fast() if we have enough input and output */
+            if (have >= 6 && left >= 258) {
+                RESTORE();
+                if (state->whave < state->wsize)
+                    state->whave = state->wsize - left;
+                inflate_fast(strm, state->wsize);
+                LOAD();
+                break;
+            }
 
-			/* get a literal, length, or end-of-block code */
-			for (;;) {
-				here = state->lencode[BITS(state->lenbits)];
-				if ((unsigned)(here.bits) <= bits) break;
-				PULLBYTE();
-			}
-			if (here.op && (here.op & 0xf0) == 0) {
-				last = here;
-				for (;;) {
-					here = state->lencode[last.val +
-						(BITS(last.bits + last.op) >> last.bits)];
-					if ((unsigned)(last.bits + here.bits) <= bits) break;
-					PULLBYTE();
-				}
-				DROPBITS(last.bits);
-			}
-			DROPBITS(here.bits);
-			state->length = (unsigned)here.val;
+            /* get a literal, length, or end-of-block code */
+            for (;;) {
+                here = state->lencode[BITS(state->lenbits)];
+                if ((unsigned)(here.bits) <= bits) break;
+                PULLBYTE();
+            }
+            if (here.op && (here.op & 0xf0) == 0) {
+                last = here;
+                for (;;) {
+                    here = state->lencode[last.val +
+                            (BITS(last.bits + last.op) >> last.bits)];
+                    if ((unsigned)(last.bits + here.bits) <= bits) break;
+                    PULLBYTE();
+                }
+                DROPBITS(last.bits);
+            }
+            DROPBITS(here.bits);
+            state->length = (unsigned)here.val;
 
-			/* process literal */
-			if (here.op == 0) {
-				Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-					"inflate:         literal '%c'\n" :
-					"inflate:         literal 0x%02x\n", here.val));
-				ROOM();
-				*put++ = (unsigned char)(state->length);
-				left--;
-				state->mode = LEN;
-				break;
-			}
+            /* process literal */
+            if (here.op == 0) {
+                Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
+                        "inflate:         literal '%c'\n" :
+                        "inflate:         literal 0x%02x\n", here.val));
+                ROOM();
+                *put++ = (unsigned char)(state->length);
+                left--;
+                state->mode = LEN;
+                break;
+            }
 
-			/* process end of block */
-			if (here.op & 32) {
-				Tracevv((stderr, "inflate:         end of block\n"));
-				state->mode = TYPE;
-				break;
-			}
+            /* process end of block */
+            if (here.op & 32) {
+                Tracevv((stderr, "inflate:         end of block\n"));
+                state->mode = TYPE;
+                break;
+            }
 
-			/* invalid code */
-			if (here.op & 64) {
-				strm->msg = (char *)"invalid literal/length code";
-				state->mode = BAD;
-				break;
-			}
+            /* invalid code */
+            if (here.op & 64) {
+                strm->msg = (char *)"invalid literal/length code";
+                state->mode = BAD;
+                break;
+            }
 
-			/* length code -- get extra bits, if any */
-			state->extra = (unsigned)(here.op) & 15;
-			if (state->extra != 0) {
-				NEEDBITS(state->extra);
-				state->length += BITS(state->extra);
-				DROPBITS(state->extra);
-			}
-			Tracevv((stderr, "inflate:         length %u\n", state->length));
+            /* length code -- get extra bits, if any */
+            state->extra = (unsigned)(here.op) & 15;
+            if (state->extra != 0) {
+                NEEDBITS(state->extra);
+                state->length += BITS(state->extra);
+                DROPBITS(state->extra);
+            }
+            Tracevv((stderr, "inflate:         length %u\n", state->length));
 
-			/* get distance code */
-			for (;;) {
-				here = state->distcode[BITS(state->distbits)];
-				if ((unsigned)(here.bits) <= bits) break;
-				PULLBYTE();
-			}
-			if ((here.op & 0xf0) == 0) {
-				last = here;
-				for (;;) {
-					here = state->distcode[last.val +
-						(BITS(last.bits + last.op) >> last.bits)];
-					if ((unsigned)(last.bits + here.bits) <= bits) break;
-					PULLBYTE();
-				}
-				DROPBITS(last.bits);
-			}
-			DROPBITS(here.bits);
-			if (here.op & 64) {
-				strm->msg = (char *)"invalid distance code";
-				state->mode = BAD;
-				break;
-			}
-			state->offset = (unsigned)here.val;
+            /* get distance code */
+            for (;;) {
+                here = state->distcode[BITS(state->distbits)];
+                if ((unsigned)(here.bits) <= bits) break;
+                PULLBYTE();
+            }
+            if ((here.op & 0xf0) == 0) {
+                last = here;
+                for (;;) {
+                    here = state->distcode[last.val +
+                            (BITS(last.bits + last.op) >> last.bits)];
+                    if ((unsigned)(last.bits + here.bits) <= bits) break;
+                    PULLBYTE();
+                }
+                DROPBITS(last.bits);
+            }
+            DROPBITS(here.bits);
+            if (here.op & 64) {
+                strm->msg = (char *)"invalid distance code";
+                state->mode = BAD;
+                break;
+            }
+            state->offset = (unsigned)here.val;
 
-			/* get distance extra bits, if any */
-			state->extra = (unsigned)(here.op) & 15;
-			if (state->extra != 0) {
-				NEEDBITS(state->extra);
-				state->offset += BITS(state->extra);
-				DROPBITS(state->extra);
-			}
-			if (state->offset > state->wsize - (state->whave < state->wsize ?
-				left : 0)) {
-				strm->msg = (char *)"invalid distance too far back";
-				state->mode = BAD;
-				break;
-			}
-			Tracevv((stderr, "inflate:         distance %u\n", state->offset));
+            /* get distance extra bits, if any */
+            state->extra = (unsigned)(here.op) & 15;
+            if (state->extra != 0) {
+                NEEDBITS(state->extra);
+                state->offset += BITS(state->extra);
+                DROPBITS(state->extra);
+            }
+            if (state->offset > state->wsize - (state->whave < state->wsize ?
+                                                left : 0)) {
+                strm->msg = (char *)"invalid distance too far back";
+                state->mode = BAD;
+                break;
+            }
+            Tracevv((stderr, "inflate:         distance %u\n", state->offset));
 
-			/* copy match from window to output */
-			do {
-				ROOM();
-				copy = state->wsize - state->offset;
-				if (copy < left) {
-					from = put + copy;
-					copy = left - copy;
-				}
-				else {
-					from = put - state->offset;
-					copy = left;
-				}
-				if (copy > state->length) copy = state->length;
-				state->length -= copy;
-				left -= copy;
-				do {
-					*put++ = *from++;
-				} while (--copy);
-			} while (state->length != 0);
-			break;
+            /* copy match from window to output */
+            do {
+                ROOM();
+                copy = state->wsize - state->offset;
+                if (copy < left) {
+                    from = put + copy;
+                    copy = left - copy;
+                }
+                else {
+                    from = put - state->offset;
+                    copy = left;
+                }
+                if (copy > state->length) copy = state->length;
+                state->length -= copy;
+                left -= copy;
+                do {
+                    *put++ = *from++;
+                } while (--copy);
+            } while (state->length != 0);
+            break;
 
-		case DONE:
-			/* inflate stream terminated properly -- write leftover output */
-			ret = Z_STREAM_END;
-			if (left < state->wsize) {
-				if (out(out_desc, state->window, state->wsize - left))
-					ret = Z_BUF_ERROR;
-			}
-			goto inf_leave;
+        case DONE:
+            /* inflate stream terminated properly -- write leftover output */
+            ret = Z_STREAM_END;
+            if (left < state->wsize) {
+                if (out(out_desc, state->window, state->wsize - left))
+                    ret = Z_BUF_ERROR;
+            }
+            goto inf_leave;
 
-		case BAD:
-			ret = Z_DATA_ERROR;
-			goto inf_leave;
+        case BAD:
+            ret = Z_DATA_ERROR;
+            goto inf_leave;
 
-		default:                /* can't happen, but makes compilers happy */
-			ret = Z_STREAM_ERROR;
-			goto inf_leave;
-		}
+        default:                /* can't happen, but makes compilers happy */
+            ret = Z_STREAM_ERROR;
+            goto inf_leave;
+        }
 
-	/* Return unused input */
-inf_leave:
-	strm->next_in = next;
-	strm->avail_in = have;
-	return ret;
+    /* Return unused input */
+  inf_leave:
+    strm->next_in = next;
+    strm->avail_in = have;
+    return ret;
 }
 
 int ZEXPORT inflateBackEnd(strm)
 z_streamp strm;
 {
-	if (strm == Z_NULL || strm->state == Z_NULL || strm->zfree == (free_func)0)
-		return Z_STREAM_ERROR;
-	ZFREE(strm, strm->state);
-	strm->state = Z_NULL;
-	Tracev((stderr, "inflate: end\n"));
-	return Z_OK;
+    if (strm == Z_NULL || strm->state == Z_NULL || strm->zfree == (free_func)0)
+        return Z_STREAM_ERROR;
+    ZFREE(strm, strm->state);
+    strm->state = Z_NULL;
+    Tracev((stderr, "inflate: end\n"));
+    return Z_OK;
 }

--- a/libs/zlib/src/inffast.c
+++ b/libs/zlib/src/inffast.c
@@ -1,5 +1,5 @@
 /* inffast.c -- fast decoding
- * Copyright (C) 1995-2008, 2010, 2013 Mark Adler
+ * Copyright (C) 1995-2017 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -8,333 +8,316 @@
 #include "inflate.h"
 #include "inffast.h"
 
-#ifndef ASMINF
-
- /* Allow machine dependent optimization for post-increment or pre-increment.
-	 Based on testing to date,
-	 Pre-increment preferred for:
-	 - PowerPC G3 (Adler)
-	 - MIPS R5000 (Randers-Pehrson)
-	 Post-increment preferred for:
-	 - none
-	 No measurable difference:
-	 - Pentium III (Anderson)
-	 - M68060 (Nikl)
-  */
-#ifdef POSTINC
-#  define OFF 0
-#  define PUP(a) *(a)++
+#ifdef ASMINF
+#  pragma message("Assembler code may have bugs -- use at your own risk")
 #else
-#  define OFF 1
-#  define PUP(a) *++(a)
-#endif
 
-  /*
-	  Decode literal, length, and distance codes and write out the resulting
-	  literal and match bytes until either not enough input or output is
-	  available, an end-of-block is encountered, or a data error is encountered.
-	  When large enough input and output buffers are supplied to inflate(), for
-	  example, a 16K input buffer and a 64K output buffer, more than 95% of the
-	  inflate execution time is spent in this routine.
+/*
+   Decode literal, length, and distance codes and write out the resulting
+   literal and match bytes until either not enough input or output is
+   available, an end-of-block is encountered, or a data error is encountered.
+   When large enough input and output buffers are supplied to inflate(), for
+   example, a 16K input buffer and a 64K output buffer, more than 95% of the
+   inflate execution time is spent in this routine.
 
-	  Entry assumptions:
+   Entry assumptions:
 
-			 state->mode == LEN
-			 strm->avail_in >= 6
-			 strm->avail_out >= 258
-			 start >= strm->avail_out
-			 state->bits < 8
+        state->mode == LEN
+        strm->avail_in >= 6
+        strm->avail_out >= 258
+        start >= strm->avail_out
+        state->bits < 8
 
-	  On return, state->mode is one of:
+   On return, state->mode is one of:
 
-			 LEN -- ran out of enough output space or enough available input
-			 TYPE -- reached end of block code, inflate() to interpret next block
-			 BAD -- error in block data
+        LEN -- ran out of enough output space or enough available input
+        TYPE -- reached end of block code, inflate() to interpret next block
+        BAD -- error in block data
 
-	  Notes:
+   Notes:
 
-		- The maximum input bits used by a length/distance pair is 15 bits for the
-		  length code, 5 bits for the length extra, 15 bits for the distance code,
-		  and 13 bits for the distance extra.  This totals 48 bits, or six bytes.
-		  Therefore if strm->avail_in >= 6, then there is enough input to avoid
-		  checking for available input while decoding.
+    - The maximum input bits used by a length/distance pair is 15 bits for the
+      length code, 5 bits for the length extra, 15 bits for the distance code,
+      and 13 bits for the distance extra.  This totals 48 bits, or six bytes.
+      Therefore if strm->avail_in >= 6, then there is enough input to avoid
+      checking for available input while decoding.
 
-		- The maximum bytes that a single length/distance pair can output is 258
-		  bytes, which is the maximum length that can be coded.  inflate_fast()
-		  requires strm->avail_out >= 258 for each loop to avoid checking for
-		  output space.
-	*/
+    - The maximum bytes that a single length/distance pair can output is 258
+      bytes, which is the maximum length that can be coded.  inflate_fast()
+      requires strm->avail_out >= 258 for each loop to avoid checking for
+      output space.
+ */
 void ZLIB_INTERNAL inflate_fast(strm, start)
 z_streamp strm;
 unsigned start;         /* inflate()'s starting value for strm->avail_out */
 {
-	struct inflate_state FAR *state;
-	z_const unsigned char FAR *in;      /* local strm->next_in */
-	z_const unsigned char FAR *last;    /* have enough input while in < last */
-	unsigned char FAR *out;     /* local strm->next_out */
-	unsigned char FAR *beg;     /* inflate()'s initial strm->next_out */
-	unsigned char FAR *end;     /* while out < end, enough space available */
-	#ifdef INFLATE_STRICT
-	unsigned dmax;              /* maximum distance from zlib header */
-	#endif
-	unsigned wsize;             /* window size or zero if not using window */
-	unsigned whave;             /* valid bytes in the window */
-	unsigned wnext;             /* window write index */
-	unsigned char FAR *window;  /* allocated sliding window, if wsize != 0 */
-	unsigned long hold;         /* local strm->hold */
-	unsigned bits;              /* local strm->bits */
-	code const FAR *lcode;      /* local strm->lencode */
-	code const FAR *dcode;      /* local strm->distcode */
-	unsigned lmask;             /* mask for first level of length codes */
-	unsigned dmask;             /* mask for first level of distance codes */
-	code here;                  /* retrieved table entry */
-	unsigned op;                /* code bits, operation, extra bits, or */
-										 /*  window position, window bytes to copy */
-	unsigned len;               /* match length, unused bytes */
-	unsigned dist;              /* match distance */
-	unsigned char FAR *from;    /* where to copy match from */
+    struct inflate_state FAR *state;
+    z_const unsigned char FAR *in;      /* local strm->next_in */
+    z_const unsigned char FAR *last;    /* have enough input while in < last */
+    unsigned char FAR *out;     /* local strm->next_out */
+    unsigned char FAR *beg;     /* inflate()'s initial strm->next_out */
+    unsigned char FAR *end;     /* while out < end, enough space available */
+#ifdef INFLATE_STRICT
+    unsigned dmax;              /* maximum distance from zlib header */
+#endif
+    unsigned wsize;             /* window size or zero if not using window */
+    unsigned whave;             /* valid bytes in the window */
+    unsigned wnext;             /* window write index */
+    unsigned char FAR *window;  /* allocated sliding window, if wsize != 0 */
+    unsigned long hold;         /* local strm->hold */
+    unsigned bits;              /* local strm->bits */
+    code const FAR *lcode;      /* local strm->lencode */
+    code const FAR *dcode;      /* local strm->distcode */
+    unsigned lmask;             /* mask for first level of length codes */
+    unsigned dmask;             /* mask for first level of distance codes */
+    code here;                  /* retrieved table entry */
+    unsigned op;                /* code bits, operation, extra bits, or */
+                                /*  window position, window bytes to copy */
+    unsigned len;               /* match length, unused bytes */
+    unsigned dist;              /* match distance */
+    unsigned char FAR *from;    /* where to copy match from */
 
-	/* copy state to local variables */
-	state = (struct inflate_state FAR *)strm->state;
-	in = strm->next_in - OFF;
-	last = in + (strm->avail_in - 5);
-	out = strm->next_out - OFF;
-	beg = out - (start - strm->avail_out);
-	end = out + (strm->avail_out - 257);
-	#ifdef INFLATE_STRICT
-	dmax = state->dmax;
-	#endif
-	wsize = state->wsize;
-	whave = state->whave;
-	wnext = state->wnext;
-	window = state->window;
-	hold = state->hold;
-	bits = state->bits;
-	lcode = state->lencode;
-	dcode = state->distcode;
-	lmask = (1U << state->lenbits) - 1;
-	dmask = (1U << state->distbits) - 1;
+    /* copy state to local variables */
+    state = (struct inflate_state FAR *)strm->state;
+    in = strm->next_in;
+    last = in + (strm->avail_in - 5);
+    out = strm->next_out;
+    beg = out - (start - strm->avail_out);
+    end = out + (strm->avail_out - 257);
+#ifdef INFLATE_STRICT
+    dmax = state->dmax;
+#endif
+    wsize = state->wsize;
+    whave = state->whave;
+    wnext = state->wnext;
+    window = state->window;
+    hold = state->hold;
+    bits = state->bits;
+    lcode = state->lencode;
+    dcode = state->distcode;
+    lmask = (1U << state->lenbits) - 1;
+    dmask = (1U << state->distbits) - 1;
 
-	/* decode literals and length/distances until end-of-block or not enough
-		input data or output space */
-	do {
-		if (bits < 15) {
-			hold += (unsigned long)(PUP(in)) << bits;
-			bits += 8;
-			hold += (unsigned long)(PUP(in)) << bits;
-			bits += 8;
-		}
-		here = lcode[hold & lmask];
-	dolen:
-		op = (unsigned)(here.bits);
-		hold >>= op;
-		bits -= op;
-		op = (unsigned)(here.op);
-		if (op == 0) {                          /* literal */
-			Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-				"inflate:         literal '%c'\n" :
-				"inflate:         literal 0x%02x\n", here.val));
-			PUP(out) = (unsigned char)(here.val);
-		}
-		else if (op & 16) {                     /* length base */
-			len = (unsigned)(here.val);
-			op &= 15;                           /* number of extra bits */
-			if (op) {
-				if (bits < op) {
-					hold += (unsigned long)(PUP(in)) << bits;
-					bits += 8;
-				}
-				len += (unsigned)hold & ((1U << op) - 1);
-				hold >>= op;
-				bits -= op;
-			}
-			Tracevv((stderr, "inflate:         length %u\n", len));
-			if (bits < 15) {
-				hold += (unsigned long)(PUP(in)) << bits;
-				bits += 8;
-				hold += (unsigned long)(PUP(in)) << bits;
-				bits += 8;
-			}
-			here = dcode[hold & dmask];
-		dodist:
-			op = (unsigned)(here.bits);
-			hold >>= op;
-			bits -= op;
-			op = (unsigned)(here.op);
-			if (op & 16) {                      /* distance base */
-				dist = (unsigned)(here.val);
-				op &= 15;                       /* number of extra bits */
-				if (bits < op) {
-					hold += (unsigned long)(PUP(in)) << bits;
-					bits += 8;
-					if (bits < op) {
-						hold += (unsigned long)(PUP(in)) << bits;
-						bits += 8;
-					}
-				}
-				dist += (unsigned)hold & ((1U << op) - 1);
-				#ifdef INFLATE_STRICT
-				if (dist > dmax) {
-					strm->msg = (char *)"invalid distance too far back";
-					state->mode = BAD;
-					break;
-				}
-				#endif
-				hold >>= op;
-				bits -= op;
-				Tracevv((stderr, "inflate:         distance %u\n", dist));
-				op = (unsigned)(out - beg);     /* max distance in output */
-				if (dist > op) {                /* see if copy from window */
-					op = dist - op;             /* distance back in window */
-					if (op > whave) {
-						if (state->sane) {
-							strm->msg =
-								(char *)"invalid distance too far back";
-							state->mode = BAD;
-							break;
-						}
-						#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
-						if (len <= op - whave) {
-							do {
-								PUP(out) = 0;
-							} while (--len);
-							continue;
-						}
-						len -= op - whave;
-						do {
-							PUP(out) = 0;
-						} while (--op > whave);
-						if (op == 0) {
-							from = out - dist;
-							do {
-								PUP(out) = PUP(from);
-							} while (--len);
-							continue;
-						}
-						#endif
-					}
-					from = window - OFF;
-					if (wnext == 0) {           /* very common case */
-						from += wsize - op;
-						if (op < len) {         /* some from window */
-							len -= op;
-							do {
-								PUP(out) = PUP(from);
-							} while (--op);
-							from = out - dist;  /* rest from output */
-						}
-					}
-					else if (wnext < op) {      /* wrap around window */
-						from += wsize + wnext - op;
-						op -= wnext;
-						if (op < len) {         /* some from end of window */
-							len -= op;
-							do {
-								PUP(out) = PUP(from);
-							} while (--op);
-							from = window - OFF;
-							if (wnext < len) {  /* some from start of window */
-								op = wnext;
-								len -= op;
-								do {
-									PUP(out) = PUP(from);
-								} while (--op);
-								from = out - dist;      /* rest from output */
-							}
-						}
-					}
-					else {                      /* contiguous in window */
-						from += wnext - op;
-						if (op < len) {         /* some from window */
-							len -= op;
-							do {
-								PUP(out) = PUP(from);
-							} while (--op);
-							from = out - dist;  /* rest from output */
-						}
-					}
-					while (len > 2) {
-						PUP(out) = PUP(from);
-						PUP(out) = PUP(from);
-						PUP(out) = PUP(from);
-						len -= 3;
-					}
-					if (len) {
-						PUP(out) = PUP(from);
-						if (len > 1)
-							PUP(out) = PUP(from);
-					}
-				}
-				else {
-					from = out - dist;          /* copy direct from output */
-					do {                        /* minimum length is three */
-						PUP(out) = PUP(from);
-						PUP(out) = PUP(from);
-						PUP(out) = PUP(from);
-						len -= 3;
-					} while (len > 2);
-					if (len) {
-						PUP(out) = PUP(from);
-						if (len > 1)
-							PUP(out) = PUP(from);
-					}
-				}
-			}
-			else if ((op & 64) == 0) {          /* 2nd level distance code */
-				here = dcode[here.val + (hold & ((1U << op) - 1))];
-				goto dodist;
-			}
-			else {
-				strm->msg = (char *)"invalid distance code";
-				state->mode = BAD;
-				break;
-			}
-		}
-		else if ((op & 64) == 0) {              /* 2nd level length code */
-			here = lcode[here.val + (hold & ((1U << op) - 1))];
-			goto dolen;
-		}
-		else if (op & 32) {                     /* end-of-block */
-			Tracevv((stderr, "inflate:         end of block\n"));
-			state->mode = TYPE;
-			break;
-		}
-		else {
-			strm->msg = (char *)"invalid literal/length code";
-			state->mode = BAD;
-			break;
-		}
-	} while (in < last && out < end);
+    /* decode literals and length/distances until end-of-block or not enough
+       input data or output space */
+    do {
+        if (bits < 15) {
+            hold += (unsigned long)(*in++) << bits;
+            bits += 8;
+            hold += (unsigned long)(*in++) << bits;
+            bits += 8;
+        }
+        here = lcode[hold & lmask];
+      dolen:
+        op = (unsigned)(here.bits);
+        hold >>= op;
+        bits -= op;
+        op = (unsigned)(here.op);
+        if (op == 0) {                          /* literal */
+            Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
+                    "inflate:         literal '%c'\n" :
+                    "inflate:         literal 0x%02x\n", here.val));
+            *out++ = (unsigned char)(here.val);
+        }
+        else if (op & 16) {                     /* length base */
+            len = (unsigned)(here.val);
+            op &= 15;                           /* number of extra bits */
+            if (op) {
+                if (bits < op) {
+                    hold += (unsigned long)(*in++) << bits;
+                    bits += 8;
+                }
+                len += (unsigned)hold & ((1U << op) - 1);
+                hold >>= op;
+                bits -= op;
+            }
+            Tracevv((stderr, "inflate:         length %u\n", len));
+            if (bits < 15) {
+                hold += (unsigned long)(*in++) << bits;
+                bits += 8;
+                hold += (unsigned long)(*in++) << bits;
+                bits += 8;
+            }
+            here = dcode[hold & dmask];
+          dodist:
+            op = (unsigned)(here.bits);
+            hold >>= op;
+            bits -= op;
+            op = (unsigned)(here.op);
+            if (op & 16) {                      /* distance base */
+                dist = (unsigned)(here.val);
+                op &= 15;                       /* number of extra bits */
+                if (bits < op) {
+                    hold += (unsigned long)(*in++) << bits;
+                    bits += 8;
+                    if (bits < op) {
+                        hold += (unsigned long)(*in++) << bits;
+                        bits += 8;
+                    }
+                }
+                dist += (unsigned)hold & ((1U << op) - 1);
+#ifdef INFLATE_STRICT
+                if (dist > dmax) {
+                    strm->msg = (char *)"invalid distance too far back";
+                    state->mode = BAD;
+                    break;
+                }
+#endif
+                hold >>= op;
+                bits -= op;
+                Tracevv((stderr, "inflate:         distance %u\n", dist));
+                op = (unsigned)(out - beg);     /* max distance in output */
+                if (dist > op) {                /* see if copy from window */
+                    op = dist - op;             /* distance back in window */
+                    if (op > whave) {
+                        if (state->sane) {
+                            strm->msg =
+                                (char *)"invalid distance too far back";
+                            state->mode = BAD;
+                            break;
+                        }
+#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+                        if (len <= op - whave) {
+                            do {
+                                *out++ = 0;
+                            } while (--len);
+                            continue;
+                        }
+                        len -= op - whave;
+                        do {
+                            *out++ = 0;
+                        } while (--op > whave);
+                        if (op == 0) {
+                            from = out - dist;
+                            do {
+                                *out++ = *from++;
+                            } while (--len);
+                            continue;
+                        }
+#endif
+                    }
+                    from = window;
+                    if (wnext == 0) {           /* very common case */
+                        from += wsize - op;
+                        if (op < len) {         /* some from window */
+                            len -= op;
+                            do {
+                                *out++ = *from++;
+                            } while (--op);
+                            from = out - dist;  /* rest from output */
+                        }
+                    }
+                    else if (wnext < op) {      /* wrap around window */
+                        from += wsize + wnext - op;
+                        op -= wnext;
+                        if (op < len) {         /* some from end of window */
+                            len -= op;
+                            do {
+                                *out++ = *from++;
+                            } while (--op);
+                            from = window;
+                            if (wnext < len) {  /* some from start of window */
+                                op = wnext;
+                                len -= op;
+                                do {
+                                    *out++ = *from++;
+                                } while (--op);
+                                from = out - dist;      /* rest from output */
+                            }
+                        }
+                    }
+                    else {                      /* contiguous in window */
+                        from += wnext - op;
+                        if (op < len) {         /* some from window */
+                            len -= op;
+                            do {
+                                *out++ = *from++;
+                            } while (--op);
+                            from = out - dist;  /* rest from output */
+                        }
+                    }
+                    while (len > 2) {
+                        *out++ = *from++;
+                        *out++ = *from++;
+                        *out++ = *from++;
+                        len -= 3;
+                    }
+                    if (len) {
+                        *out++ = *from++;
+                        if (len > 1)
+                            *out++ = *from++;
+                    }
+                }
+                else {
+                    from = out - dist;          /* copy direct from output */
+                    do {                        /* minimum length is three */
+                        *out++ = *from++;
+                        *out++ = *from++;
+                        *out++ = *from++;
+                        len -= 3;
+                    } while (len > 2);
+                    if (len) {
+                        *out++ = *from++;
+                        if (len > 1)
+                            *out++ = *from++;
+                    }
+                }
+            }
+            else if ((op & 64) == 0) {          /* 2nd level distance code */
+                here = dcode[here.val + (hold & ((1U << op) - 1))];
+                goto dodist;
+            }
+            else {
+                strm->msg = (char *)"invalid distance code";
+                state->mode = BAD;
+                break;
+            }
+        }
+        else if ((op & 64) == 0) {              /* 2nd level length code */
+            here = lcode[here.val + (hold & ((1U << op) - 1))];
+            goto dolen;
+        }
+        else if (op & 32) {                     /* end-of-block */
+            Tracevv((stderr, "inflate:         end of block\n"));
+            state->mode = TYPE;
+            break;
+        }
+        else {
+            strm->msg = (char *)"invalid literal/length code";
+            state->mode = BAD;
+            break;
+        }
+    } while (in < last && out < end);
 
-	/* return unused bytes (on entry, bits < 8, so in won't go too far back) */
-	len = bits >> 3;
-	in -= len;
-	bits -= len << 3;
-	hold &= (1U << bits) - 1;
+    /* return unused bytes (on entry, bits < 8, so in won't go too far back) */
+    len = bits >> 3;
+    in -= len;
+    bits -= len << 3;
+    hold &= (1U << bits) - 1;
 
-	/* update state and return */
-	strm->next_in = in + OFF;
-	strm->next_out = out + OFF;
-	strm->avail_in = (unsigned)(in < last ? 5 + (last - in) : 5 - (in - last));
-	strm->avail_out = (unsigned)(out < end ?
-		257 + (end - out) : 257 - (out - end));
-	state->hold = hold;
-	state->bits = bits;
-	return;
+    /* update state and return */
+    strm->next_in = in;
+    strm->next_out = out;
+    strm->avail_in = (unsigned)(in < last ? 5 + (last - in) : 5 - (in - last));
+    strm->avail_out = (unsigned)(out < end ?
+                                 257 + (end - out) : 257 - (out - end));
+    state->hold = hold;
+    state->bits = bits;
+    return;
 }
 
 /*
-	inflate_fast() speedups that turned out slower (on a PowerPC G3 750CXe):
-	- Using bit fields for code structure
-	- Different op definition to avoid & for extra bits (do & for table bits)
-	- Three separate decoding do-loops for direct, window, and wnext == 0
-	- Special case for distance > 1 copies to do overlapped load and store copy
-	- Explicit branch predictions (based on measured branch probabilities)
-	- Deferring match copy and interspersed it with decoding subsequent codes
-	- Swapping literal/length else
-	- Swapping window/direct else
-	- Larger unrolled copy loops (three is about right)
-	- Moving len -= 3 statement into middle of loop
+   inflate_fast() speedups that turned out slower (on a PowerPC G3 750CXe):
+   - Using bit fields for code structure
+   - Different op definition to avoid & for extra bits (do & for table bits)
+   - Three separate decoding do-loops for direct, window, and wnext == 0
+   - Special case for distance > 1 copies to do overlapped load and store copy
+   - Explicit branch predictions (based on measured branch probabilities)
+   - Deferring match copy and interspersed it with decoding subsequent codes
+   - Swapping literal/length else
+   - Swapping window/direct else
+   - Larger unrolled copy loops (three is about right)
+   - Moving len -= 3 statement into middle of loop
  */
 
 #endif /* !ASMINF */

--- a/libs/zlib/src/inflate.c
+++ b/libs/zlib/src/inflate.c
@@ -1,5 +1,5 @@
 /* inflate.c -- zlib decompression
- * Copyright (C) 1995-2012 Mark Adler
+ * Copyright (C) 1995-2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -91,90 +91,105 @@
 #  endif
 #endif
 
- /* function prototypes */
+/* function prototypes */
+local int inflateStateCheck OF((z_streamp strm));
 local void fixedtables OF((struct inflate_state FAR *state));
 local int updatewindow OF((z_streamp strm, const unsigned char FAR *end,
-	unsigned copy));
+                           unsigned copy));
 #ifdef BUILDFIXED
-void makefixed OF((void));
+   void makefixed OF((void));
 #endif
 local unsigned syncsearch OF((unsigned FAR *have, const unsigned char FAR *buf,
-	unsigned len));
+                              unsigned len));
+
+local int inflateStateCheck(strm)
+z_streamp strm;
+{
+    struct inflate_state FAR *state;
+    if (strm == Z_NULL ||
+        strm->zalloc == (alloc_func)0 || strm->zfree == (free_func)0)
+        return 1;
+    state = (struct inflate_state FAR *)strm->state;
+    if (state == Z_NULL || state->strm != strm ||
+        state->mode < HEAD || state->mode > SYNC)
+        return 1;
+    return 0;
+}
 
 int ZEXPORT inflateResetKeep(strm)
 z_streamp strm;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	strm->total_in = strm->total_out = state->total = 0;
-	strm->msg = Z_NULL;
-	if (state->wrap)        /* to support ill-conceived Java test suite */
-		strm->adler = state->wrap & 1;
-	state->mode = HEAD;
-	state->last = 0;
-	state->havedict = 0;
-	state->dmax = 32768U;
-	state->head = Z_NULL;
-	state->hold = 0;
-	state->bits = 0;
-	state->lencode = state->distcode = state->next = state->codes;
-	state->sane = 1;
-	state->back = -1;
-	Tracev((stderr, "inflate: reset\n"));
-	return Z_OK;
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    strm->total_in = strm->total_out = state->total = 0;
+    strm->msg = Z_NULL;
+    if (state->wrap)        /* to support ill-conceived Java test suite */
+        strm->adler = state->wrap & 1;
+    state->mode = HEAD;
+    state->last = 0;
+    state->havedict = 0;
+    state->dmax = 32768U;
+    state->head = Z_NULL;
+    state->hold = 0;
+    state->bits = 0;
+    state->lencode = state->distcode = state->next = state->codes;
+    state->sane = 1;
+    state->back = -1;
+    Tracev((stderr, "inflate: reset\n"));
+    return Z_OK;
 }
 
 int ZEXPORT inflateReset(strm)
 z_streamp strm;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	state->wsize = 0;
-	state->whave = 0;
-	state->wnext = 0;
-	return inflateResetKeep(strm);
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    state->wsize = 0;
+    state->whave = 0;
+    state->wnext = 0;
+    return inflateResetKeep(strm);
 }
 
 int ZEXPORT inflateReset2(strm, windowBits)
 z_streamp strm;
 int windowBits;
 {
-	int wrap;
-	struct inflate_state FAR *state;
+    int wrap;
+    struct inflate_state FAR *state;
 
-	/* get the state */
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
+    /* get the state */
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
 
-	/* extract wrap request from windowBits parameter */
-	if (windowBits < 0) {
-		wrap = 0;
-		windowBits = -windowBits;
-	}
-	else {
-		wrap = (windowBits >> 4) + 1;
-		#ifdef GUNZIP
-		if (windowBits < 48)
-			windowBits &= 15;
-		#endif
-	}
+    /* extract wrap request from windowBits parameter */
+    if (windowBits < 0) {
+        wrap = 0;
+        windowBits = -windowBits;
+    }
+    else {
+        wrap = (windowBits >> 4) + 5;
+#ifdef GUNZIP
+        if (windowBits < 48)
+            windowBits &= 15;
+#endif
+    }
 
-	/* set number of window bits, free window if different */
-	if (windowBits && (windowBits < 8 || windowBits > 15))
-		return Z_STREAM_ERROR;
-	if (state->window != Z_NULL && state->wbits != (unsigned)windowBits) {
-		ZFREE(strm, state->window);
-		state->window = Z_NULL;
-	}
+    /* set number of window bits, free window if different */
+    if (windowBits && (windowBits < 8 || windowBits > 15))
+        return Z_STREAM_ERROR;
+    if (state->window != Z_NULL && state->wbits != (unsigned)windowBits) {
+        ZFREE(strm, state->window);
+        state->window = Z_NULL;
+    }
 
-	/* update state and reset the rest of it */
-	state->wrap = wrap;
-	state->wbits = (unsigned)windowBits;
-	return inflateReset(strm);
+    /* update state and reset the rest of it */
+    state->wrap = wrap;
+    state->wbits = (unsigned)windowBits;
+    return inflateReset(strm);
 }
 
 int ZEXPORT inflateInit2_(strm, windowBits, version, stream_size)
@@ -183,40 +198,42 @@ int windowBits;
 const char *version;
 int stream_size;
 {
-	int ret;
-	struct inflate_state FAR *state;
+    int ret;
+    struct inflate_state FAR *state;
 
-	if (version == Z_NULL || version[0] != ZLIB_VERSION[0] ||
-		stream_size != (int)(sizeof(z_stream)))
-		return Z_VERSION_ERROR;
-	if (strm == Z_NULL) return Z_STREAM_ERROR;
-	strm->msg = Z_NULL;                 /* in case we return an error */
-	if (strm->zalloc == (alloc_func)0) {
-		#ifdef Z_SOLO
-		return Z_STREAM_ERROR;
-		#else
-		strm->zalloc = zcalloc;
-		strm->opaque = (voidpf)0;
-		#endif
-	}
-	if (strm->zfree == (free_func)0)
-		#ifdef Z_SOLO
-		return Z_STREAM_ERROR;
-	#else
-		strm->zfree = zcfree;
-	#endif
-	state = (struct inflate_state FAR *)
-		ZALLOC(strm, 1, sizeof(struct inflate_state));
-	if (state == Z_NULL) return Z_MEM_ERROR;
-	Tracev((stderr, "inflate: allocated\n"));
-	strm->state = (struct internal_state FAR *)state;
-	state->window = Z_NULL;
-	ret = inflateReset2(strm, windowBits);
-	if (ret != Z_OK) {
-		ZFREE(strm, state);
-		strm->state = Z_NULL;
-	}
-	return ret;
+    if (version == Z_NULL || version[0] != ZLIB_VERSION[0] ||
+        stream_size != (int)(sizeof(z_stream)))
+        return Z_VERSION_ERROR;
+    if (strm == Z_NULL) return Z_STREAM_ERROR;
+    strm->msg = Z_NULL;                 /* in case we return an error */
+    if (strm->zalloc == (alloc_func)0) {
+#ifdef Z_SOLO
+        return Z_STREAM_ERROR;
+#else
+        strm->zalloc = zcalloc;
+        strm->opaque = (voidpf)0;
+#endif
+    }
+    if (strm->zfree == (free_func)0)
+#ifdef Z_SOLO
+        return Z_STREAM_ERROR;
+#else
+        strm->zfree = zcfree;
+#endif
+    state = (struct inflate_state FAR *)
+            ZALLOC(strm, 1, sizeof(struct inflate_state));
+    if (state == Z_NULL) return Z_MEM_ERROR;
+    Tracev((stderr, "inflate: allocated\n"));
+    strm->state = (struct internal_state FAR *)state;
+    state->strm = strm;
+    state->window = Z_NULL;
+    state->mode = HEAD;     /* to pass state test in inflateReset2() */
+    ret = inflateReset2(strm, windowBits);
+    if (ret != Z_OK) {
+        ZFREE(strm, state);
+        strm->state = Z_NULL;
+    }
+    return ret;
 }
 
 int ZEXPORT inflateInit_(strm, version, stream_size)
@@ -224,7 +241,7 @@ z_streamp strm;
 const char *version;
 int stream_size;
 {
-	return inflateInit2_(strm, DEF_WBITS, version, stream_size);
+    return inflateInit2_(strm, DEF_WBITS, version, stream_size);
 }
 
 int ZEXPORT inflatePrime(strm, bits, value)
@@ -232,198 +249,198 @@ z_streamp strm;
 int bits;
 int value;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	if (bits < 0) {
-		state->hold = 0;
-		state->bits = 0;
-		return Z_OK;
-	}
-	if (bits > 16 || state->bits + bits > 32) return Z_STREAM_ERROR;
-	value &= (1L << bits) - 1;
-	state->hold += value << state->bits;
-	state->bits += bits;
-	return Z_OK;
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    if (bits < 0) {
+        state->hold = 0;
+        state->bits = 0;
+        return Z_OK;
+    }
+    if (bits > 16 || state->bits + (uInt)bits > 32) return Z_STREAM_ERROR;
+    value &= (1L << bits) - 1;
+    state->hold += (unsigned)value << state->bits;
+    state->bits += (uInt)bits;
+    return Z_OK;
 }
 
 /*
-	Return state with length and distance decoding tables and index sizes set to
-	fixed code decoding.  Normally this returns fixed tables from inffixed.h.
-	If BUILDFIXED is defined, then instead this routine builds the tables the
-	first time it's called, and returns those tables the first time and
-	thereafter.  This reduces the size of the code by about 2K bytes, in
-	exchange for a little execution time.  However, BUILDFIXED should not be
-	used for threaded applications, since the rewriting of the tables and virgin
-	may not be thread-safe.
+   Return state with length and distance decoding tables and index sizes set to
+   fixed code decoding.  Normally this returns fixed tables from inffixed.h.
+   If BUILDFIXED is defined, then instead this routine builds the tables the
+   first time it's called, and returns those tables the first time and
+   thereafter.  This reduces the size of the code by about 2K bytes, in
+   exchange for a little execution time.  However, BUILDFIXED should not be
+   used for threaded applications, since the rewriting of the tables and virgin
+   may not be thread-safe.
  */
 local void fixedtables(state)
 struct inflate_state FAR *state;
 {
-	#ifdef BUILDFIXED
-	static int virgin = 1;
-	static code *lenfix, *distfix;
-	static code fixed[544];
+#ifdef BUILDFIXED
+    static int virgin = 1;
+    static code *lenfix, *distfix;
+    static code fixed[544];
 
-	/* build fixed huffman tables if first call (may not be thread safe) */
-	if (virgin) {
-		unsigned sym, bits;
-		static code *next;
+    /* build fixed huffman tables if first call (may not be thread safe) */
+    if (virgin) {
+        unsigned sym, bits;
+        static code *next;
 
-		/* literal/length table */
-		sym = 0;
-		while (sym < 144) state->lens[sym++] = 8;
-		while (sym < 256) state->lens[sym++] = 9;
-		while (sym < 280) state->lens[sym++] = 7;
-		while (sym < 288) state->lens[sym++] = 8;
-		next = fixed;
-		lenfix = next;
-		bits = 9;
-		inflate_table(LENS, state->lens, 288, &(next), &(bits), state->work);
+        /* literal/length table */
+        sym = 0;
+        while (sym < 144) state->lens[sym++] = 8;
+        while (sym < 256) state->lens[sym++] = 9;
+        while (sym < 280) state->lens[sym++] = 7;
+        while (sym < 288) state->lens[sym++] = 8;
+        next = fixed;
+        lenfix = next;
+        bits = 9;
+        inflate_table(LENS, state->lens, 288, &(next), &(bits), state->work);
 
-		/* distance table */
-		sym = 0;
-		while (sym < 32) state->lens[sym++] = 5;
-		distfix = next;
-		bits = 5;
-		inflate_table(DISTS, state->lens, 32, &(next), &(bits), state->work);
+        /* distance table */
+        sym = 0;
+        while (sym < 32) state->lens[sym++] = 5;
+        distfix = next;
+        bits = 5;
+        inflate_table(DISTS, state->lens, 32, &(next), &(bits), state->work);
 
-		/* do this just once */
-		virgin = 0;
-	}
-	#else /* !BUILDFIXED */
-	#   include "inffixed.h"
-	#endif /* BUILDFIXED */
-	state->lencode = lenfix;
-	state->lenbits = 9;
-	state->distcode = distfix;
-	state->distbits = 5;
+        /* do this just once */
+        virgin = 0;
+    }
+#else /* !BUILDFIXED */
+#   include "inffixed.h"
+#endif /* BUILDFIXED */
+    state->lencode = lenfix;
+    state->lenbits = 9;
+    state->distcode = distfix;
+    state->distbits = 5;
 }
 
 #ifdef MAKEFIXED
 #include <stdio.h>
 
 /*
-	Write out the inffixed.h that is #include'd above.  Defining MAKEFIXED also
-	defines BUILDFIXED, so the tables are built on the fly.  makefixed() writes
-	those tables to stdout, which would be piped to inffixed.h.  A small program
-	can simply call makefixed to do this:
+   Write out the inffixed.h that is #include'd above.  Defining MAKEFIXED also
+   defines BUILDFIXED, so the tables are built on the fly.  makefixed() writes
+   those tables to stdout, which would be piped to inffixed.h.  A small program
+   can simply call makefixed to do this:
 
-	 void makefixed(void);
+    void makefixed(void);
 
-	 int main(void)
-	 {
-		  makefixed();
-		  return 0;
-	 }
+    int main(void)
+    {
+        makefixed();
+        return 0;
+    }
 
-	Then that can be linked with zlib built with MAKEFIXED defined and run:
+   Then that can be linked with zlib built with MAKEFIXED defined and run:
 
-	 a.out > inffixed.h
+    a.out > inffixed.h
  */
 void makefixed()
 {
-	unsigned low, size;
-	struct inflate_state state;
+    unsigned low, size;
+    struct inflate_state state;
 
-	fixedtables(&state);
-	puts("    /* inffixed.h -- table for decoding fixed codes");
-	puts("     * Generated automatically by makefixed().");
-	puts("     */");
-	puts("");
-	puts("    /* WARNING: this file should *not* be used by applications.");
-	puts("       It is part of the implementation of this library and is");
-	puts("       subject to change. Applications should only use zlib.h.");
-	puts("     */");
-	puts("");
-	size = 1U << 9;
-	printf("    static const code lenfix[%u] = {", size);
-	low = 0;
-	for (;;) {
-		if ((low % 7) == 0) printf("\n        ");
-		printf("{%u,%u,%d}", (low & 127) == 99 ? 64 : state.lencode[low].op,
-			state.lencode[low].bits, state.lencode[low].val);
-		if (++low == size) break;
-		putchar(',');
-	}
-	puts("\n    };");
-	size = 1U << 5;
-	printf("\n    static const code distfix[%u] = {", size);
-	low = 0;
-	for (;;) {
-		if ((low % 6) == 0) printf("\n        ");
-		printf("{%u,%u,%d}", state.distcode[low].op, state.distcode[low].bits,
-			state.distcode[low].val);
-		if (++low == size) break;
-		putchar(',');
-	}
-	puts("\n    };");
+    fixedtables(&state);
+    puts("    /* inffixed.h -- table for decoding fixed codes");
+    puts("     * Generated automatically by makefixed().");
+    puts("     */");
+    puts("");
+    puts("    /* WARNING: this file should *not* be used by applications.");
+    puts("       It is part of the implementation of this library and is");
+    puts("       subject to change. Applications should only use zlib.h.");
+    puts("     */");
+    puts("");
+    size = 1U << 9;
+    printf("    static const code lenfix[%u] = {", size);
+    low = 0;
+    for (;;) {
+        if ((low % 7) == 0) printf("\n        ");
+        printf("{%u,%u,%d}", (low & 127) == 99 ? 64 : state.lencode[low].op,
+               state.lencode[low].bits, state.lencode[low].val);
+        if (++low == size) break;
+        putchar(',');
+    }
+    puts("\n    };");
+    size = 1U << 5;
+    printf("\n    static const code distfix[%u] = {", size);
+    low = 0;
+    for (;;) {
+        if ((low % 6) == 0) printf("\n        ");
+        printf("{%u,%u,%d}", state.distcode[low].op, state.distcode[low].bits,
+               state.distcode[low].val);
+        if (++low == size) break;
+        putchar(',');
+    }
+    puts("\n    };");
 }
 #endif /* MAKEFIXED */
 
 /*
-	Update the window with the last wsize (normally 32K) bytes written before
-	returning.  If window does not exist yet, create it.  This is only called
-	when a window is already in use, or when output has been written during this
-	inflate call, but the end of the deflate stream has not been reached yet.
-	It is also called to create a window for dictionary data when a dictionary
-	is loaded.
+   Update the window with the last wsize (normally 32K) bytes written before
+   returning.  If window does not exist yet, create it.  This is only called
+   when a window is already in use, or when output has been written during this
+   inflate call, but the end of the deflate stream has not been reached yet.
+   It is also called to create a window for dictionary data when a dictionary
+   is loaded.
 
-	Providing output buffers larger than 32K to inflate() should provide a speed
-	advantage, since only the last 32K of output is copied to the sliding window
-	upon return from inflate(), and since all distances after the first 32K of
-	output will fall in the output data, making match copies simpler and faster.
-	The advantage may be dependent on the size of the processor's data caches.
+   Providing output buffers larger than 32K to inflate() should provide a speed
+   advantage, since only the last 32K of output is copied to the sliding window
+   upon return from inflate(), and since all distances after the first 32K of
+   output will fall in the output data, making match copies simpler and faster.
+   The advantage may be dependent on the size of the processor's data caches.
  */
 local int updatewindow(strm, end, copy)
 z_streamp strm;
 const Bytef *end;
 unsigned copy;
 {
-	struct inflate_state FAR *state;
-	unsigned dist;
+    struct inflate_state FAR *state;
+    unsigned dist;
 
-	state = (struct inflate_state FAR *)strm->state;
+    state = (struct inflate_state FAR *)strm->state;
 
-	/* if it hasn't been done already, allocate space for the window */
-	if (state->window == Z_NULL) {
-		state->window = (unsigned char FAR *)
-			ZALLOC(strm, 1U << state->wbits,
-				sizeof(unsigned char));
-		if (state->window == Z_NULL) return 1;
-	}
+    /* if it hasn't been done already, allocate space for the window */
+    if (state->window == Z_NULL) {
+        state->window = (unsigned char FAR *)
+                        ZALLOC(strm, 1U << state->wbits,
+                               sizeof(unsigned char));
+        if (state->window == Z_NULL) return 1;
+    }
 
-	/* if window not in use yet, initialize */
-	if (state->wsize == 0) {
-		state->wsize = 1U << state->wbits;
-		state->wnext = 0;
-		state->whave = 0;
-	}
+    /* if window not in use yet, initialize */
+    if (state->wsize == 0) {
+        state->wsize = 1U << state->wbits;
+        state->wnext = 0;
+        state->whave = 0;
+    }
 
-	/* copy state->wsize or less output bytes into the circular window */
-	if (copy >= state->wsize) {
-		zmemcpy(state->window, end - state->wsize, state->wsize);
-		state->wnext = 0;
-		state->whave = state->wsize;
-	}
-	else {
-		dist = state->wsize - state->wnext;
-		if (dist > copy) dist = copy;
-		zmemcpy(state->window + state->wnext, end - copy, dist);
-		copy -= dist;
-		if (copy) {
-			zmemcpy(state->window, end - copy, copy);
-			state->wnext = copy;
-			state->whave = state->wsize;
-		}
-		else {
-			state->wnext += dist;
-			if (state->wnext == state->wsize) state->wnext = 0;
-			if (state->whave < state->wsize) state->whave += dist;
-		}
-	}
-	return 0;
+    /* copy state->wsize or less output bytes into the circular window */
+    if (copy >= state->wsize) {
+        zmemcpy(state->window, end - state->wsize, state->wsize);
+        state->wnext = 0;
+        state->whave = state->wsize;
+    }
+    else {
+        dist = state->wsize - state->wnext;
+        if (dist > copy) dist = copy;
+        zmemcpy(state->window + state->wnext, end - copy, dist);
+        copy -= dist;
+        if (copy) {
+            zmemcpy(state->window, end - copy, copy);
+            state->wnext = copy;
+            state->whave = state->wsize;
+        }
+        else {
+            state->wnext += dist;
+            if (state->wnext == state->wsize) state->wnext = 0;
+            if (state->whave < state->wsize) state->whave += dist;
+        }
+    }
+    return 0;
 }
 
 /* Macros for inflate(): */
@@ -485,7 +502,7 @@ unsigned copy;
     } while (0)
 
 /* Get a byte of input into the bit accumulator, or return from inflate()
-	if there is no input available. */
+   if there is no input available. */
 #define PULLBYTE() \
     do { \
         if (have == 0) goto inf_leave; \
@@ -494,15 +511,15 @@ unsigned copy;
         bits += 8; \
     } while (0)
 
-	/* Assure that there are at least n bits in the bit accumulator.  If there is
-		not enough available input to do that, then return from inflate(). */
+/* Assure that there are at least n bits in the bit accumulator.  If there is
+   not enough available input to do that, then return from inflate(). */
 #define NEEDBITS(n) \
     do { \
         while (bits < (unsigned)(n)) \
             PULLBYTE(); \
     } while (0)
 
-		/* Return the low n bits of the bit accumulator (n < 16) */
+/* Return the low n bits of the bit accumulator (n < 16) */
 #define BITS(n) \
     ((unsigned)hold & ((1U << (n)) - 1))
 
@@ -521,748 +538,754 @@ unsigned copy;
     } while (0)
 
 /*
-	inflate() uses a state machine to process as much input data and generate as
-	much output data as possible before returning.  The state machine is
-	structured roughly as follows:
+   inflate() uses a state machine to process as much input data and generate as
+   much output data as possible before returning.  The state machine is
+   structured roughly as follows:
 
-	 for (;;) switch (state) {
-	 ...
-	 case STATEn:
-		  if (not enough input data or output space to make progress)
-				return;
-		  ... make progress ...
-		  state = STATEm;
-		  break;
-	 ...
-	 }
+    for (;;) switch (state) {
+    ...
+    case STATEn:
+        if (not enough input data or output space to make progress)
+            return;
+        ... make progress ...
+        state = STATEm;
+        break;
+    ...
+    }
 
-	so when inflate() is called again, the same case is attempted again, and
-	if the appropriate resources are provided, the machine proceeds to the
-	next state.  The NEEDBITS() macro is usually the way the state evaluates
-	whether it can proceed or should return.  NEEDBITS() does the return if
-	the requested bits are not available.  The typical use of the BITS macros
-	is:
+   so when inflate() is called again, the same case is attempted again, and
+   if the appropriate resources are provided, the machine proceeds to the
+   next state.  The NEEDBITS() macro is usually the way the state evaluates
+   whether it can proceed or should return.  NEEDBITS() does the return if
+   the requested bits are not available.  The typical use of the BITS macros
+   is:
 
-		  NEEDBITS(n);
-		  ... do something with BITS(n) ...
-		  DROPBITS(n);
+        NEEDBITS(n);
+        ... do something with BITS(n) ...
+        DROPBITS(n);
 
-	where NEEDBITS(n) either returns from inflate() if there isn't enough
-	input left to load n bits into the accumulator, or it continues.  BITS(n)
-	gives the low n bits in the accumulator.  When done, DROPBITS(n) drops
-	the low n bits off the accumulator.  INITBITS() clears the accumulator
-	and sets the number of available bits to zero.  BYTEBITS() discards just
-	enough bits to put the accumulator on a byte boundary.  After BYTEBITS()
-	and a NEEDBITS(8), then BITS(8) would return the next byte in the stream.
+   where NEEDBITS(n) either returns from inflate() if there isn't enough
+   input left to load n bits into the accumulator, or it continues.  BITS(n)
+   gives the low n bits in the accumulator.  When done, DROPBITS(n) drops
+   the low n bits off the accumulator.  INITBITS() clears the accumulator
+   and sets the number of available bits to zero.  BYTEBITS() discards just
+   enough bits to put the accumulator on a byte boundary.  After BYTEBITS()
+   and a NEEDBITS(8), then BITS(8) would return the next byte in the stream.
 
-	NEEDBITS(n) uses PULLBYTE() to get an available byte of input, or to return
-	if there is no input available.  The decoding of variable length codes uses
-	PULLBYTE() directly in order to pull just enough bytes to decode the next
-	code, and no more.
+   NEEDBITS(n) uses PULLBYTE() to get an available byte of input, or to return
+   if there is no input available.  The decoding of variable length codes uses
+   PULLBYTE() directly in order to pull just enough bytes to decode the next
+   code, and no more.
 
-	Some states loop until they get enough input, making sure that enough
-	state information is maintained to continue the loop where it left off
-	if NEEDBITS() returns in the loop.  For example, want, need, and keep
-	would all have to actually be part of the saved state in case NEEDBITS()
-	returns:
+   Some states loop until they get enough input, making sure that enough
+   state information is maintained to continue the loop where it left off
+   if NEEDBITS() returns in the loop.  For example, want, need, and keep
+   would all have to actually be part of the saved state in case NEEDBITS()
+   returns:
 
-	 case STATEw:
-		  while (want < need) {
-				NEEDBITS(n);
-				keep[want++] = BITS(n);
-				DROPBITS(n);
-		  }
-		  state = STATEx;
-	 case STATEx:
+    case STATEw:
+        while (want < need) {
+            NEEDBITS(n);
+            keep[want++] = BITS(n);
+            DROPBITS(n);
+        }
+        state = STATEx;
+    case STATEx:
 
-	As shown above, if the next state is also the next case, then the break
-	is omitted.
+   As shown above, if the next state is also the next case, then the break
+   is omitted.
 
-	A state may also return if there is not enough output space available to
-	complete that state.  Those states are copying stored data, writing a
-	literal byte, and copying a matching string.
+   A state may also return if there is not enough output space available to
+   complete that state.  Those states are copying stored data, writing a
+   literal byte, and copying a matching string.
 
-	When returning, a "goto inf_leave" is used to update the total counters,
-	update the check value, and determine whether any progress has been made
-	during that inflate() call in order to return the proper return code.
-	Progress is defined as a change in either strm->avail_in or strm->avail_out.
-	When there is a window, goto inf_leave will update the window with the last
-	output written.  If a goto inf_leave occurs in the middle of decompression
-	and there is no window currently, goto inf_leave will create one and copy
-	output to the window for the next call of inflate().
+   When returning, a "goto inf_leave" is used to update the total counters,
+   update the check value, and determine whether any progress has been made
+   during that inflate() call in order to return the proper return code.
+   Progress is defined as a change in either strm->avail_in or strm->avail_out.
+   When there is a window, goto inf_leave will update the window with the last
+   output written.  If a goto inf_leave occurs in the middle of decompression
+   and there is no window currently, goto inf_leave will create one and copy
+   output to the window for the next call of inflate().
 
-	In this implementation, the flush parameter of inflate() only affects the
-	return code (per zlib.h).  inflate() always writes as much as possible to
-	strm->next_out, given the space available and the provided input--the effect
-	documented in zlib.h of Z_SYNC_FLUSH.  Furthermore, inflate() always defers
-	the allocation of and copying into a sliding window until necessary, which
-	provides the effect documented in zlib.h for Z_FINISH when the entire input
-	stream available.  So the only thing the flush parameter actually does is:
-	when flush is set to Z_FINISH, inflate() cannot return Z_OK.  Instead it
-	will return Z_BUF_ERROR if it has not reached the end of the stream.
+   In this implementation, the flush parameter of inflate() only affects the
+   return code (per zlib.h).  inflate() always writes as much as possible to
+   strm->next_out, given the space available and the provided input--the effect
+   documented in zlib.h of Z_SYNC_FLUSH.  Furthermore, inflate() always defers
+   the allocation of and copying into a sliding window until necessary, which
+   provides the effect documented in zlib.h for Z_FINISH when the entire input
+   stream available.  So the only thing the flush parameter actually does is:
+   when flush is set to Z_FINISH, inflate() cannot return Z_OK.  Instead it
+   will return Z_BUF_ERROR if it has not reached the end of the stream.
  */
 
 int ZEXPORT inflate(strm, flush)
 z_streamp strm;
 int flush;
 {
-	struct inflate_state FAR *state;
-	z_const unsigned char FAR *next;    /* next input */
-	unsigned char FAR *put;     /* next output */
-	unsigned have, left;        /* available input and output */
-	unsigned long hold;         /* bit buffer */
-	unsigned bits;              /* bits in bit buffer */
-	unsigned in, out;           /* save starting available input and output */
-	unsigned copy;              /* number of stored or match bytes to copy */
-	unsigned char FAR *from;    /* where to copy match bytes from */
-	code here;                  /* current decoding table entry */
-	code last;                  /* parent table entry */
-	unsigned len;               /* length to copy for repeats, bits to drop */
-	int ret;                    /* return code */
-	#ifdef GUNZIP
-	unsigned char hbuf[4];      /* buffer for gzip header crc calculation */
-	#endif
-	static const unsigned short order[19] = /* permutation of code lengths */
-	{ 16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15 };
+    struct inflate_state FAR *state;
+    z_const unsigned char FAR *next;    /* next input */
+    unsigned char FAR *put;     /* next output */
+    unsigned have, left;        /* available input and output */
+    unsigned long hold;         /* bit buffer */
+    unsigned bits;              /* bits in bit buffer */
+    unsigned in, out;           /* save starting available input and output */
+    unsigned copy;              /* number of stored or match bytes to copy */
+    unsigned char FAR *from;    /* where to copy match bytes from */
+    code here;                  /* current decoding table entry */
+    code last;                  /* parent table entry */
+    unsigned len;               /* length to copy for repeats, bits to drop */
+    int ret;                    /* return code */
+#ifdef GUNZIP
+    unsigned char hbuf[4];      /* buffer for gzip header crc calculation */
+#endif
+    static const unsigned short order[19] = /* permutation of code lengths */
+        {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
 
-	if (strm == Z_NULL || strm->state == Z_NULL || strm->next_out == Z_NULL ||
-		(strm->next_in == Z_NULL && strm->avail_in != 0))
-		return Z_STREAM_ERROR;
+    if (inflateStateCheck(strm) || strm->next_out == Z_NULL ||
+        (strm->next_in == Z_NULL && strm->avail_in != 0))
+        return Z_STREAM_ERROR;
 
-	state = (struct inflate_state FAR *)strm->state;
-	if (state->mode == TYPE) state->mode = TYPEDO;      /* skip check */
-	LOAD();
-	in = have;
-	out = left;
-	ret = Z_OK;
-	for (;;)
-		switch (state->mode) {
-		case HEAD:
-			if (state->wrap == 0) {
-				state->mode = TYPEDO;
-				break;
-			}
-			NEEDBITS(16);
-			#ifdef GUNZIP
-			if ((state->wrap & 2) && hold == 0x8b1f) {  /* gzip header */
-				state->check = crc32(0L, Z_NULL, 0);
-				CRC2(state->check, hold);
-				INITBITS();
-				state->mode = FLAGS;
-				break;
-			}
-			state->flags = 0;           /* expect zlib header */
-			if (state->head != Z_NULL)
-				state->head->done = -1;
-			if (!(state->wrap & 1) ||   /* check if zlib header allowed */
-				#else
-			if (
-				#endif
-				((BITS(8) << 8) + (hold >> 8)) % 31) {
-				strm->msg = (char *)"incorrect header check";
-				state->mode = BAD;
-				break;
-			}
-			if (BITS(4) != Z_DEFLATED) {
-				strm->msg = (char *)"unknown compression method";
-				state->mode = BAD;
-				break;
-			}
-			DROPBITS(4);
-			len = BITS(4) + 8;
-			if (state->wbits == 0)
-				state->wbits = len;
-			else if (len > state->wbits) {
-				strm->msg = (char *)"invalid window size";
-				state->mode = BAD;
-				break;
-			}
-			state->dmax = 1U << len;
-			Tracev((stderr, "inflate:   zlib header ok\n"));
-			strm->adler = state->check = adler32(0L, Z_NULL, 0);
-			state->mode = hold & 0x200 ? DICTID : TYPE;
-			INITBITS();
-			break;
-			#ifdef GUNZIP
-		case FLAGS:
-			NEEDBITS(16);
-			state->flags = (int)(hold);
-			if ((state->flags & 0xff) != Z_DEFLATED) {
-				strm->msg = (char *)"unknown compression method";
-				state->mode = BAD;
-				break;
-			}
-			if (state->flags & 0xe000) {
-				strm->msg = (char *)"unknown header flags set";
-				state->mode = BAD;
-				break;
-			}
-			if (state->head != Z_NULL)
-				state->head->text = (int)((hold >> 8) & 1);
-			if (state->flags & 0x0200) CRC2(state->check, hold);
-			INITBITS();
-			state->mode = TIME;
-		case TIME:
-			NEEDBITS(32);
-			if (state->head != Z_NULL)
-				state->head->time = hold;
-			if (state->flags & 0x0200) CRC4(state->check, hold);
-			INITBITS();
-			state->mode = OS;
-		case OS:
-			NEEDBITS(16);
-			if (state->head != Z_NULL) {
-				state->head->xflags = (int)(hold & 0xff);
-				state->head->os = (int)(hold >> 8);
-			}
-			if (state->flags & 0x0200) CRC2(state->check, hold);
-			INITBITS();
-			state->mode = EXLEN;
-		case EXLEN:
-			if (state->flags & 0x0400) {
-				NEEDBITS(16);
-				state->length = (unsigned)(hold);
-				if (state->head != Z_NULL)
-					state->head->extra_len = (unsigned)hold;
-				if (state->flags & 0x0200) CRC2(state->check, hold);
-				INITBITS();
-			}
-			else if (state->head != Z_NULL)
-				state->head->extra = Z_NULL;
-			state->mode = EXTRA;
-		case EXTRA:
-			if (state->flags & 0x0400) {
-				copy = state->length;
-				if (copy > have) copy = have;
-				if (copy) {
-					if (state->head != Z_NULL &&
-						state->head->extra != Z_NULL) {
-						len = state->head->extra_len - state->length;
-						zmemcpy(state->head->extra + len, next,
-							len + copy > state->head->extra_max ?
-							state->head->extra_max - len : copy);
-					}
-					if (state->flags & 0x0200)
-						state->check = crc32(state->check, next, copy);
-					have -= copy;
-					next += copy;
-					state->length -= copy;
-				}
-				if (state->length) goto inf_leave;
-			}
-			state->length = 0;
-			state->mode = NAME;
-		case NAME:
-			if (state->flags & 0x0800) {
-				if (have == 0) goto inf_leave;
-				copy = 0;
-				do {
-					len = (unsigned)(next[copy++]);
-					if (state->head != Z_NULL &&
-						state->head->name != Z_NULL &&
-						state->length < state->head->name_max)
-						state->head->name[state->length++] = len;
-				} while (len && copy < have);
-				if (state->flags & 0x0200)
-					state->check = crc32(state->check, next, copy);
-				have -= copy;
-				next += copy;
-				if (len) goto inf_leave;
-			}
-			else if (state->head != Z_NULL)
-				state->head->name = Z_NULL;
-			state->length = 0;
-			state->mode = COMMENT;
-		case COMMENT:
-			if (state->flags & 0x1000) {
-				if (have == 0) goto inf_leave;
-				copy = 0;
-				do {
-					len = (unsigned)(next[copy++]);
-					if (state->head != Z_NULL &&
-						state->head->comment != Z_NULL &&
-						state->length < state->head->comm_max)
-						state->head->comment[state->length++] = len;
-				} while (len && copy < have);
-				if (state->flags & 0x0200)
-					state->check = crc32(state->check, next, copy);
-				have -= copy;
-				next += copy;
-				if (len) goto inf_leave;
-			}
-			else if (state->head != Z_NULL)
-				state->head->comment = Z_NULL;
-			state->mode = HCRC;
-		case HCRC:
-			if (state->flags & 0x0200) {
-				NEEDBITS(16);
-				if (hold != (state->check & 0xffff)) {
-					strm->msg = (char *)"header crc mismatch";
-					state->mode = BAD;
-					break;
-				}
-				INITBITS();
-			}
-			if (state->head != Z_NULL) {
-				state->head->hcrc = (int)((state->flags >> 9) & 1);
-				state->head->done = 1;
-			}
-			strm->adler = state->check = crc32(0L, Z_NULL, 0);
-			state->mode = TYPE;
-			break;
-			#endif
-		case DICTID:
-			NEEDBITS(32);
-			strm->adler = state->check = ZSWAP32(hold);
-			INITBITS();
-			state->mode = DICT;
-		case DICT:
-			if (state->havedict == 0) {
-				RESTORE();
-				return Z_NEED_DICT;
-			}
-			strm->adler = state->check = adler32(0L, Z_NULL, 0);
-			state->mode = TYPE;
-		case TYPE:
-			if (flush == Z_BLOCK || flush == Z_TREES) goto inf_leave;
-		case TYPEDO:
-			if (state->last) {
-				BYTEBITS();
-				state->mode = CHECK;
-				break;
-			}
-			NEEDBITS(3);
-			state->last = BITS(1);
-			DROPBITS(1);
-			switch (BITS(2)) {
-			case 0:                             /* stored block */
-				Tracev((stderr, "inflate:     stored block%s\n",
-					state->last ? " (last)" : ""));
-				state->mode = STORED;
-				break;
-			case 1:                             /* fixed block */
-				fixedtables(state);
-				Tracev((stderr, "inflate:     fixed codes block%s\n",
-					state->last ? " (last)" : ""));
-				state->mode = LEN_;             /* decode codes */
-				if (flush == Z_TREES) {
-					DROPBITS(2);
-					goto inf_leave;
-				}
-				break;
-			case 2:                             /* dynamic block */
-				Tracev((stderr, "inflate:     dynamic codes block%s\n",
-					state->last ? " (last)" : ""));
-				state->mode = TABLE;
-				break;
-			case 3:
-				strm->msg = (char *)"invalid block type";
-				state->mode = BAD;
-			}
-			DROPBITS(2);
-			break;
-		case STORED:
-			BYTEBITS();                         /* go to byte boundary */
-			NEEDBITS(32);
-			if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
-				strm->msg = (char *)"invalid stored block lengths";
-				state->mode = BAD;
-				break;
-			}
-			state->length = (unsigned)hold & 0xffff;
-			Tracev((stderr, "inflate:       stored length %u\n",
-				state->length));
-			INITBITS();
-			state->mode = COPY_;
-			if (flush == Z_TREES) goto inf_leave;
-		case COPY_:
-			state->mode = COPY;
-		case COPY:
-			copy = state->length;
-			if (copy) {
-				if (copy > have) copy = have;
-				if (copy > left) copy = left;
-				if (copy == 0) goto inf_leave;
-				zmemcpy(put, next, copy);
-				have -= copy;
-				next += copy;
-				left -= copy;
-				put += copy;
-				state->length -= copy;
-				break;
-			}
-			Tracev((stderr, "inflate:       stored end\n"));
-			state->mode = TYPE;
-			break;
-		case TABLE:
-			NEEDBITS(14);
-			state->nlen = BITS(5) + 257;
-			DROPBITS(5);
-			state->ndist = BITS(5) + 1;
-			DROPBITS(5);
-			state->ncode = BITS(4) + 4;
-			DROPBITS(4);
-			#ifndef PKZIP_BUG_WORKAROUND
-			if (state->nlen > 286 || state->ndist > 30) {
-				strm->msg = (char *)"too many length or distance symbols";
-				state->mode = BAD;
-				break;
-			}
-			#endif
-			Tracev((stderr, "inflate:       table sizes ok\n"));
-			state->have = 0;
-			state->mode = LENLENS;
-		case LENLENS:
-			while (state->have < state->ncode) {
-				NEEDBITS(3);
-				state->lens[order[state->have++]] = (unsigned short)BITS(3);
-				DROPBITS(3);
-			}
-			while (state->have < 19)
-				state->lens[order[state->have++]] = 0;
-			state->next = state->codes;
-			state->lencode = (const code FAR *)(state->next);
-			state->lenbits = 7;
-			ret = inflate_table(CODES, state->lens, 19, &(state->next),
-				&(state->lenbits), state->work);
-			if (ret) {
-				strm->msg = (char *)"invalid code lengths set";
-				state->mode = BAD;
-				break;
-			}
-			Tracev((stderr, "inflate:       code lengths ok\n"));
-			state->have = 0;
-			state->mode = CODELENS;
-		case CODELENS:
-			while (state->have < state->nlen + state->ndist) {
-				for (;;) {
-					here = state->lencode[BITS(state->lenbits)];
-					if ((unsigned)(here.bits) <= bits) break;
-					PULLBYTE();
-				}
-				if (here.val < 16) {
-					DROPBITS(here.bits);
-					state->lens[state->have++] = here.val;
-				}
-				else {
-					if (here.val == 16) {
-						NEEDBITS(here.bits + 2);
-						DROPBITS(here.bits);
-						if (state->have == 0) {
-							strm->msg = (char *)"invalid bit length repeat";
-							state->mode = BAD;
-							break;
-						}
-						len = state->lens[state->have - 1];
-						copy = 3 + BITS(2);
-						DROPBITS(2);
-					}
-					else if (here.val == 17) {
-						NEEDBITS(here.bits + 3);
-						DROPBITS(here.bits);
-						len = 0;
-						copy = 3 + BITS(3);
-						DROPBITS(3);
-					}
-					else {
-						NEEDBITS(here.bits + 7);
-						DROPBITS(here.bits);
-						len = 0;
-						copy = 11 + BITS(7);
-						DROPBITS(7);
-					}
-					if (state->have + copy > state->nlen + state->ndist) {
-						strm->msg = (char *)"invalid bit length repeat";
-						state->mode = BAD;
-						break;
-					}
-					while (copy--)
-						state->lens[state->have++] = (unsigned short)len;
-				}
-			}
+    state = (struct inflate_state FAR *)strm->state;
+    if (state->mode == TYPE) state->mode = TYPEDO;      /* skip check */
+    LOAD();
+    in = have;
+    out = left;
+    ret = Z_OK;
+    for (;;)
+        switch (state->mode) {
+        case HEAD:
+            if (state->wrap == 0) {
+                state->mode = TYPEDO;
+                break;
+            }
+            NEEDBITS(16);
+#ifdef GUNZIP
+            if ((state->wrap & 2) && hold == 0x8b1f) {  /* gzip header */
+                if (state->wbits == 0)
+                    state->wbits = 15;
+                state->check = crc32(0L, Z_NULL, 0);
+                CRC2(state->check, hold);
+                INITBITS();
+                state->mode = FLAGS;
+                break;
+            }
+            state->flags = 0;           /* expect zlib header */
+            if (state->head != Z_NULL)
+                state->head->done = -1;
+            if (!(state->wrap & 1) ||   /* check if zlib header allowed */
+#else
+            if (
+#endif
+                ((BITS(8) << 8) + (hold >> 8)) % 31) {
+                strm->msg = (char *)"incorrect header check";
+                state->mode = BAD;
+                break;
+            }
+            if (BITS(4) != Z_DEFLATED) {
+                strm->msg = (char *)"unknown compression method";
+                state->mode = BAD;
+                break;
+            }
+            DROPBITS(4);
+            len = BITS(4) + 8;
+            if (state->wbits == 0)
+                state->wbits = len;
+            if (len > 15 || len > state->wbits) {
+                strm->msg = (char *)"invalid window size";
+                state->mode = BAD;
+                break;
+            }
+            state->dmax = 1U << len;
+            Tracev((stderr, "inflate:   zlib header ok\n"));
+            strm->adler = state->check = adler32(0L, Z_NULL, 0);
+            state->mode = hold & 0x200 ? DICTID : TYPE;
+            INITBITS();
+            break;
+#ifdef GUNZIP
+        case FLAGS:
+            NEEDBITS(16);
+            state->flags = (int)(hold);
+            if ((state->flags & 0xff) != Z_DEFLATED) {
+                strm->msg = (char *)"unknown compression method";
+                state->mode = BAD;
+                break;
+            }
+            if (state->flags & 0xe000) {
+                strm->msg = (char *)"unknown header flags set";
+                state->mode = BAD;
+                break;
+            }
+            if (state->head != Z_NULL)
+                state->head->text = (int)((hold >> 8) & 1);
+            if ((state->flags & 0x0200) && (state->wrap & 4))
+                CRC2(state->check, hold);
+            INITBITS();
+            state->mode = TIME;
+        case TIME:
+            NEEDBITS(32);
+            if (state->head != Z_NULL)
+                state->head->time = hold;
+            if ((state->flags & 0x0200) && (state->wrap & 4))
+                CRC4(state->check, hold);
+            INITBITS();
+            state->mode = OS;
+        case OS:
+            NEEDBITS(16);
+            if (state->head != Z_NULL) {
+                state->head->xflags = (int)(hold & 0xff);
+                state->head->os = (int)(hold >> 8);
+            }
+            if ((state->flags & 0x0200) && (state->wrap & 4))
+                CRC2(state->check, hold);
+            INITBITS();
+            state->mode = EXLEN;
+        case EXLEN:
+            if (state->flags & 0x0400) {
+                NEEDBITS(16);
+                state->length = (unsigned)(hold);
+                if (state->head != Z_NULL)
+                    state->head->extra_len = (unsigned)hold;
+                if ((state->flags & 0x0200) && (state->wrap & 4))
+                    CRC2(state->check, hold);
+                INITBITS();
+            }
+            else if (state->head != Z_NULL)
+                state->head->extra = Z_NULL;
+            state->mode = EXTRA;
+        case EXTRA:
+            if (state->flags & 0x0400) {
+                copy = state->length;
+                if (copy > have) copy = have;
+                if (copy) {
+                    if (state->head != Z_NULL &&
+                        state->head->extra != Z_NULL) {
+                        len = state->head->extra_len - state->length;
+                        zmemcpy(state->head->extra + len, next,
+                                len + copy > state->head->extra_max ?
+                                state->head->extra_max - len : copy);
+                    }
+                    if ((state->flags & 0x0200) && (state->wrap & 4))
+                        state->check = crc32(state->check, next, copy);
+                    have -= copy;
+                    next += copy;
+                    state->length -= copy;
+                }
+                if (state->length) goto inf_leave;
+            }
+            state->length = 0;
+            state->mode = NAME;
+        case NAME:
+            if (state->flags & 0x0800) {
+                if (have == 0) goto inf_leave;
+                copy = 0;
+                do {
+                    len = (unsigned)(next[copy++]);
+                    if (state->head != Z_NULL &&
+                            state->head->name != Z_NULL &&
+                            state->length < state->head->name_max)
+                        state->head->name[state->length++] = (Bytef)len;
+                } while (len && copy < have);
+                if ((state->flags & 0x0200) && (state->wrap & 4))
+                    state->check = crc32(state->check, next, copy);
+                have -= copy;
+                next += copy;
+                if (len) goto inf_leave;
+            }
+            else if (state->head != Z_NULL)
+                state->head->name = Z_NULL;
+            state->length = 0;
+            state->mode = COMMENT;
+        case COMMENT:
+            if (state->flags & 0x1000) {
+                if (have == 0) goto inf_leave;
+                copy = 0;
+                do {
+                    len = (unsigned)(next[copy++]);
+                    if (state->head != Z_NULL &&
+                            state->head->comment != Z_NULL &&
+                            state->length < state->head->comm_max)
+                        state->head->comment[state->length++] = (Bytef)len;
+                } while (len && copy < have);
+                if ((state->flags & 0x0200) && (state->wrap & 4))
+                    state->check = crc32(state->check, next, copy);
+                have -= copy;
+                next += copy;
+                if (len) goto inf_leave;
+            }
+            else if (state->head != Z_NULL)
+                state->head->comment = Z_NULL;
+            state->mode = HCRC;
+        case HCRC:
+            if (state->flags & 0x0200) {
+                NEEDBITS(16);
+                if ((state->wrap & 4) && hold != (state->check & 0xffff)) {
+                    strm->msg = (char *)"header crc mismatch";
+                    state->mode = BAD;
+                    break;
+                }
+                INITBITS();
+            }
+            if (state->head != Z_NULL) {
+                state->head->hcrc = (int)((state->flags >> 9) & 1);
+                state->head->done = 1;
+            }
+            strm->adler = state->check = crc32(0L, Z_NULL, 0);
+            state->mode = TYPE;
+            break;
+#endif
+        case DICTID:
+            NEEDBITS(32);
+            strm->adler = state->check = ZSWAP32(hold);
+            INITBITS();
+            state->mode = DICT;
+        case DICT:
+            if (state->havedict == 0) {
+                RESTORE();
+                return Z_NEED_DICT;
+            }
+            strm->adler = state->check = adler32(0L, Z_NULL, 0);
+            state->mode = TYPE;
+        case TYPE:
+            if (flush == Z_BLOCK || flush == Z_TREES) goto inf_leave;
+        case TYPEDO:
+            if (state->last) {
+                BYTEBITS();
+                state->mode = CHECK;
+                break;
+            }
+            NEEDBITS(3);
+            state->last = BITS(1);
+            DROPBITS(1);
+            switch (BITS(2)) {
+            case 0:                             /* stored block */
+                Tracev((stderr, "inflate:     stored block%s\n",
+                        state->last ? " (last)" : ""));
+                state->mode = STORED;
+                break;
+            case 1:                             /* fixed block */
+                fixedtables(state);
+                Tracev((stderr, "inflate:     fixed codes block%s\n",
+                        state->last ? " (last)" : ""));
+                state->mode = LEN_;             /* decode codes */
+                if (flush == Z_TREES) {
+                    DROPBITS(2);
+                    goto inf_leave;
+                }
+                break;
+            case 2:                             /* dynamic block */
+                Tracev((stderr, "inflate:     dynamic codes block%s\n",
+                        state->last ? " (last)" : ""));
+                state->mode = TABLE;
+                break;
+            case 3:
+                strm->msg = (char *)"invalid block type";
+                state->mode = BAD;
+            }
+            DROPBITS(2);
+            break;
+        case STORED:
+            BYTEBITS();                         /* go to byte boundary */
+            NEEDBITS(32);
+            if ((hold & 0xffff) != ((hold >> 16) ^ 0xffff)) {
+                strm->msg = (char *)"invalid stored block lengths";
+                state->mode = BAD;
+                break;
+            }
+            state->length = (unsigned)hold & 0xffff;
+            Tracev((stderr, "inflate:       stored length %u\n",
+                    state->length));
+            INITBITS();
+            state->mode = COPY_;
+            if (flush == Z_TREES) goto inf_leave;
+        case COPY_:
+            state->mode = COPY;
+        case COPY:
+            copy = state->length;
+            if (copy) {
+                if (copy > have) copy = have;
+                if (copy > left) copy = left;
+                if (copy == 0) goto inf_leave;
+                zmemcpy(put, next, copy);
+                have -= copy;
+                next += copy;
+                left -= copy;
+                put += copy;
+                state->length -= copy;
+                break;
+            }
+            Tracev((stderr, "inflate:       stored end\n"));
+            state->mode = TYPE;
+            break;
+        case TABLE:
+            NEEDBITS(14);
+            state->nlen = BITS(5) + 257;
+            DROPBITS(5);
+            state->ndist = BITS(5) + 1;
+            DROPBITS(5);
+            state->ncode = BITS(4) + 4;
+            DROPBITS(4);
+#ifndef PKZIP_BUG_WORKAROUND
+            if (state->nlen > 286 || state->ndist > 30) {
+                strm->msg = (char *)"too many length or distance symbols";
+                state->mode = BAD;
+                break;
+            }
+#endif
+            Tracev((stderr, "inflate:       table sizes ok\n"));
+            state->have = 0;
+            state->mode = LENLENS;
+        case LENLENS:
+            while (state->have < state->ncode) {
+                NEEDBITS(3);
+                state->lens[order[state->have++]] = (unsigned short)BITS(3);
+                DROPBITS(3);
+            }
+            while (state->have < 19)
+                state->lens[order[state->have++]] = 0;
+            state->next = state->codes;
+            state->lencode = (const code FAR *)(state->next);
+            state->lenbits = 7;
+            ret = inflate_table(CODES, state->lens, 19, &(state->next),
+                                &(state->lenbits), state->work);
+            if (ret) {
+                strm->msg = (char *)"invalid code lengths set";
+                state->mode = BAD;
+                break;
+            }
+            Tracev((stderr, "inflate:       code lengths ok\n"));
+            state->have = 0;
+            state->mode = CODELENS;
+        case CODELENS:
+            while (state->have < state->nlen + state->ndist) {
+                for (;;) {
+                    here = state->lencode[BITS(state->lenbits)];
+                    if ((unsigned)(here.bits) <= bits) break;
+                    PULLBYTE();
+                }
+                if (here.val < 16) {
+                    DROPBITS(here.bits);
+                    state->lens[state->have++] = here.val;
+                }
+                else {
+                    if (here.val == 16) {
+                        NEEDBITS(here.bits + 2);
+                        DROPBITS(here.bits);
+                        if (state->have == 0) {
+                            strm->msg = (char *)"invalid bit length repeat";
+                            state->mode = BAD;
+                            break;
+                        }
+                        len = state->lens[state->have - 1];
+                        copy = 3 + BITS(2);
+                        DROPBITS(2);
+                    }
+                    else if (here.val == 17) {
+                        NEEDBITS(here.bits + 3);
+                        DROPBITS(here.bits);
+                        len = 0;
+                        copy = 3 + BITS(3);
+                        DROPBITS(3);
+                    }
+                    else {
+                        NEEDBITS(here.bits + 7);
+                        DROPBITS(here.bits);
+                        len = 0;
+                        copy = 11 + BITS(7);
+                        DROPBITS(7);
+                    }
+                    if (state->have + copy > state->nlen + state->ndist) {
+                        strm->msg = (char *)"invalid bit length repeat";
+                        state->mode = BAD;
+                        break;
+                    }
+                    while (copy--)
+                        state->lens[state->have++] = (unsigned short)len;
+                }
+            }
 
-			/* handle error breaks in while */
-			if (state->mode == BAD) break;
+            /* handle error breaks in while */
+            if (state->mode == BAD) break;
 
-			/* check for end-of-block code (better have one) */
-			if (state->lens[256] == 0) {
-				strm->msg = (char *)"invalid code -- missing end-of-block";
-				state->mode = BAD;
-				break;
-			}
+            /* check for end-of-block code (better have one) */
+            if (state->lens[256] == 0) {
+                strm->msg = (char *)"invalid code -- missing end-of-block";
+                state->mode = BAD;
+                break;
+            }
 
-			/* build code tables -- note: do not change the lenbits or distbits
-				values here (9 and 6) without reading the comments in inftrees.h
-				concerning the ENOUGH constants, which depend on those values */
-			state->next = state->codes;
-			state->lencode = (const code FAR *)(state->next);
-			state->lenbits = 9;
-			ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
-				&(state->lenbits), state->work);
-			if (ret) {
-				strm->msg = (char *)"invalid literal/lengths set";
-				state->mode = BAD;
-				break;
-			}
-			state->distcode = (const code FAR *)(state->next);
-			state->distbits = 6;
-			ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
-				&(state->next), &(state->distbits), state->work);
-			if (ret) {
-				strm->msg = (char *)"invalid distances set";
-				state->mode = BAD;
-				break;
-			}
-			Tracev((stderr, "inflate:       codes ok\n"));
-			state->mode = LEN_;
-			if (flush == Z_TREES) goto inf_leave;
-		case LEN_:
-			state->mode = LEN;
-		case LEN:
-			if (have >= 6 && left >= 258) {
-				RESTORE();
-				inflate_fast(strm, out);
-				LOAD();
-				if (state->mode == TYPE)
-					state->back = -1;
-				break;
-			}
-			state->back = 0;
-			for (;;) {
-				here = state->lencode[BITS(state->lenbits)];
-				if ((unsigned)(here.bits) <= bits) break;
-				PULLBYTE();
-			}
-			if (here.op && (here.op & 0xf0) == 0) {
-				last = here;
-				for (;;) {
-					here = state->lencode[last.val +
-						(BITS(last.bits + last.op) >> last.bits)];
-					if ((unsigned)(last.bits + here.bits) <= bits) break;
-					PULLBYTE();
-				}
-				DROPBITS(last.bits);
-				state->back += last.bits;
-			}
-			DROPBITS(here.bits);
-			state->back += here.bits;
-			state->length = (unsigned)here.val;
-			if ((int)(here.op) == 0) {
-				Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
-					"inflate:         literal '%c'\n" :
-					"inflate:         literal 0x%02x\n", here.val));
-				state->mode = LIT;
-				break;
-			}
-			if (here.op & 32) {
-				Tracevv((stderr, "inflate:         end of block\n"));
-				state->back = -1;
-				state->mode = TYPE;
-				break;
-			}
-			if (here.op & 64) {
-				strm->msg = (char *)"invalid literal/length code";
-				state->mode = BAD;
-				break;
-			}
-			state->extra = (unsigned)(here.op) & 15;
-			state->mode = LENEXT;
-		case LENEXT:
-			if (state->extra) {
-				NEEDBITS(state->extra);
-				state->length += BITS(state->extra);
-				DROPBITS(state->extra);
-				state->back += state->extra;
-			}
-			Tracevv((stderr, "inflate:         length %u\n", state->length));
-			state->was = state->length;
-			state->mode = DIST;
-		case DIST:
-			for (;;) {
-				here = state->distcode[BITS(state->distbits)];
-				if ((unsigned)(here.bits) <= bits) break;
-				PULLBYTE();
-			}
-			if ((here.op & 0xf0) == 0) {
-				last = here;
-				for (;;) {
-					here = state->distcode[last.val +
-						(BITS(last.bits + last.op) >> last.bits)];
-					if ((unsigned)(last.bits + here.bits) <= bits) break;
-					PULLBYTE();
-				}
-				DROPBITS(last.bits);
-				state->back += last.bits;
-			}
-			DROPBITS(here.bits);
-			state->back += here.bits;
-			if (here.op & 64) {
-				strm->msg = (char *)"invalid distance code";
-				state->mode = BAD;
-				break;
-			}
-			state->offset = (unsigned)here.val;
-			state->extra = (unsigned)(here.op) & 15;
-			state->mode = DISTEXT;
-		case DISTEXT:
-			if (state->extra) {
-				NEEDBITS(state->extra);
-				state->offset += BITS(state->extra);
-				DROPBITS(state->extra);
-				state->back += state->extra;
-			}
-			#ifdef INFLATE_STRICT
-			if (state->offset > state->dmax) {
-				strm->msg = (char *)"invalid distance too far back";
-				state->mode = BAD;
-				break;
-			}
-			#endif
-			Tracevv((stderr, "inflate:         distance %u\n", state->offset));
-			state->mode = MATCH;
-		case MATCH:
-			if (left == 0) goto inf_leave;
-			copy = out - left;
-			if (state->offset > copy) {         /* copy from window */
-				copy = state->offset - copy;
-				if (copy > state->whave) {
-					if (state->sane) {
-						strm->msg = (char *)"invalid distance too far back";
-						state->mode = BAD;
-						break;
-					}
-					#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
-					Trace((stderr, "inflate.c too far\n"));
-					copy -= state->whave;
-					if (copy > state->length) copy = state->length;
-					if (copy > left) copy = left;
-					left -= copy;
-					state->length -= copy;
-					do {
-						*put++ = 0;
-					} while (--copy);
-					if (state->length == 0) state->mode = LEN;
-					break;
-					#endif
-				}
-				if (copy > state->wnext) {
-					copy -= state->wnext;
-					from = state->window + (state->wsize - copy);
-				}
-				else
-					from = state->window + (state->wnext - copy);
-				if (copy > state->length) copy = state->length;
-			}
-			else {                              /* copy from output */
-				from = put - state->offset;
-				copy = state->length;
-			}
-			if (copy > left) copy = left;
-			left -= copy;
-			state->length -= copy;
-			do {
-				*put++ = *from++;
-			} while (--copy);
-			if (state->length == 0) state->mode = LEN;
-			break;
-		case LIT:
-			if (left == 0) goto inf_leave;
-			*put++ = (unsigned char)(state->length);
-			left--;
-			state->mode = LEN;
-			break;
-		case CHECK:
-			if (state->wrap) {
-				NEEDBITS(32);
-				out -= left;
-				strm->total_out += out;
-				state->total += out;
-				if (out)
-					strm->adler = state->check =
-					UPDATE(state->check, put - out, out);
-				out = left;
-				if ((
-					#ifdef GUNZIP
-					state->flags ? hold :
-					#endif
-					ZSWAP32(hold)) != state->check) {
-					strm->msg = (char *)"incorrect data check";
-					state->mode = BAD;
-					break;
-				}
-				INITBITS();
-				Tracev((stderr, "inflate:   check matches trailer\n"));
-			}
-			#ifdef GUNZIP
-			state->mode = LENGTH;
-		case LENGTH:
-			if (state->wrap && state->flags) {
-				NEEDBITS(32);
-				if (hold != (state->total & 0xffffffffUL)) {
-					strm->msg = (char *)"incorrect length check";
-					state->mode = BAD;
-					break;
-				}
-				INITBITS();
-				Tracev((stderr, "inflate:   length matches trailer\n"));
-			}
-			#endif
-			state->mode = DONE;
-		case DONE:
-			ret = Z_STREAM_END;
-			goto inf_leave;
-		case BAD:
-			ret = Z_DATA_ERROR;
-			goto inf_leave;
-		case MEM:
-			return Z_MEM_ERROR;
-		case SYNC:
-		default:
-			return Z_STREAM_ERROR;
-		}
+            /* build code tables -- note: do not change the lenbits or distbits
+               values here (9 and 6) without reading the comments in inftrees.h
+               concerning the ENOUGH constants, which depend on those values */
+            state->next = state->codes;
+            state->lencode = (const code FAR *)(state->next);
+            state->lenbits = 9;
+            ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
+                                &(state->lenbits), state->work);
+            if (ret) {
+                strm->msg = (char *)"invalid literal/lengths set";
+                state->mode = BAD;
+                break;
+            }
+            state->distcode = (const code FAR *)(state->next);
+            state->distbits = 6;
+            ret = inflate_table(DISTS, state->lens + state->nlen, state->ndist,
+                            &(state->next), &(state->distbits), state->work);
+            if (ret) {
+                strm->msg = (char *)"invalid distances set";
+                state->mode = BAD;
+                break;
+            }
+            Tracev((stderr, "inflate:       codes ok\n"));
+            state->mode = LEN_;
+            if (flush == Z_TREES) goto inf_leave;
+        case LEN_:
+            state->mode = LEN;
+        case LEN:
+            if (have >= 6 && left >= 258) {
+                RESTORE();
+                inflate_fast(strm, out);
+                LOAD();
+                if (state->mode == TYPE)
+                    state->back = -1;
+                break;
+            }
+            state->back = 0;
+            for (;;) {
+                here = state->lencode[BITS(state->lenbits)];
+                if ((unsigned)(here.bits) <= bits) break;
+                PULLBYTE();
+            }
+            if (here.op && (here.op & 0xf0) == 0) {
+                last = here;
+                for (;;) {
+                    here = state->lencode[last.val +
+                            (BITS(last.bits + last.op) >> last.bits)];
+                    if ((unsigned)(last.bits + here.bits) <= bits) break;
+                    PULLBYTE();
+                }
+                DROPBITS(last.bits);
+                state->back += last.bits;
+            }
+            DROPBITS(here.bits);
+            state->back += here.bits;
+            state->length = (unsigned)here.val;
+            if ((int)(here.op) == 0) {
+                Tracevv((stderr, here.val >= 0x20 && here.val < 0x7f ?
+                        "inflate:         literal '%c'\n" :
+                        "inflate:         literal 0x%02x\n", here.val));
+                state->mode = LIT;
+                break;
+            }
+            if (here.op & 32) {
+                Tracevv((stderr, "inflate:         end of block\n"));
+                state->back = -1;
+                state->mode = TYPE;
+                break;
+            }
+            if (here.op & 64) {
+                strm->msg = (char *)"invalid literal/length code";
+                state->mode = BAD;
+                break;
+            }
+            state->extra = (unsigned)(here.op) & 15;
+            state->mode = LENEXT;
+        case LENEXT:
+            if (state->extra) {
+                NEEDBITS(state->extra);
+                state->length += BITS(state->extra);
+                DROPBITS(state->extra);
+                state->back += state->extra;
+            }
+            Tracevv((stderr, "inflate:         length %u\n", state->length));
+            state->was = state->length;
+            state->mode = DIST;
+        case DIST:
+            for (;;) {
+                here = state->distcode[BITS(state->distbits)];
+                if ((unsigned)(here.bits) <= bits) break;
+                PULLBYTE();
+            }
+            if ((here.op & 0xf0) == 0) {
+                last = here;
+                for (;;) {
+                    here = state->distcode[last.val +
+                            (BITS(last.bits + last.op) >> last.bits)];
+                    if ((unsigned)(last.bits + here.bits) <= bits) break;
+                    PULLBYTE();
+                }
+                DROPBITS(last.bits);
+                state->back += last.bits;
+            }
+            DROPBITS(here.bits);
+            state->back += here.bits;
+            if (here.op & 64) {
+                strm->msg = (char *)"invalid distance code";
+                state->mode = BAD;
+                break;
+            }
+            state->offset = (unsigned)here.val;
+            state->extra = (unsigned)(here.op) & 15;
+            state->mode = DISTEXT;
+        case DISTEXT:
+            if (state->extra) {
+                NEEDBITS(state->extra);
+                state->offset += BITS(state->extra);
+                DROPBITS(state->extra);
+                state->back += state->extra;
+            }
+#ifdef INFLATE_STRICT
+            if (state->offset > state->dmax) {
+                strm->msg = (char *)"invalid distance too far back";
+                state->mode = BAD;
+                break;
+            }
+#endif
+            Tracevv((stderr, "inflate:         distance %u\n", state->offset));
+            state->mode = MATCH;
+        case MATCH:
+            if (left == 0) goto inf_leave;
+            copy = out - left;
+            if (state->offset > copy) {         /* copy from window */
+                copy = state->offset - copy;
+                if (copy > state->whave) {
+                    if (state->sane) {
+                        strm->msg = (char *)"invalid distance too far back";
+                        state->mode = BAD;
+                        break;
+                    }
+#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+                    Trace((stderr, "inflate.c too far\n"));
+                    copy -= state->whave;
+                    if (copy > state->length) copy = state->length;
+                    if (copy > left) copy = left;
+                    left -= copy;
+                    state->length -= copy;
+                    do {
+                        *put++ = 0;
+                    } while (--copy);
+                    if (state->length == 0) state->mode = LEN;
+                    break;
+#endif
+                }
+                if (copy > state->wnext) {
+                    copy -= state->wnext;
+                    from = state->window + (state->wsize - copy);
+                }
+                else
+                    from = state->window + (state->wnext - copy);
+                if (copy > state->length) copy = state->length;
+            }
+            else {                              /* copy from output */
+                from = put - state->offset;
+                copy = state->length;
+            }
+            if (copy > left) copy = left;
+            left -= copy;
+            state->length -= copy;
+            do {
+                *put++ = *from++;
+            } while (--copy);
+            if (state->length == 0) state->mode = LEN;
+            break;
+        case LIT:
+            if (left == 0) goto inf_leave;
+            *put++ = (unsigned char)(state->length);
+            left--;
+            state->mode = LEN;
+            break;
+        case CHECK:
+            if (state->wrap) {
+                NEEDBITS(32);
+                out -= left;
+                strm->total_out += out;
+                state->total += out;
+                if ((state->wrap & 4) && out)
+                    strm->adler = state->check =
+                        UPDATE(state->check, put - out, out);
+                out = left;
+                if ((state->wrap & 4) && (
+#ifdef GUNZIP
+                     state->flags ? hold :
+#endif
+                     ZSWAP32(hold)) != state->check) {
+                    strm->msg = (char *)"incorrect data check";
+                    state->mode = BAD;
+                    break;
+                }
+                INITBITS();
+                Tracev((stderr, "inflate:   check matches trailer\n"));
+            }
+#ifdef GUNZIP
+            state->mode = LENGTH;
+        case LENGTH:
+            if (state->wrap && state->flags) {
+                NEEDBITS(32);
+                if (hold != (state->total & 0xffffffffUL)) {
+                    strm->msg = (char *)"incorrect length check";
+                    state->mode = BAD;
+                    break;
+                }
+                INITBITS();
+                Tracev((stderr, "inflate:   length matches trailer\n"));
+            }
+#endif
+            state->mode = DONE;
+        case DONE:
+            ret = Z_STREAM_END;
+            goto inf_leave;
+        case BAD:
+            ret = Z_DATA_ERROR;
+            goto inf_leave;
+        case MEM:
+            return Z_MEM_ERROR;
+        case SYNC:
+        default:
+            return Z_STREAM_ERROR;
+        }
 
-	/*
-		Return from inflate(), updating the total counts and the check value.
-		If there was no progress during the inflate() call, return a buffer
-		error.  Call updatewindow() to create and/or update the window state.
-		Note: a memory error from inflate() is non-recoverable.
-	 */
-inf_leave:
-	RESTORE();
-	if (state->wsize || (out != strm->avail_out && state->mode < BAD &&
-		(state->mode < CHECK || flush != Z_FINISH)))
-		if (updatewindow(strm, strm->next_out, out - strm->avail_out)) {
-			state->mode = MEM;
-			return Z_MEM_ERROR;
-		}
-	in -= strm->avail_in;
-	out -= strm->avail_out;
-	strm->total_in += in;
-	strm->total_out += out;
-	state->total += out;
-	if (state->wrap && out)
-		strm->adler = state->check =
-		UPDATE(state->check, strm->next_out - out, out);
-	strm->data_type = state->bits + (state->last ? 64 : 0) +
-		(state->mode == TYPE ? 128 : 0) +
-		(state->mode == LEN_ || state->mode == COPY_ ? 256 : 0);
-	if (((in == 0 && out == 0) || flush == Z_FINISH) && ret == Z_OK)
-		ret = Z_BUF_ERROR;
-	return ret;
+    /*
+       Return from inflate(), updating the total counts and the check value.
+       If there was no progress during the inflate() call, return a buffer
+       error.  Call updatewindow() to create and/or update the window state.
+       Note: a memory error from inflate() is non-recoverable.
+     */
+  inf_leave:
+    RESTORE();
+    if (state->wsize || (out != strm->avail_out && state->mode < BAD &&
+            (state->mode < CHECK || flush != Z_FINISH)))
+        if (updatewindow(strm, strm->next_out, out - strm->avail_out)) {
+            state->mode = MEM;
+            return Z_MEM_ERROR;
+        }
+    in -= strm->avail_in;
+    out -= strm->avail_out;
+    strm->total_in += in;
+    strm->total_out += out;
+    state->total += out;
+    if ((state->wrap & 4) && out)
+        strm->adler = state->check =
+            UPDATE(state->check, strm->next_out - out, out);
+    strm->data_type = (int)state->bits + (state->last ? 64 : 0) +
+                      (state->mode == TYPE ? 128 : 0) +
+                      (state->mode == LEN_ || state->mode == COPY_ ? 256 : 0);
+    if (((in == 0 && out == 0) || flush == Z_FINISH) && ret == Z_OK)
+        ret = Z_BUF_ERROR;
+    return ret;
 }
 
 int ZEXPORT inflateEnd(strm)
 z_streamp strm;
 {
-	struct inflate_state FAR *state;
-	if (strm == Z_NULL || strm->state == Z_NULL || strm->zfree == (free_func)0)
-		return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	if (state->window != Z_NULL) ZFREE(strm, state->window);
-	ZFREE(strm, strm->state);
-	strm->state = Z_NULL;
-	Tracev((stderr, "inflate: end\n"));
-	return Z_OK;
+    struct inflate_state FAR *state;
+    if (inflateStateCheck(strm))
+        return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    if (state->window != Z_NULL) ZFREE(strm, state->window);
+    ZFREE(strm, strm->state);
+    strm->state = Z_NULL;
+    Tracev((stderr, "inflate: end\n"));
+    return Z_OK;
 }
 
 int ZEXPORT inflateGetDictionary(strm, dictionary, dictLength)
@@ -1270,22 +1293,22 @@ z_streamp strm;
 Bytef *dictionary;
 uInt *dictLength;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	/* check state */
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
+    /* check state */
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
 
-	/* copy dictionary */
-	if (state->whave && dictionary != Z_NULL) {
-		zmemcpy(dictionary, state->window + state->wnext,
-			state->whave - state->wnext);
-		zmemcpy(dictionary + state->whave - state->wnext,
-			state->window, state->wnext);
-	}
-	if (dictLength != Z_NULL)
-		*dictLength = state->whave;
-	return Z_OK;
+    /* copy dictionary */
+    if (state->whave && dictionary != Z_NULL) {
+        zmemcpy(dictionary, state->window + state->wnext,
+                state->whave - state->wnext);
+        zmemcpy(dictionary + state->whave - state->wnext,
+                state->window, state->wnext);
+    }
+    if (dictLength != Z_NULL)
+        *dictLength = state->whave;
+    return Z_OK;
 }
 
 int ZEXPORT inflateSetDictionary(strm, dictionary, dictLength)
@@ -1293,220 +1316,246 @@ z_streamp strm;
 const Bytef *dictionary;
 uInt dictLength;
 {
-	struct inflate_state FAR *state;
-	unsigned long dictid;
-	int ret;
+    struct inflate_state FAR *state;
+    unsigned long dictid;
+    int ret;
 
-	/* check state */
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	if (state->wrap != 0 && state->mode != DICT)
-		return Z_STREAM_ERROR;
+    /* check state */
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    if (state->wrap != 0 && state->mode != DICT)
+        return Z_STREAM_ERROR;
 
-	/* check for correct dictionary identifier */
-	if (state->mode == DICT) {
-		dictid = adler32(0L, Z_NULL, 0);
-		dictid = adler32(dictid, dictionary, dictLength);
-		if (dictid != state->check)
-			return Z_DATA_ERROR;
-	}
+    /* check for correct dictionary identifier */
+    if (state->mode == DICT) {
+        dictid = adler32(0L, Z_NULL, 0);
+        dictid = adler32(dictid, dictionary, dictLength);
+        if (dictid != state->check)
+            return Z_DATA_ERROR;
+    }
 
-	/* copy dictionary to window using updatewindow(), which will amend the
-		existing dictionary if appropriate */
-	ret = updatewindow(strm, dictionary + dictLength, dictLength);
-	if (ret) {
-		state->mode = MEM;
-		return Z_MEM_ERROR;
-	}
-	state->havedict = 1;
-	Tracev((stderr, "inflate:   dictionary set\n"));
-	return Z_OK;
+    /* copy dictionary to window using updatewindow(), which will amend the
+       existing dictionary if appropriate */
+    ret = updatewindow(strm, dictionary + dictLength, dictLength);
+    if (ret) {
+        state->mode = MEM;
+        return Z_MEM_ERROR;
+    }
+    state->havedict = 1;
+    Tracev((stderr, "inflate:   dictionary set\n"));
+    return Z_OK;
 }
 
 int ZEXPORT inflateGetHeader(strm, head)
 z_streamp strm;
 gz_headerp head;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	/* check state */
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	if ((state->wrap & 2) == 0) return Z_STREAM_ERROR;
+    /* check state */
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    if ((state->wrap & 2) == 0) return Z_STREAM_ERROR;
 
-	/* save header structure */
-	state->head = head;
-	head->done = 0;
-	return Z_OK;
+    /* save header structure */
+    state->head = head;
+    head->done = 0;
+    return Z_OK;
 }
 
 /*
-	Search buf[0..len-1] for the pattern: 0, 0, 0xff, 0xff.  Return when found
-	or when out of input.  When called, *have is the number of pattern bytes
-	found in order so far, in 0..3.  On return *have is updated to the new
-	state.  If on return *have equals four, then the pattern was found and the
-	return value is how many bytes were read including the last byte of the
-	pattern.  If *have is less than four, then the pattern has not been found
-	yet and the return value is len.  In the latter case, syncsearch() can be
-	called again with more data and the *have state.  *have is initialized to
-	zero for the first call.
+   Search buf[0..len-1] for the pattern: 0, 0, 0xff, 0xff.  Return when found
+   or when out of input.  When called, *have is the number of pattern bytes
+   found in order so far, in 0..3.  On return *have is updated to the new
+   state.  If on return *have equals four, then the pattern was found and the
+   return value is how many bytes were read including the last byte of the
+   pattern.  If *have is less than four, then the pattern has not been found
+   yet and the return value is len.  In the latter case, syncsearch() can be
+   called again with more data and the *have state.  *have is initialized to
+   zero for the first call.
  */
 local unsigned syncsearch(have, buf, len)
 unsigned FAR *have;
 const unsigned char FAR *buf;
 unsigned len;
 {
-	unsigned got;
-	unsigned next;
+    unsigned got;
+    unsigned next;
 
-	got = *have;
-	next = 0;
-	while (next < len && got < 4) {
-		if ((int)(buf[next]) == (got < 2 ? 0 : 0xff))
-			got++;
-		else if (buf[next])
-			got = 0;
-		else
-			got = 4 - got;
-		next++;
-	}
-	*have = got;
-	return next;
+    got = *have;
+    next = 0;
+    while (next < len && got < 4) {
+        if ((int)(buf[next]) == (got < 2 ? 0 : 0xff))
+            got++;
+        else if (buf[next])
+            got = 0;
+        else
+            got = 4 - got;
+        next++;
+    }
+    *have = got;
+    return next;
 }
 
 int ZEXPORT inflateSync(strm)
 z_streamp strm;
 {
-	unsigned len;               /* number of bytes to look at or looked at */
-	unsigned long in, out;      /* temporary to save total_in and total_out */
-	unsigned char buf[4];       /* to restore bit buffer to byte string */
-	struct inflate_state FAR *state;
+    unsigned len;               /* number of bytes to look at or looked at */
+    unsigned long in, out;      /* temporary to save total_in and total_out */
+    unsigned char buf[4];       /* to restore bit buffer to byte string */
+    struct inflate_state FAR *state;
 
-	/* check parameters */
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	if (strm->avail_in == 0 && state->bits < 8) return Z_BUF_ERROR;
+    /* check parameters */
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    if (strm->avail_in == 0 && state->bits < 8) return Z_BUF_ERROR;
 
-	/* if first time, start search in bit buffer */
-	if (state->mode != SYNC) {
-		state->mode = SYNC;
-		state->hold <<= state->bits & 7;
-		state->bits -= state->bits & 7;
-		len = 0;
-		while (state->bits >= 8) {
-			buf[len++] = (unsigned char)(state->hold);
-			state->hold >>= 8;
-			state->bits -= 8;
-		}
-		state->have = 0;
-		syncsearch(&(state->have), buf, len);
-	}
+    /* if first time, start search in bit buffer */
+    if (state->mode != SYNC) {
+        state->mode = SYNC;
+        state->hold <<= state->bits & 7;
+        state->bits -= state->bits & 7;
+        len = 0;
+        while (state->bits >= 8) {
+            buf[len++] = (unsigned char)(state->hold);
+            state->hold >>= 8;
+            state->bits -= 8;
+        }
+        state->have = 0;
+        syncsearch(&(state->have), buf, len);
+    }
 
-	/* search available input */
-	len = syncsearch(&(state->have), strm->next_in, strm->avail_in);
-	strm->avail_in -= len;
-	strm->next_in += len;
-	strm->total_in += len;
+    /* search available input */
+    len = syncsearch(&(state->have), strm->next_in, strm->avail_in);
+    strm->avail_in -= len;
+    strm->next_in += len;
+    strm->total_in += len;
 
-	/* return no joy or set up to restart inflate() on a new block */
-	if (state->have != 4) return Z_DATA_ERROR;
-	in = strm->total_in;  out = strm->total_out;
-	inflateReset(strm);
-	strm->total_in = in;  strm->total_out = out;
-	state->mode = TYPE;
-	return Z_OK;
+    /* return no joy or set up to restart inflate() on a new block */
+    if (state->have != 4) return Z_DATA_ERROR;
+    in = strm->total_in;  out = strm->total_out;
+    inflateReset(strm);
+    strm->total_in = in;  strm->total_out = out;
+    state->mode = TYPE;
+    return Z_OK;
 }
 
 /*
-	Returns true if inflate is currently at the end of a block generated by
-	Z_SYNC_FLUSH or Z_FULL_FLUSH. This function is used by one PPP
-	implementation to provide an additional safety check. PPP uses
-	Z_SYNC_FLUSH but removes the length bytes of the resulting empty stored
-	block. When decompressing, PPP checks that at the end of input packet,
-	inflate is waiting for these length bytes.
+   Returns true if inflate is currently at the end of a block generated by
+   Z_SYNC_FLUSH or Z_FULL_FLUSH. This function is used by one PPP
+   implementation to provide an additional safety check. PPP uses
+   Z_SYNC_FLUSH but removes the length bytes of the resulting empty stored
+   block. When decompressing, PPP checks that at the end of input packet,
+   inflate is waiting for these length bytes.
  */
 int ZEXPORT inflateSyncPoint(strm)
 z_streamp strm;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	return state->mode == STORED && state->bits == 0;
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    return state->mode == STORED && state->bits == 0;
 }
 
 int ZEXPORT inflateCopy(dest, source)
 z_streamp dest;
 z_streamp source;
 {
-	struct inflate_state FAR *state;
-	struct inflate_state FAR *copy;
-	unsigned char FAR *window;
-	unsigned wsize;
+    struct inflate_state FAR *state;
+    struct inflate_state FAR *copy;
+    unsigned char FAR *window;
+    unsigned wsize;
 
-	/* check input */
-	if (dest == Z_NULL || source == Z_NULL || source->state == Z_NULL ||
-		source->zalloc == (alloc_func)0 || source->zfree == (free_func)0)
-		return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)source->state;
+    /* check input */
+    if (inflateStateCheck(source) || dest == Z_NULL)
+        return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)source->state;
 
-	/* allocate space */
-	copy = (struct inflate_state FAR *)
-		ZALLOC(source, 1, sizeof(struct inflate_state));
-	if (copy == Z_NULL) return Z_MEM_ERROR;
-	window = Z_NULL;
-	if (state->window != Z_NULL) {
-		window = (unsigned char FAR *)
-			ZALLOC(source, 1U << state->wbits, sizeof(unsigned char));
-		if (window == Z_NULL) {
-			ZFREE(source, copy);
-			return Z_MEM_ERROR;
-		}
-	}
+    /* allocate space */
+    copy = (struct inflate_state FAR *)
+           ZALLOC(source, 1, sizeof(struct inflate_state));
+    if (copy == Z_NULL) return Z_MEM_ERROR;
+    window = Z_NULL;
+    if (state->window != Z_NULL) {
+        window = (unsigned char FAR *)
+                 ZALLOC(source, 1U << state->wbits, sizeof(unsigned char));
+        if (window == Z_NULL) {
+            ZFREE(source, copy);
+            return Z_MEM_ERROR;
+        }
+    }
 
-	/* copy state */
-	zmemcpy((voidpf)dest, (voidpf)source, sizeof(z_stream));
-	zmemcpy((voidpf)copy, (voidpf)state, sizeof(struct inflate_state));
-	if (state->lencode >= state->codes &&
-		state->lencode <= state->codes + ENOUGH - 1) {
-		copy->lencode = copy->codes + (state->lencode - state->codes);
-		copy->distcode = copy->codes + (state->distcode - state->codes);
-	}
-	copy->next = copy->codes + (state->next - state->codes);
-	if (window != Z_NULL) {
-		wsize = 1U << state->wbits;
-		zmemcpy(window, state->window, wsize);
-	}
-	copy->window = window;
-	dest->state = (struct internal_state FAR *)copy;
-	return Z_OK;
+    /* copy state */
+    zmemcpy((voidpf)dest, (voidpf)source, sizeof(z_stream));
+    zmemcpy((voidpf)copy, (voidpf)state, sizeof(struct inflate_state));
+    copy->strm = dest;
+    if (state->lencode >= state->codes &&
+        state->lencode <= state->codes + ENOUGH - 1) {
+        copy->lencode = copy->codes + (state->lencode - state->codes);
+        copy->distcode = copy->codes + (state->distcode - state->codes);
+    }
+    copy->next = copy->codes + (state->next - state->codes);
+    if (window != Z_NULL) {
+        wsize = 1U << state->wbits;
+        zmemcpy(window, state->window, wsize);
+    }
+    copy->window = window;
+    dest->state = (struct internal_state FAR *)copy;
+    return Z_OK;
 }
 
 int ZEXPORT inflateUndermine(strm, subvert)
 z_streamp strm;
 int subvert;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return Z_STREAM_ERROR;
-	state = (struct inflate_state FAR *)strm->state;
-	state->sane = !subvert;
-	#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
-	return Z_OK;
-	#else
-	state->sane = 1;
-	return Z_DATA_ERROR;
-	#endif
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+    state->sane = !subvert;
+    return Z_OK;
+#else
+    (void)subvert;
+    state->sane = 1;
+    return Z_DATA_ERROR;
+#endif
+}
+
+int ZEXPORT inflateValidate(strm, check)
+z_streamp strm;
+int check;
+{
+    struct inflate_state FAR *state;
+
+    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    state = (struct inflate_state FAR *)strm->state;
+    if (check)
+        state->wrap |= 4;
+    else
+        state->wrap &= ~4;
+    return Z_OK;
 }
 
 long ZEXPORT inflateMark(strm)
 z_streamp strm;
 {
-	struct inflate_state FAR *state;
+    struct inflate_state FAR *state;
 
-	if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
-	state = (struct inflate_state FAR *)strm->state;
-	return ((long)(state->back) << 16) +
-		(state->mode == COPY ? state->length :
-			(state->mode == MATCH ? state->was - state->length : 0));
+    if (inflateStateCheck(strm))
+        return -(1L << 16);
+    state = (struct inflate_state FAR *)strm->state;
+    return (long)(((unsigned long)((long)state->back)) << 16) +
+        (state->mode == COPY ? state->length :
+            (state->mode == MATCH ? state->was - state->length : 0));
+}
+
+unsigned long ZEXPORT inflateCodesUsed(strm)
+z_streamp strm;
+{
+    struct inflate_state FAR *state;
+    if (inflateStateCheck(strm)) return (unsigned long)-1;
+    state = (struct inflate_state FAR *)strm->state;
+    return (unsigned long)(state->next - state->codes);
 }

--- a/libs/zlib/src/inflate.h
+++ b/libs/zlib/src/inflate.h
@@ -1,5 +1,5 @@
 /* inflate.h -- internal inflate state definition
- * Copyright (C) 1995-2009 Mark Adler
+ * Copyright (C) 1995-2016 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -18,7 +18,7 @@
 
 /* Possible inflate modes between inflate() calls */
 typedef enum {
-    HEAD,       /* i: waiting for magic header */
+    HEAD = 16180,   /* i: waiting for magic header */
     FLAGS,      /* i: waiting for method and flags (gzip) */
     TIME,       /* i: waiting for modification time (gzip) */
     OS,         /* i: waiting for extra flags and operating system (gzip) */
@@ -77,11 +77,14 @@ typedef enum {
         CHECK -> LENGTH -> DONE
  */
 
-/* state maintained between inflate() calls.  Approximately 10K bytes. */
+/* State maintained between inflate() calls -- approximately 7K bytes, not
+   including the allocated sliding window, which is up to 32K bytes. */
 struct inflate_state {
+    z_streamp strm;             /* pointer back to this zlib stream */
     inflate_mode mode;          /* current inflate mode */
     int last;                   /* true if processing last block */
-    int wrap;                   /* bit 0 true for zlib, bit 1 true for gzip */
+    int wrap;                   /* bit 0 true for zlib, bit 1 true for gzip,
+                                   bit 2 true to validate check value */
     int havedict;               /* true if dictionary provided */
     int flags;                  /* gzip header method and flags (0 if zlib) */
     unsigned dmax;              /* zlib header max distance (INFLATE_STRICT) */

--- a/libs/zlib/src/inftrees.c
+++ b/libs/zlib/src/inftrees.c
@@ -1,5 +1,5 @@
 /* inftrees.c -- generate Huffman trees for efficient decoding
- * Copyright (C) 1995-2013 Mark Adler
+ * Copyright (C) 1995-2017 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -9,7 +9,7 @@
 #define MAXBITS 15
 
 const char inflate_copyright[] =
-   " inflate 1.2.8 Copyright 1995-2013 Mark Adler ";
+   " inflate 1.2.11 Copyright 1995-2017 Mark Adler ";
 /*
   If you use the zlib library in a product, an acknowledgment is welcome
   in the documentation of your product. If for some reason you cannot
@@ -37,270 +37,268 @@ code FAR * FAR *table;
 unsigned FAR *bits;
 unsigned short FAR *work;
 {
-	unsigned len;               /* a code's length in bits */
-	unsigned sym;               /* index of code symbols */
-	unsigned min, max;          /* minimum and maximum code lengths */
-	unsigned root;              /* number of index bits for root table */
-	unsigned curr;              /* number of index bits for current table */
-	unsigned drop;              /* code bits to drop for sub-table */
-	int left;                   /* number of prefix codes available */
-	unsigned used;              /* code entries in table used */
-	unsigned huff;              /* Huffman code */
-	unsigned incr;              /* for incrementing code, index */
-	unsigned fill;              /* index for replicating entries */
-	unsigned low;               /* low bits for current root entry */
-	unsigned mask;              /* mask for low root bits */
-	code here;                  /* table entry for duplication */
-	code FAR *next;             /* next available space in table */
-	const unsigned short FAR *base;     /* base value table to use */
-	const unsigned short FAR *extra;    /* extra bits table to use */
-	int end;                    /* use base and extra for symbol > end */
-	unsigned short count[MAXBITS + 1];    /* number of codes of each length */
-	unsigned short offs[MAXBITS + 1];     /* offsets in table for each length */
-	static const unsigned short lbase[31] = { /* Length codes 257..285 base */
-		 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31,
-		 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0 };
-	static const unsigned short lext[31] = { /* Length codes 257..285 extra */
-		 16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 18, 18, 18, 18,
-		 19, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21, 16, 72, 78 };
-	static const unsigned short dbase[32] = { /* Distance codes 0..29 base */
-		 1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193,
-		 257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
-		 8193, 12289, 16385, 24577, 0, 0 };
-	static const unsigned short dext[32] = { /* Distance codes 0..29 extra */
-		 16, 16, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22,
-		 23, 23, 24, 24, 25, 25, 26, 26, 27, 27,
-		 28, 28, 29, 29, 64, 64 };
+    unsigned len;               /* a code's length in bits */
+    unsigned sym;               /* index of code symbols */
+    unsigned min, max;          /* minimum and maximum code lengths */
+    unsigned root;              /* number of index bits for root table */
+    unsigned curr;              /* number of index bits for current table */
+    unsigned drop;              /* code bits to drop for sub-table */
+    int left;                   /* number of prefix codes available */
+    unsigned used;              /* code entries in table used */
+    unsigned huff;              /* Huffman code */
+    unsigned incr;              /* for incrementing code, index */
+    unsigned fill;              /* index for replicating entries */
+    unsigned low;               /* low bits for current root entry */
+    unsigned mask;              /* mask for low root bits */
+    code here;                  /* table entry for duplication */
+    code FAR *next;             /* next available space in table */
+    const unsigned short FAR *base;     /* base value table to use */
+    const unsigned short FAR *extra;    /* extra bits table to use */
+    unsigned match;             /* use base and extra for symbol >= match */
+    unsigned short count[MAXBITS+1];    /* number of codes of each length */
+    unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
+    static const unsigned short lbase[31] = { /* Length codes 257..285 base */
+        3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31,
+        35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258, 0, 0};
+    static const unsigned short lext[31] = { /* Length codes 257..285 extra */
+        16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 18, 18, 18, 18,
+        19, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21, 16, 77, 202};
+    static const unsigned short dbase[32] = { /* Distance codes 0..29 base */
+        1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193,
+        257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
+        8193, 12289, 16385, 24577, 0, 0};
+    static const unsigned short dext[32] = { /* Distance codes 0..29 extra */
+        16, 16, 16, 16, 17, 17, 18, 18, 19, 19, 20, 20, 21, 21, 22, 22,
+        23, 23, 24, 24, 25, 25, 26, 26, 27, 27,
+        28, 28, 29, 29, 64, 64};
 
-	/*
-		Process a set of code lengths to create a canonical Huffman code.  The
-		code lengths are lens[0..codes-1].  Each length corresponds to the
-		symbols 0..codes-1.  The Huffman code is generated by first sorting the
-		symbols by length from short to long, and retaining the symbol order
-		for codes with equal lengths.  Then the code starts with all zero bits
-		for the first code of the shortest length, and the codes are integer
-		increments for the same length, and zeros are appended as the length
-		increases.  For the deflate format, these bits are stored backwards
-		from their more natural integer increment ordering, and so when the
-		decoding tables are built in the large loop below, the integer codes
-		are incremented backwards.
+    /*
+       Process a set of code lengths to create a canonical Huffman code.  The
+       code lengths are lens[0..codes-1].  Each length corresponds to the
+       symbols 0..codes-1.  The Huffman code is generated by first sorting the
+       symbols by length from short to long, and retaining the symbol order
+       for codes with equal lengths.  Then the code starts with all zero bits
+       for the first code of the shortest length, and the codes are integer
+       increments for the same length, and zeros are appended as the length
+       increases.  For the deflate format, these bits are stored backwards
+       from their more natural integer increment ordering, and so when the
+       decoding tables are built in the large loop below, the integer codes
+       are incremented backwards.
 
-		This routine assumes, but does not check, that all of the entries in
-		lens[] are in the range 0..MAXBITS.  The caller must assure this.
-		1..MAXBITS is interpreted as that code length.  zero means that that
-		symbol does not occur in this code.
+       This routine assumes, but does not check, that all of the entries in
+       lens[] are in the range 0..MAXBITS.  The caller must assure this.
+       1..MAXBITS is interpreted as that code length.  zero means that that
+       symbol does not occur in this code.
 
-		The codes are sorted by computing a count of codes for each length,
-		creating from that a table of starting indices for each length in the
-		sorted table, and then entering the symbols in order in the sorted
-		table.  The sorted table is work[], with that space being provided by
-		the caller.
+       The codes are sorted by computing a count of codes for each length,
+       creating from that a table of starting indices for each length in the
+       sorted table, and then entering the symbols in order in the sorted
+       table.  The sorted table is work[], with that space being provided by
+       the caller.
 
-		The length counts are used for other purposes as well, i.e. finding
-		the minimum and maximum length codes, determining if there are any
-		codes at all, checking for a valid set of lengths, and looking ahead
-		at length counts to determine sub-table sizes when building the
-		decoding tables.
-	 */
+       The length counts are used for other purposes as well, i.e. finding
+       the minimum and maximum length codes, determining if there are any
+       codes at all, checking for a valid set of lengths, and looking ahead
+       at length counts to determine sub-table sizes when building the
+       decoding tables.
+     */
 
-	 /* accumulate lengths for codes (assumes lens[] all in 0..MAXBITS) */
-	for (len = 0; len <= MAXBITS; len++)
-		count[len] = 0;
-	for (sym = 0; sym < codes; sym++)
-		count[lens[sym]]++;
+    /* accumulate lengths for codes (assumes lens[] all in 0..MAXBITS) */
+    for (len = 0; len <= MAXBITS; len++)
+        count[len] = 0;
+    for (sym = 0; sym < codes; sym++)
+        count[lens[sym]]++;
 
-	/* bound code lengths, force root to be within code lengths */
-	root = *bits;
-	for (max = MAXBITS; max >= 1; max--)
-		if (count[max] != 0) break;
-	if (root > max) root = max;
-	if (max == 0) {                     /* no symbols to code at all */
-		here.op = (unsigned char)64;    /* invalid code marker */
-		here.bits = (unsigned char)1;
-		here.val = (unsigned short)0;
-		*(*table)++ = here;             /* make a table to force an error */
-		*(*table)++ = here;
-		*bits = 1;
-		return 0;     /* no symbols, but wait for decoding to report error */
-	}
-	for (min = 1; min < max; min++)
-		if (count[min] != 0) break;
-	if (root < min) root = min;
+    /* bound code lengths, force root to be within code lengths */
+    root = *bits;
+    for (max = MAXBITS; max >= 1; max--)
+        if (count[max] != 0) break;
+    if (root > max) root = max;
+    if (max == 0) {                     /* no symbols to code at all */
+        here.op = (unsigned char)64;    /* invalid code marker */
+        here.bits = (unsigned char)1;
+        here.val = (unsigned short)0;
+        *(*table)++ = here;             /* make a table to force an error */
+        *(*table)++ = here;
+        *bits = 1;
+        return 0;     /* no symbols, but wait for decoding to report error */
+    }
+    for (min = 1; min < max; min++)
+        if (count[min] != 0) break;
+    if (root < min) root = min;
 
-	/* check for an over-subscribed or incomplete set of lengths */
-	left = 1;
-	for (len = 1; len <= MAXBITS; len++) {
-		left <<= 1;
-		left -= count[len];
-		if (left < 0) return -1;        /* over-subscribed */
-	}
-	if (left > 0 && (type == CODES || max != 1))
-		return -1;                      /* incomplete set */
+    /* check for an over-subscribed or incomplete set of lengths */
+    left = 1;
+    for (len = 1; len <= MAXBITS; len++) {
+        left <<= 1;
+        left -= count[len];
+        if (left < 0) return -1;        /* over-subscribed */
+    }
+    if (left > 0 && (type == CODES || max != 1))
+        return -1;                      /* incomplete set */
 
-  /* generate offsets into symbol table for each length for sorting */
-	offs[1] = 0;
-	for (len = 1; len < MAXBITS; len++)
-		offs[len + 1] = offs[len] + count[len];
+    /* generate offsets into symbol table for each length for sorting */
+    offs[1] = 0;
+    for (len = 1; len < MAXBITS; len++)
+        offs[len + 1] = offs[len] + count[len];
 
-	/* sort symbols by length, by symbol order within each length */
-	for (sym = 0; sym < codes; sym++)
-		if (lens[sym] != 0) work[offs[lens[sym]]++] = (unsigned short)sym;
+    /* sort symbols by length, by symbol order within each length */
+    for (sym = 0; sym < codes; sym++)
+        if (lens[sym] != 0) work[offs[lens[sym]]++] = (unsigned short)sym;
 
-	/*
-		Create and fill in decoding tables.  In this loop, the table being
-		filled is at next and has curr index bits.  The code being used is huff
-		with length len.  That code is converted to an index by dropping drop
-		bits off of the bottom.  For codes where len is less than drop + curr,
-		those top drop + curr - len bits are incremented through all values to
-		fill the table with replicated entries.
+    /*
+       Create and fill in decoding tables.  In this loop, the table being
+       filled is at next and has curr index bits.  The code being used is huff
+       with length len.  That code is converted to an index by dropping drop
+       bits off of the bottom.  For codes where len is less than drop + curr,
+       those top drop + curr - len bits are incremented through all values to
+       fill the table with replicated entries.
 
-		root is the number of index bits for the root table.  When len exceeds
-		root, sub-tables are created pointed to by the root entry with an index
-		of the low root bits of huff.  This is saved in low to check for when a
-		new sub-table should be started.  drop is zero when the root table is
-		being filled, and drop is root when sub-tables are being filled.
+       root is the number of index bits for the root table.  When len exceeds
+       root, sub-tables are created pointed to by the root entry with an index
+       of the low root bits of huff.  This is saved in low to check for when a
+       new sub-table should be started.  drop is zero when the root table is
+       being filled, and drop is root when sub-tables are being filled.
 
-		When a new sub-table is needed, it is necessary to look ahead in the
-		code lengths to determine what size sub-table is needed.  The length
-		counts are used for this, and so count[] is decremented as codes are
-		entered in the tables.
+       When a new sub-table is needed, it is necessary to look ahead in the
+       code lengths to determine what size sub-table is needed.  The length
+       counts are used for this, and so count[] is decremented as codes are
+       entered in the tables.
 
-		used keeps track of how many table entries have been allocated from the
-		provided *table space.  It is checked for LENS and DIST tables against
-		the constants ENOUGH_LENS and ENOUGH_DISTS to guard against changes in
-		the initial root table size constants.  See the comments in inftrees.h
-		for more information.
+       used keeps track of how many table entries have been allocated from the
+       provided *table space.  It is checked for LENS and DIST tables against
+       the constants ENOUGH_LENS and ENOUGH_DISTS to guard against changes in
+       the initial root table size constants.  See the comments in inftrees.h
+       for more information.
 
-		sym increments through all symbols, and the loop terminates when
-		all codes of length max, i.e. all codes, have been processed.  This
-		routine permits incomplete codes, so another loop after this one fills
-		in the rest of the decoding tables with invalid code markers.
-	 */
+       sym increments through all symbols, and the loop terminates when
+       all codes of length max, i.e. all codes, have been processed.  This
+       routine permits incomplete codes, so another loop after this one fills
+       in the rest of the decoding tables with invalid code markers.
+     */
 
-	 /* set up for code type */
-	switch (type) {
-	case CODES:
-		base = extra = work;    /* dummy value--not used */
-		end = 19;
-		break;
-	case LENS:
-		base = lbase;
-		base -= 257;
-		extra = lext;
-		extra -= 257;
-		end = 256;
-		break;
-	default:            /* DISTS */
-		base = dbase;
-		extra = dext;
-		end = -1;
-	}
+    /* set up for code type */
+    switch (type) {
+    case CODES:
+        base = extra = work;    /* dummy value--not used */
+        match = 20;
+        break;
+    case LENS:
+        base = lbase;
+        extra = lext;
+        match = 257;
+        break;
+    default:    /* DISTS */
+        base = dbase;
+        extra = dext;
+        match = 0;
+    }
 
-	/* initialize state for loop */
-	huff = 0;                   /* starting code */
-	sym = 0;                    /* starting code symbol */
-	len = min;                  /* starting code length */
-	next = *table;              /* current table to fill in */
-	curr = root;                /* current table index bits */
-	drop = 0;                   /* current bits to drop from code for index */
-	low = (unsigned)(-1);       /* trigger new sub-table when len > root */
-	used = 1U << root;          /* use root table entries */
-	mask = used - 1;            /* mask for comparing low */
+    /* initialize state for loop */
+    huff = 0;                   /* starting code */
+    sym = 0;                    /* starting code symbol */
+    len = min;                  /* starting code length */
+    next = *table;              /* current table to fill in */
+    curr = root;                /* current table index bits */
+    drop = 0;                   /* current bits to drop from code for index */
+    low = (unsigned)(-1);       /* trigger new sub-table when len > root */
+    used = 1U << root;          /* use root table entries */
+    mask = used - 1;            /* mask for comparing low */
 
-	/* check available table space */
-	if ((type == LENS && used > ENOUGH_LENS) ||
-		(type == DISTS && used > ENOUGH_DISTS))
-		return 1;
+    /* check available table space */
+    if ((type == LENS && used > ENOUGH_LENS) ||
+        (type == DISTS && used > ENOUGH_DISTS))
+        return 1;
 
-	/* process all codes and make table entries */
-	for (;;) {
-		/* create table entry */
-		here.bits = (unsigned char)(len - drop);
-		if ((int)(work[sym]) < end) {
-			here.op = (unsigned char)0;
-			here.val = work[sym];
-		}
-		else if ((int)(work[sym]) > end) {
-			here.op = (unsigned char)(extra[work[sym]]);
-			here.val = base[work[sym]];
-		}
-		else {
-			here.op = (unsigned char)(32 + 64);         /* end of block */
-			here.val = 0;
-		}
+    /* process all codes and make table entries */
+    for (;;) {
+        /* create table entry */
+        here.bits = (unsigned char)(len - drop);
+        if (work[sym] + 1U < match) {
+            here.op = (unsigned char)0;
+            here.val = work[sym];
+        }
+        else if (work[sym] >= match) {
+            here.op = (unsigned char)(extra[work[sym] - match]);
+            here.val = base[work[sym] - match];
+        }
+        else {
+            here.op = (unsigned char)(32 + 64);         /* end of block */
+            here.val = 0;
+        }
 
-		/* replicate for those indices with low len bits equal to huff */
-		incr = 1U << (len - drop);
-		fill = 1U << curr;
-		min = fill;                 /* save offset to next table */
-		do {
-			fill -= incr;
-			next[(huff >> drop) + fill] = here;
-		} while (fill != 0);
+        /* replicate for those indices with low len bits equal to huff */
+        incr = 1U << (len - drop);
+        fill = 1U << curr;
+        min = fill;                 /* save offset to next table */
+        do {
+            fill -= incr;
+            next[(huff >> drop) + fill] = here;
+        } while (fill != 0);
 
-		/* backwards increment the len-bit code huff */
-		incr = 1U << (len - 1);
-		while (huff & incr)
-			incr >>= 1;
-		if (incr != 0) {
-			huff &= incr - 1;
-			huff += incr;
-		}
-		else
-			huff = 0;
+        /* backwards increment the len-bit code huff */
+        incr = 1U << (len - 1);
+        while (huff & incr)
+            incr >>= 1;
+        if (incr != 0) {
+            huff &= incr - 1;
+            huff += incr;
+        }
+        else
+            huff = 0;
 
-		/* go to next symbol, update count, len */
-		sym++;
-		if (--(count[len]) == 0) {
-			if (len == max) break;
-			len = lens[work[sym]];
-		}
+        /* go to next symbol, update count, len */
+        sym++;
+        if (--(count[len]) == 0) {
+            if (len == max) break;
+            len = lens[work[sym]];
+        }
 
-		/* create new sub-table if needed */
-		if (len > root && (huff & mask) != low) {
-			/* if first time, transition to sub-tables */
-			if (drop == 0)
-				drop = root;
+        /* create new sub-table if needed */
+        if (len > root && (huff & mask) != low) {
+            /* if first time, transition to sub-tables */
+            if (drop == 0)
+                drop = root;
 
-			/* increment past last table */
-			next += min;            /* here min is 1 << curr */
+            /* increment past last table */
+            next += min;            /* here min is 1 << curr */
 
-			/* determine length of next table */
-			curr = len - drop;
-			left = (int)(1 << curr);
-			while (curr + drop < max) {
-				left -= count[curr + drop];
-				if (left <= 0) break;
-				curr++;
-				left <<= 1;
-			}
+            /* determine length of next table */
+            curr = len - drop;
+            left = (int)(1 << curr);
+            while (curr + drop < max) {
+                left -= count[curr + drop];
+                if (left <= 0) break;
+                curr++;
+                left <<= 1;
+            }
 
-			/* check for enough space */
-			used += 1U << curr;
-			if ((type == LENS && used > ENOUGH_LENS) ||
-				(type == DISTS && used > ENOUGH_DISTS))
-				return 1;
+            /* check for enough space */
+            used += 1U << curr;
+            if ((type == LENS && used > ENOUGH_LENS) ||
+                (type == DISTS && used > ENOUGH_DISTS))
+                return 1;
 
-			/* point entry in root table to sub-table */
-			low = huff & mask;
-			(*table)[low].op = (unsigned char)curr;
-			(*table)[low].bits = (unsigned char)root;
-			(*table)[low].val = (unsigned short)(next - *table);
-		}
-	}
+            /* point entry in root table to sub-table */
+            low = huff & mask;
+            (*table)[low].op = (unsigned char)curr;
+            (*table)[low].bits = (unsigned char)root;
+            (*table)[low].val = (unsigned short)(next - *table);
+        }
+    }
 
-	/* fill in remaining table entry if code is incomplete (guaranteed to have
-		at most one remaining entry, since if the code is incomplete, the
-		maximum code length that was allowed to get this far is one bit) */
-	if (huff != 0) {
-		here.op = (unsigned char)64;            /* invalid code marker */
-		here.bits = (unsigned char)(len - drop);
-		here.val = (unsigned short)0;
-		next[huff] = here;
-	}
+    /* fill in remaining table entry if code is incomplete (guaranteed to have
+       at most one remaining entry, since if the code is incomplete, the
+       maximum code length that was allowed to get this far is one bit) */
+    if (huff != 0) {
+        here.op = (unsigned char)64;            /* invalid code marker */
+        here.bits = (unsigned char)(len - drop);
+        here.val = (unsigned short)0;
+        next[huff] = here;
+    }
 
-	/* set return parameters */
-	*table += used;
-	*bits = root;
-	return 0;
+    /* set return parameters */
+    *table += used;
+    *bits = root;
+    return 0;
 }

--- a/libs/zlib/src/ioapi.c
+++ b/libs/zlib/src/ioapi.c
@@ -34,7 +34,7 @@ voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,const void*filename
         return (*(pfilefunc->zfile_func64.zopen64_file)) (pfilefunc->zfile_func64.opaque,filename,mode);
     else
     {
-        return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque,(const char*)filename,mode);
+        return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque,(const wchar_t*)filename,mode);
     }
 }
 
@@ -84,7 +84,7 @@ void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def* p_filef
 
 
 
-static voidpf  ZCALLBACK fopen_file_func OF((voidpf opaque, const char* filename, int mode));
+static voidpf  ZCALLBACK fopen_file_func OF((voidpf opaque, const wchar_t* filename, int mode));
 static uLong   ZCALLBACK fread_file_func OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 static uLong   ZCALLBACK fwrite_file_func OF((voidpf opaque, voidpf stream, const void* buf,uLong size));
 static ZPOS64_T ZCALLBACK ftell64_file_func OF((voidpf opaque, voidpf stream));
@@ -92,39 +92,39 @@ static long    ZCALLBACK fseek64_file_func OF((voidpf opaque, voidpf stream, ZPO
 static int     ZCALLBACK fclose_file_func OF((voidpf opaque, voidpf stream));
 static int     ZCALLBACK ferror_file_func OF((voidpf opaque, voidpf stream));
 
-static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, int mode)
+static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const wchar_t* filename, int mode)
 {
     FILE* file = NULL;
-    const char* mode_fopen = NULL;
+    const wchar_t* mode_fopen = NULL;
     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
-        mode_fopen = "rb";
+        mode_fopen = L"rb";
     else
     if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
-        mode_fopen = "r+b";
+        mode_fopen = L"r+b";
     else
     if (mode & ZLIB_FILEFUNC_MODE_CREATE)
-        mode_fopen = "wb";
+        mode_fopen = L"wb";
 
     if ((filename!=NULL) && (mode_fopen != NULL))
-        file = fopen(filename, mode_fopen);
+        file = _wfopen(filename, mode_fopen);
     return file;
 }
 
 static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, int mode)
 {
     FILE* file = NULL;
-    const char* mode_fopen = NULL;
+    const wchar_t* mode_fopen = NULL;
     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
-        mode_fopen = "rb";
+        mode_fopen = L"rb";
     else
     if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
-        mode_fopen = "r+b";
+        mode_fopen = L"r+b";
     else
     if (mode & ZLIB_FILEFUNC_MODE_CREATE)
-        mode_fopen = "wb";
+        mode_fopen = L"wb";
 
     if ((filename!=NULL) && (mode_fopen != NULL))
-        file = FOPEN_FUNC((const char*)filename, mode_fopen);
+        file = _wfopen((const wchar_t*)filename, mode_fopen);
     return file;
 }
 

--- a/libs/zlib/src/ioapi.c
+++ b/libs/zlib/src/ioapi.c
@@ -28,215 +28,220 @@
 
 #include "ioapi.h"
 
-voidpf call_zopen64(const zlib_filefunc64_32_def* pfilefunc, const void*filename, int mode)
+voidpf call_zopen64 (const zlib_filefunc64_32_def* pfilefunc,const void*filename,int mode)
 {
-	if (pfilefunc->zfile_func64.zopen64_file != NULL)
-		return (*(pfilefunc->zfile_func64.zopen64_file)) (pfilefunc->zfile_func64.opaque, filename, mode);
-	else {
-		return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque, (const wchar_t*)filename, mode);
-	}
+    if (pfilefunc->zfile_func64.zopen64_file != NULL)
+        return (*(pfilefunc->zfile_func64.zopen64_file)) (pfilefunc->zfile_func64.opaque,filename,mode);
+    else
+    {
+        return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque,(const char*)filename,mode);
+    }
 }
 
-long call_zseek64(const zlib_filefunc64_32_def* pfilefunc, voidpf filestream, ZPOS64_T offset, int origin)
+long call_zseek64 (const zlib_filefunc64_32_def* pfilefunc,voidpf filestream, ZPOS64_T offset, int origin)
 {
-	if (pfilefunc->zfile_func64.zseek64_file != NULL)
-		return (*(pfilefunc->zfile_func64.zseek64_file)) (pfilefunc->zfile_func64.opaque, filestream, offset, origin);
-	else {
-		uLong offsetTruncated = (uLong)offset;
-		if (offsetTruncated != offset)
-			return -1;
-		else
-			return (*(pfilefunc->zseek32_file))(pfilefunc->zfile_func64.opaque, filestream, offsetTruncated, origin);
-	}
+    if (pfilefunc->zfile_func64.zseek64_file != NULL)
+        return (*(pfilefunc->zfile_func64.zseek64_file)) (pfilefunc->zfile_func64.opaque,filestream,offset,origin);
+    else
+    {
+        uLong offsetTruncated = (uLong)offset;
+        if (offsetTruncated != offset)
+            return -1;
+        else
+            return (*(pfilefunc->zseek32_file))(pfilefunc->zfile_func64.opaque,filestream,offsetTruncated,origin);
+    }
 }
 
-ZPOS64_T call_ztell64(const zlib_filefunc64_32_def* pfilefunc, voidpf filestream)
+ZPOS64_T call_ztell64 (const zlib_filefunc64_32_def* pfilefunc,voidpf filestream)
 {
-	if (pfilefunc->zfile_func64.zseek64_file != NULL)
-		return (*(pfilefunc->zfile_func64.ztell64_file)) (pfilefunc->zfile_func64.opaque, filestream);
-	else {
-		uLong tell_uLong = (*(pfilefunc->ztell32_file))(pfilefunc->zfile_func64.opaque, filestream);
-		if ((tell_uLong) == MAXU32)
-			return (ZPOS64_T)-1;
-		else
-			return tell_uLong;
-	}
+    if (pfilefunc->zfile_func64.zseek64_file != NULL)
+        return (*(pfilefunc->zfile_func64.ztell64_file)) (pfilefunc->zfile_func64.opaque,filestream);
+    else
+    {
+        uLong tell_uLong = (*(pfilefunc->ztell32_file))(pfilefunc->zfile_func64.opaque,filestream);
+        if ((tell_uLong) == MAXU32)
+            return (ZPOS64_T)-1;
+        else
+            return tell_uLong;
+    }
 }
 
-void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def* p_filefunc64_32, const zlib_filefunc_def* p_filefunc32)
+void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def* p_filefunc64_32,const zlib_filefunc_def* p_filefunc32)
 {
-	p_filefunc64_32->zfile_func64.zopen64_file = NULL;
-	p_filefunc64_32->zopen32_file = p_filefunc32->zopen_file;
-	p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;
-	p_filefunc64_32->zfile_func64.zread_file = p_filefunc32->zread_file;
-	p_filefunc64_32->zfile_func64.zwrite_file = p_filefunc32->zwrite_file;
-	p_filefunc64_32->zfile_func64.ztell64_file = NULL;
-	p_filefunc64_32->zfile_func64.zseek64_file = NULL;
-	p_filefunc64_32->zfile_func64.zclose_file = p_filefunc32->zclose_file;
-	p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;
-	p_filefunc64_32->zfile_func64.opaque = p_filefunc32->opaque;
-	p_filefunc64_32->zseek32_file = p_filefunc32->zseek_file;
-	p_filefunc64_32->ztell32_file = p_filefunc32->ztell_file;
+    p_filefunc64_32->zfile_func64.zopen64_file = NULL;
+    p_filefunc64_32->zopen32_file = p_filefunc32->zopen_file;
+    p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;
+    p_filefunc64_32->zfile_func64.zread_file = p_filefunc32->zread_file;
+    p_filefunc64_32->zfile_func64.zwrite_file = p_filefunc32->zwrite_file;
+    p_filefunc64_32->zfile_func64.ztell64_file = NULL;
+    p_filefunc64_32->zfile_func64.zseek64_file = NULL;
+    p_filefunc64_32->zfile_func64.zclose_file = p_filefunc32->zclose_file;
+    p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;
+    p_filefunc64_32->zfile_func64.opaque = p_filefunc32->opaque;
+    p_filefunc64_32->zseek32_file = p_filefunc32->zseek_file;
+    p_filefunc64_32->ztell32_file = p_filefunc32->ztell_file;
 }
 
 
 
-static voidpf  ZCALLBACK fopen_file_func OF((voidpf opaque, const wchar_t* filename, int mode));
+static voidpf  ZCALLBACK fopen_file_func OF((voidpf opaque, const char* filename, int mode));
 static uLong   ZCALLBACK fread_file_func OF((voidpf opaque, voidpf stream, void* buf, uLong size));
-static uLong   ZCALLBACK fwrite_file_func OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
+static uLong   ZCALLBACK fwrite_file_func OF((voidpf opaque, voidpf stream, const void* buf,uLong size));
 static ZPOS64_T ZCALLBACK ftell64_file_func OF((voidpf opaque, voidpf stream));
 static long    ZCALLBACK fseek64_file_func OF((voidpf opaque, voidpf stream, ZPOS64_T offset, int origin));
 static int     ZCALLBACK fclose_file_func OF((voidpf opaque, voidpf stream));
 static int     ZCALLBACK ferror_file_func OF((voidpf opaque, voidpf stream));
 
-static voidpf ZCALLBACK fopen_file_func(voidpf opaque, const wchar_t* filename, int mode)
+static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, int mode)
 {
-	FILE* file = NULL;
-	const wchar_t* mode_fopen = NULL;
-	if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
-		mode_fopen = L"rb";
-	else
-		if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
-			mode_fopen = L"r+b";
-		else
-			if (mode & ZLIB_FILEFUNC_MODE_CREATE)
-				mode_fopen = L"wb";
+    FILE* file = NULL;
+    const char* mode_fopen = NULL;
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+        mode_fopen = "rb";
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+        mode_fopen = "r+b";
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+        mode_fopen = "wb";
 
-	if ((filename != NULL) && (mode_fopen != NULL))
-		file = _wfopen(filename, mode_fopen);
-	return file;
+    if ((filename!=NULL) && (mode_fopen != NULL))
+        file = fopen(filename, mode_fopen);
+    return file;
 }
 
-static voidpf ZCALLBACK fopen64_file_func(voidpf opaque, const void* filename, int mode)
+static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, int mode)
 {
-	FILE* file = NULL;
-	const wchar_t* mode_fopen = NULL;
-	if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
-		mode_fopen = L"rb";
-	else
-		if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
-			mode_fopen = L"r+b";
-		else
-			if (mode & ZLIB_FILEFUNC_MODE_CREATE)
-				mode_fopen = L"wb";
+    FILE* file = NULL;
+    const char* mode_fopen = NULL;
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+        mode_fopen = "rb";
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+        mode_fopen = "r+b";
+    else
+    if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+        mode_fopen = "wb";
 
-	if ((filename != NULL) && (mode_fopen != NULL))
-		file = _wfopen((const wchar_t*)filename, mode_fopen);
-	return file;
-}
-
-
-static uLong ZCALLBACK fread_file_func(voidpf opaque, voidpf stream, void* buf, uLong size)
-{
-	uLong ret;
-	ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
-	return ret;
-}
-
-static uLong ZCALLBACK fwrite_file_func(voidpf opaque, voidpf stream, const void* buf, uLong size)
-{
-	uLong ret;
-	ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
-	return ret;
-}
-
-static long ZCALLBACK ftell_file_func(voidpf opaque, voidpf stream)
-{
-	long ret;
-	ret = ftell((FILE *)stream);
-	return ret;
+    if ((filename!=NULL) && (mode_fopen != NULL))
+        file = FOPEN_FUNC((const char*)filename, mode_fopen);
+    return file;
 }
 
 
-static ZPOS64_T ZCALLBACK ftell64_file_func(voidpf opaque, voidpf stream)
+static uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf, uLong size)
 {
-	ZPOS64_T ret;
-	ret = FTELLO_FUNC((FILE *)stream);
-	return ret;
+    uLong ret;
+    ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
+    return ret;
 }
 
-static long ZCALLBACK fseek_file_func(voidpf  opaque, voidpf stream, uLong offset, int origin)
+static uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const void* buf, uLong size)
 {
-	int fseek_origin = 0;
-	long ret;
-	switch (origin) {
-	case ZLIB_FILEFUNC_SEEK_CUR:
-		fseek_origin = SEEK_CUR;
-		break;
-	case ZLIB_FILEFUNC_SEEK_END:
-		fseek_origin = SEEK_END;
-		break;
-	case ZLIB_FILEFUNC_SEEK_SET:
-		fseek_origin = SEEK_SET;
-		break;
-	default: return -1;
-	}
-	ret = 0;
-	if (fseek((FILE *)stream, offset, fseek_origin) != 0)
-		ret = -1;
-	return ret;
+    uLong ret;
+    ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
+    return ret;
 }
 
-static long ZCALLBACK fseek64_file_func(voidpf  opaque, voidpf stream, ZPOS64_T offset, int origin)
+static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 {
-	int fseek_origin = 0;
-	long ret;
-	switch (origin) {
-	case ZLIB_FILEFUNC_SEEK_CUR:
-		fseek_origin = SEEK_CUR;
-		break;
-	case ZLIB_FILEFUNC_SEEK_END:
-		fseek_origin = SEEK_END;
-		break;
-	case ZLIB_FILEFUNC_SEEK_SET:
-		fseek_origin = SEEK_SET;
-		break;
-	default: return -1;
-	}
-	ret = 0;
-
-	if (FSEEKO_FUNC((FILE *)stream, offset, fseek_origin) != 0)
-		ret = -1;
-
-	return ret;
+    long ret;
+    ret = ftell((FILE *)stream);
+    return ret;
 }
 
 
-static int ZCALLBACK fclose_file_func(voidpf opaque, voidpf stream)
+static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf opaque, voidpf stream)
 {
-	int ret;
-	ret = fclose((FILE *)stream);
-	return ret;
+    ZPOS64_T ret;
+    ret = FTELLO_FUNC((FILE *)stream);
+    return ret;
 }
 
-static int ZCALLBACK ferror_file_func(voidpf opaque, voidpf stream)
+static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offset, int origin)
 {
-	int ret;
-	ret = ferror((FILE *)stream);
-	return ret;
+    int fseek_origin=0;
+    long ret;
+    switch (origin)
+    {
+    case ZLIB_FILEFUNC_SEEK_CUR :
+        fseek_origin = SEEK_CUR;
+        break;
+    case ZLIB_FILEFUNC_SEEK_END :
+        fseek_origin = SEEK_END;
+        break;
+    case ZLIB_FILEFUNC_SEEK_SET :
+        fseek_origin = SEEK_SET;
+        break;
+    default: return -1;
+    }
+    ret = 0;
+    if (fseek((FILE *)stream, offset, fseek_origin) != 0)
+        ret = -1;
+    return ret;
 }
 
-void fill_fopen_filefunc(pzlib_filefunc_def)
-zlib_filefunc_def* pzlib_filefunc_def;
+static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T offset, int origin)
 {
-	pzlib_filefunc_def->zopen_file = fopen_file_func;
-	pzlib_filefunc_def->zread_file = fread_file_func;
-	pzlib_filefunc_def->zwrite_file = fwrite_file_func;
-	pzlib_filefunc_def->ztell_file = ftell_file_func;
-	pzlib_filefunc_def->zseek_file = fseek_file_func;
-	pzlib_filefunc_def->zclose_file = fclose_file_func;
-	pzlib_filefunc_def->zerror_file = ferror_file_func;
-	pzlib_filefunc_def->opaque = NULL;
+    int fseek_origin=0;
+    long ret;
+    switch (origin)
+    {
+    case ZLIB_FILEFUNC_SEEK_CUR :
+        fseek_origin = SEEK_CUR;
+        break;
+    case ZLIB_FILEFUNC_SEEK_END :
+        fseek_origin = SEEK_END;
+        break;
+    case ZLIB_FILEFUNC_SEEK_SET :
+        fseek_origin = SEEK_SET;
+        break;
+    default: return -1;
+    }
+    ret = 0;
+
+    if(FSEEKO_FUNC((FILE *)stream, offset, fseek_origin) != 0)
+                        ret = -1;
+
+    return ret;
 }
 
-void fill_fopen64_filefunc(zlib_filefunc64_def*  pzlib_filefunc_def)
+
+static int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
 {
-	pzlib_filefunc_def->zopen64_file = fopen64_file_func;
-	pzlib_filefunc_def->zread_file = fread_file_func;
-	pzlib_filefunc_def->zwrite_file = fwrite_file_func;
-	pzlib_filefunc_def->ztell64_file = ftell64_file_func;
-	pzlib_filefunc_def->zseek64_file = fseek64_file_func;
-	pzlib_filefunc_def->zclose_file = fclose_file_func;
-	pzlib_filefunc_def->zerror_file = ferror_file_func;
-	pzlib_filefunc_def->opaque = NULL;
+    int ret;
+    ret = fclose((FILE *)stream);
+    return ret;
+}
+
+static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
+{
+    int ret;
+    ret = ferror((FILE *)stream);
+    return ret;
+}
+
+void fill_fopen_filefunc (pzlib_filefunc_def)
+  zlib_filefunc_def* pzlib_filefunc_def;
+{
+    pzlib_filefunc_def->zopen_file = fopen_file_func;
+    pzlib_filefunc_def->zread_file = fread_file_func;
+    pzlib_filefunc_def->zwrite_file = fwrite_file_func;
+    pzlib_filefunc_def->ztell_file = ftell_file_func;
+    pzlib_filefunc_def->zseek_file = fseek_file_func;
+    pzlib_filefunc_def->zclose_file = fclose_file_func;
+    pzlib_filefunc_def->zerror_file = ferror_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}
+
+void fill_fopen64_filefunc (zlib_filefunc64_def*  pzlib_filefunc_def)
+{
+    pzlib_filefunc_def->zopen64_file = fopen64_file_func;
+    pzlib_filefunc_def->zread_file = fread_file_func;
+    pzlib_filefunc_def->zwrite_file = fwrite_file_func;
+    pzlib_filefunc_def->ztell64_file = ftell64_file_func;
+    pzlib_filefunc_def->zseek64_file = fseek64_file_func;
+    pzlib_filefunc_def->zclose_file = fclose_file_func;
+    pzlib_filefunc_def->zerror_file = ferror_file_func;
+    pzlib_filefunc_def->opaque = NULL;
 }

--- a/libs/zlib/src/ioapi.h
+++ b/libs/zlib/src/ioapi.h
@@ -132,7 +132,7 @@ extern "C" {
 
 
 
-typedef voidpf   (ZCALLBACK *open_file_func)      OF((voidpf opaque, const char* filename, int mode));
+typedef voidpf   (ZCALLBACK *open_file_func)      OF((voidpf opaque, const wchar_t* filename, int mode));
 typedef uLong    (ZCALLBACK *read_file_func)      OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 typedef uLong    (ZCALLBACK *write_file_func)     OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
 typedef int      (ZCALLBACK *close_file_func)     OF((voidpf opaque, voidpf stream));

--- a/libs/zlib/src/ioapi.h
+++ b/libs/zlib/src/ioapi.h
@@ -41,7 +41,6 @@
 
 #endif
 
-#include <tchar.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "zlib.h"
@@ -133,7 +132,7 @@ extern "C" {
 
 
 
-typedef voidpf   (ZCALLBACK *open_file_func)      OF((voidpf opaque, const wchar_t* filename, int mode));
+typedef voidpf   (ZCALLBACK *open_file_func)      OF((voidpf opaque, const char* filename, int mode));
 typedef uLong    (ZCALLBACK *read_file_func)      OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 typedef uLong    (ZCALLBACK *write_file_func)     OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
 typedef int      (ZCALLBACK *close_file_func)     OF((voidpf opaque, voidpf stream));

--- a/libs/zlib/src/iowin32.c
+++ b/libs/zlib/src/iowin32.c
@@ -33,7 +33,7 @@
 #endif
 #endif
 
-voidpf  ZCALLBACK win32_open_file_func  OF((voidpf opaque, const char* filename, int mode));
+voidpf  ZCALLBACK win32_open_file_func  OF((voidpf opaque, const wchar_t* filename, int mode));
 uLong   ZCALLBACK win32_read_file_func  OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 uLong   ZCALLBACK win32_write_file_func OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
 ZPOS64_T ZCALLBACK win32_tell64_file_func  OF((voidpf opaque, voidpf stream));
@@ -166,7 +166,7 @@ voidpf ZCALLBACK win32_open64_file_funcW (voidpf opaque,const void* filename,int
 }
 
 
-voidpf ZCALLBACK win32_open_file_func (voidpf opaque,const char* filename,int mode)
+voidpf ZCALLBACK win32_open_file_func (voidpf opaque,const wchar_t* filename,int mode)
 {
     const char* mode_fopen = NULL;
     DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;

--- a/libs/zlib/src/iowin32.c
+++ b/libs/zlib/src/iowin32.c
@@ -26,13 +26,14 @@
 #endif
 
 
+// see Include/shared/winapifamily.h in the Windows Kit
 #if defined(WINAPI_FAMILY_PARTITION) && (!(defined(IOWIN32_USING_WINRT_API)))
-#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
+#if WINAPI_FAMILY_ONE_PARTITION(WINAPI_FAMILY, WINAPI_PARTITION_APP)
 #define IOWIN32_USING_WINRT_API 1
 #endif
 #endif
 
-voidpf  ZCALLBACK win32_open_file_func  OF((voidpf opaque, const wchar_t* filename, int mode));
+voidpf  ZCALLBACK win32_open_file_func  OF((voidpf opaque, const char* filename, int mode));
 uLong   ZCALLBACK win32_read_file_func  OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 uLong   ZCALLBACK win32_write_file_func OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
 ZPOS64_T ZCALLBACK win32_tell64_file_func  OF((voidpf opaque, voidpf stream));
@@ -42,386 +43,420 @@ int     ZCALLBACK win32_error_file_func OF((voidpf opaque, voidpf stream));
 
 typedef struct
 {
-	HANDLE hf;
-	int error;
+    HANDLE hf;
+    int error;
 } WIN32FILE_IOWIN;
 
-static void win32_translate_open_mode(int mode,
-	DWORD* lpdwDesiredAccess,
-	DWORD* lpdwCreationDisposition,
-	DWORD* lpdwShareMode,
-	DWORD* lpdwFlagsAndAttributes)
-{
-	*lpdwDesiredAccess = *lpdwShareMode = *lpdwFlagsAndAttributes = *lpdwCreationDisposition = 0;
 
-	if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ) {
-		*lpdwDesiredAccess = GENERIC_READ;
-		*lpdwCreationDisposition = OPEN_EXISTING;
-		*lpdwShareMode = FILE_SHARE_READ;
-	}
-	else if (mode & ZLIB_FILEFUNC_MODE_EXISTING) {
-		*lpdwDesiredAccess = GENERIC_WRITE | GENERIC_READ;
-		*lpdwCreationDisposition = OPEN_EXISTING;
-	}
-	else if (mode & ZLIB_FILEFUNC_MODE_CREATE) {
-		*lpdwDesiredAccess = GENERIC_WRITE | GENERIC_READ;
-		*lpdwCreationDisposition = CREATE_ALWAYS;
-	}
+static void win32_translate_open_mode(int mode,
+                                      DWORD* lpdwDesiredAccess,
+                                      DWORD* lpdwCreationDisposition,
+                                      DWORD* lpdwShareMode,
+                                      DWORD* lpdwFlagsAndAttributes)
+{
+    *lpdwDesiredAccess = *lpdwShareMode = *lpdwFlagsAndAttributes = *lpdwCreationDisposition = 0;
+
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+    {
+        *lpdwDesiredAccess = GENERIC_READ;
+        *lpdwCreationDisposition = OPEN_EXISTING;
+        *lpdwShareMode = FILE_SHARE_READ;
+    }
+    else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+    {
+        *lpdwDesiredAccess = GENERIC_WRITE | GENERIC_READ;
+        *lpdwCreationDisposition = OPEN_EXISTING;
+    }
+    else if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+    {
+        *lpdwDesiredAccess = GENERIC_WRITE | GENERIC_READ;
+        *lpdwCreationDisposition = CREATE_ALWAYS;
+    }
 }
 
 static voidpf win32_build_iowin(HANDLE hFile)
 {
-	voidpf ret = NULL;
+    voidpf ret=NULL;
 
-	if ((hFile != NULL) && (hFile != INVALID_HANDLE_VALUE)) {
-		WIN32FILE_IOWIN w32fiow;
-		w32fiow.hf = hFile;
-		w32fiow.error = 0;
-		ret = malloc(sizeof(WIN32FILE_IOWIN));
+    if ((hFile != NULL) && (hFile != INVALID_HANDLE_VALUE))
+    {
+        WIN32FILE_IOWIN w32fiow;
+        w32fiow.hf = hFile;
+        w32fiow.error = 0;
+        ret = malloc(sizeof(WIN32FILE_IOWIN));
 
-		if (ret == NULL)
-			CloseHandle(hFile);
-		else
-			*((WIN32FILE_IOWIN*)ret) = w32fiow;
-	}
-	return ret;
+        if (ret==NULL)
+            CloseHandle(hFile);
+        else
+            *((WIN32FILE_IOWIN*)ret) = w32fiow;
+    }
+    return ret;
 }
 
-voidpf ZCALLBACK win32_open64_file_func(voidpf opaque, const void* filename, int mode)
+voidpf ZCALLBACK win32_open64_file_func (voidpf opaque,const void* filename,int mode)
 {
-	const char* mode_fopen = NULL;
-	DWORD dwDesiredAccess, dwCreationDisposition, dwShareMode, dwFlagsAndAttributes;
-	HANDLE hFile = NULL;
+    const char* mode_fopen = NULL;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
 
-	win32_translate_open_mode(mode, &dwDesiredAccess, &dwCreationDisposition, &dwShareMode, &dwFlagsAndAttributes);
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-	#ifdef IOWIN32_USING_WINRT_API
-	#ifdef UNICODE
-	if ((filename != NULL) && (dwDesiredAccess != 0))
-		hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
-	#else
-	if ((filename != NULL) && (dwDesiredAccess != 0)) {
-		WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
-		MultiByteToWideChar(CP_ACP, 0, (const char*)filename, -1, filenameW, FILENAME_MAX + 0x200);
-		hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
-	}
-	#endif
-	#else
-	if ((filename != NULL) && (dwDesiredAccess != 0))
-		hFile = CreateFile((LPCTSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
-	#endif
+#ifdef IOWIN32_USING_WINRT_API
+#ifdef UNICODE
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+    {
+        WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+        MultiByteToWideChar(CP_ACP,0,(const char*)filename,-1,filenameW,FILENAME_MAX + 0x200);
+        hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+    }
+#endif
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile((LPCTSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
 
-	return win32_build_iowin(hFile);
+    return win32_build_iowin(hFile);
 }
 
-voidpf ZCALLBACK win32_open64_file_funcA(voidpf opaque, const void* filename, int mode)
+
+voidpf ZCALLBACK win32_open64_file_funcA (voidpf opaque,const void* filename,int mode)
 {
-	const char* mode_fopen = NULL;
-	DWORD dwDesiredAccess, dwCreationDisposition, dwShareMode, dwFlagsAndAttributes;
-	HANDLE hFile = NULL;
+    const char* mode_fopen = NULL;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
 
-	win32_translate_open_mode(mode, &dwDesiredAccess, &dwCreationDisposition, &dwShareMode, &dwFlagsAndAttributes);
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-	#ifdef IOWIN32_USING_WINRT_API
-	if ((filename != NULL) && (dwDesiredAccess != 0)) {
-		WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
-		MultiByteToWideChar(CP_ACP, 0, (const char*)filename, -1, filenameW, FILENAME_MAX + 0x200);
-		hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
-	}
-	#else
-	if ((filename != NULL) && (dwDesiredAccess != 0))
-		hFile = CreateFileA((LPCSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
-	#endif
+#ifdef IOWIN32_USING_WINRT_API
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+    {
+        WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+        MultiByteToWideChar(CP_ACP,0,(const char*)filename,-1,filenameW,FILENAME_MAX + 0x200);
+        hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+    }
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFileA((LPCSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
 
-	return win32_build_iowin(hFile);
+    return win32_build_iowin(hFile);
 }
 
-voidpf ZCALLBACK win32_open64_file_funcW(voidpf opaque, const void* filename, int mode)
+
+voidpf ZCALLBACK win32_open64_file_funcW (voidpf opaque,const void* filename,int mode)
 {
-	const char* mode_fopen = NULL;
-	DWORD dwDesiredAccess, dwCreationDisposition, dwShareMode, dwFlagsAndAttributes;
-	HANDLE hFile = NULL;
+    const char* mode_fopen = NULL;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
 
-	win32_translate_open_mode(mode, &dwDesiredAccess, &dwCreationDisposition, &dwShareMode, &dwFlagsAndAttributes);
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-	#ifdef IOWIN32_USING_WINRT_API
-	if ((filename != NULL) && (dwDesiredAccess != 0))
-		hFile = CreateFile2((LPCWSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
-	#else
-	if ((filename != NULL) && (dwDesiredAccess != 0))
-		hFile = CreateFileW((LPCWSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
-	#endif
+#ifdef IOWIN32_USING_WINRT_API
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile2((LPCWSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition,NULL);
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFileW((LPCWSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
 
-	return win32_build_iowin(hFile);
+    return win32_build_iowin(hFile);
 }
 
-voidpf ZCALLBACK win32_open_file_func(voidpf opaque, const wchar_t* filename, int mode)
+
+voidpf ZCALLBACK win32_open_file_func (voidpf opaque,const char* filename,int mode)
 {
-	const char* mode_fopen = NULL;
-	DWORD dwDesiredAccess, dwCreationDisposition, dwShareMode, dwFlagsAndAttributes;
-	HANDLE hFile = NULL;
+    const char* mode_fopen = NULL;
+    DWORD dwDesiredAccess,dwCreationDisposition,dwShareMode,dwFlagsAndAttributes ;
+    HANDLE hFile = NULL;
 
-	win32_translate_open_mode(mode, &dwDesiredAccess, &dwCreationDisposition, &dwShareMode, &dwFlagsAndAttributes);
+    win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-	#ifdef IOWIN32_USING_WINRT_API
-	#ifdef UNICODE
-	if ((filename != NULL) && (dwDesiredAccess != 0))
-		hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
-	#else
-	if ((filename != NULL) && (dwDesiredAccess != 0)) {
-		WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
-		MultiByteToWideChar(CP_ACP, 0, (const char*)filename, -1, filenameW, FILENAME_MAX + 0x200);
-		hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
-	}
-	#endif
-	#else
-	if ((filename != NULL) && (dwDesiredAccess != 0))
-		hFile = CreateFile((LPCTSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
-	#endif
+#ifdef IOWIN32_USING_WINRT_API
+#ifdef UNICODE
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+    {
+        WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
+        MultiByteToWideChar(CP_ACP,0,(const char*)filename,-1,filenameW,FILENAME_MAX + 0x200);
+        hFile = CreateFile2(filenameW, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
+    }
+#endif
+#else
+    if ((filename!=NULL) && (dwDesiredAccess != 0))
+        hFile = CreateFile((LPCTSTR)filename, dwDesiredAccess, dwShareMode, NULL, dwCreationDisposition, dwFlagsAndAttributes, NULL);
+#endif
 
-	return win32_build_iowin(hFile);
+    return win32_build_iowin(hFile);
 }
 
-uLong ZCALLBACK win32_read_file_func(voidpf opaque, voidpf stream, void* buf, uLong size)
+
+uLong ZCALLBACK win32_read_file_func (voidpf opaque, voidpf stream, void* buf,uLong size)
 {
-	uLong ret = 0;
-	HANDLE hFile = NULL;
-	if (stream != NULL)
-		hFile = ((WIN32FILE_IOWIN*)stream)->hf;
+    uLong ret=0;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
 
-	if (hFile != NULL) {
-		if (!ReadFile(hFile, buf, size, &ret, NULL)) {
-			DWORD dwErr = GetLastError();
-			if (dwErr == ERROR_HANDLE_EOF)
-				dwErr = 0;
-			((WIN32FILE_IOWIN*)stream)->error = (int)dwErr;
-		}
-	}
+    if (hFile != NULL)
+    {
+        if (!ReadFile(hFile, buf, size, &ret, NULL))
+        {
+            DWORD dwErr = GetLastError();
+            if (dwErr == ERROR_HANDLE_EOF)
+                dwErr = 0;
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
-uLong ZCALLBACK win32_write_file_func(voidpf opaque, voidpf stream, const void* buf, uLong size)
+
+uLong ZCALLBACK win32_write_file_func (voidpf opaque,voidpf stream,const void* buf,uLong size)
 {
-	uLong ret = 0;
-	HANDLE hFile = NULL;
-	if (stream != NULL)
-		hFile = ((WIN32FILE_IOWIN*)stream)->hf;
+    uLong ret=0;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
 
-	if (hFile != NULL) {
-		if (!WriteFile(hFile, buf, size, &ret, NULL)) {
-			DWORD dwErr = GetLastError();
-			if (dwErr == ERROR_HANDLE_EOF)
-				dwErr = 0;
-			((WIN32FILE_IOWIN*)stream)->error = (int)dwErr;
-		}
-	}
+    if (hFile != NULL)
+    {
+        if (!WriteFile(hFile, buf, size, &ret, NULL))
+        {
+            DWORD dwErr = GetLastError();
+            if (dwErr == ERROR_HANDLE_EOF)
+                dwErr = 0;
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
-static BOOL MySetFilePointerEx(HANDLE hFile, LARGE_INTEGER pos, LARGE_INTEGER *newPos, DWORD dwMoveMethod)
+static BOOL MySetFilePointerEx(HANDLE hFile, LARGE_INTEGER pos, LARGE_INTEGER *newPos,  DWORD dwMoveMethod)
 {
-	#ifdef IOWIN32_USING_WINRT_API
-	return SetFilePointerEx(hFile, pos, newPos, dwMoveMethod);
-	#else
-	LONG lHigh = pos.HighPart;
-	DWORD dwNewPos = SetFilePointer(hFile, pos.LowPart, &lHigh, FILE_CURRENT);
-	BOOL fOk = TRUE;
-	if (dwNewPos == 0xFFFFFFFF)
-		if (GetLastError() != NO_ERROR)
-			fOk = FALSE;
-	if ((newPos != NULL) && (fOk)) {
-		newPos->LowPart = dwNewPos;
-		newPos->HighPart = lHigh;
-	}
-	return fOk;
-	#endif
+#ifdef IOWIN32_USING_WINRT_API
+    return SetFilePointerEx(hFile, pos, newPos, dwMoveMethod);
+#else
+    LONG lHigh = pos.HighPart;
+    DWORD dwNewPos = SetFilePointer(hFile, pos.LowPart, &lHigh, dwMoveMethod);
+    BOOL fOk = TRUE;
+    if (dwNewPos == 0xFFFFFFFF)
+        if (GetLastError() != NO_ERROR)
+            fOk = FALSE;
+    if ((newPos != NULL) && (fOk))
+    {
+        newPos->LowPart = dwNewPos;
+        newPos->HighPart = lHigh;
+    }
+    return fOk;
+#endif
 }
 
-long ZCALLBACK win32_tell_file_func(voidpf opaque, voidpf stream)
+long ZCALLBACK win32_tell_file_func (voidpf opaque,voidpf stream)
 {
-	long ret = -1;
-	HANDLE hFile = NULL;
-	if (stream != NULL)
-		hFile = ((WIN32FILE_IOWIN*)stream)->hf;
-	if (hFile != NULL) {
-		LARGE_INTEGER pos;
-		pos.QuadPart = 0;
+    long ret=-1;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+    if (hFile != NULL)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = 0;
 
-		if (!MySetFilePointerEx(hFile, pos, &pos, FILE_CURRENT)) {
-			DWORD dwErr = GetLastError();
-			((WIN32FILE_IOWIN*)stream)->error = (int)dwErr;
-			ret = -1;
-		}
-		else
-			ret = (long)pos.LowPart;
-	}
-	return ret;
+        if (!MySetFilePointerEx(hFile, pos, &pos, FILE_CURRENT))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = -1;
+        }
+        else
+            ret=(long)pos.LowPart;
+    }
+    return ret;
 }
 
-ZPOS64_T ZCALLBACK win32_tell64_file_func(voidpf opaque, voidpf stream)
+ZPOS64_T ZCALLBACK win32_tell64_file_func (voidpf opaque, voidpf stream)
 {
-	ZPOS64_T ret = (ZPOS64_T)-1;
-	HANDLE hFile = NULL;
-	if (stream != NULL)
-		hFile = ((WIN32FILE_IOWIN*)stream)->hf;
+    ZPOS64_T ret= (ZPOS64_T)-1;
+    HANDLE hFile = NULL;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream)->hf;
 
-	if (hFile) {
-		LARGE_INTEGER pos;
-		pos.QuadPart = 0;
+    if (hFile)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = 0;
 
-		if (!MySetFilePointerEx(hFile, pos, &pos, FILE_CURRENT)) {
-			DWORD dwErr = GetLastError();
-			((WIN32FILE_IOWIN*)stream)->error = (int)dwErr;
-			ret = (ZPOS64_T)-1;
-		}
-		else
-			ret = pos.QuadPart;
-	}
-	return ret;
+        if (!MySetFilePointerEx(hFile, pos, &pos, FILE_CURRENT))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = (ZPOS64_T)-1;
+        }
+        else
+            ret=pos.QuadPart;
+    }
+    return ret;
 }
 
-long ZCALLBACK win32_seek_file_func(voidpf opaque, voidpf stream, uLong offset, int origin)
+
+long ZCALLBACK win32_seek_file_func (voidpf opaque,voidpf stream,uLong offset,int origin)
 {
-	DWORD dwMoveMethod = 0xFFFFFFFF;
-	HANDLE hFile = NULL;
+    DWORD dwMoveMethod=0xFFFFFFFF;
+    HANDLE hFile = NULL;
 
-	long ret = -1;
-	if (stream != NULL)
-		hFile = ((WIN32FILE_IOWIN*)stream)->hf;
-	switch (origin) {
-	case ZLIB_FILEFUNC_SEEK_CUR:
-		dwMoveMethod = FILE_CURRENT;
-		break;
-	case ZLIB_FILEFUNC_SEEK_END:
-		dwMoveMethod = FILE_END;
-		break;
-	case ZLIB_FILEFUNC_SEEK_SET:
-		dwMoveMethod = FILE_BEGIN;
-		break;
-	default: return -1;
-	}
+    long ret=-1;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+    switch (origin)
+    {
+    case ZLIB_FILEFUNC_SEEK_CUR :
+        dwMoveMethod = FILE_CURRENT;
+        break;
+    case ZLIB_FILEFUNC_SEEK_END :
+        dwMoveMethod = FILE_END;
+        break;
+    case ZLIB_FILEFUNC_SEEK_SET :
+        dwMoveMethod = FILE_BEGIN;
+        break;
+    default: return -1;
+    }
 
-	if (hFile != NULL) {
-		LARGE_INTEGER pos;
-		pos.QuadPart = offset;
-		if (!MySetFilePointerEx(hFile, pos, NULL, dwMoveMethod)) {
-			DWORD dwErr = GetLastError();
-			((WIN32FILE_IOWIN*)stream)->error = (int)dwErr;
-			ret = -1;
-		}
-		else
-			ret = 0;
-	}
-	return ret;
+    if (hFile != NULL)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = offset;
+        if (!MySetFilePointerEx(hFile, pos, NULL, dwMoveMethod))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = -1;
+        }
+        else
+            ret=0;
+    }
+    return ret;
 }
 
-long ZCALLBACK win32_seek64_file_func(voidpf opaque, voidpf stream, ZPOS64_T offset, int origin)
+long ZCALLBACK win32_seek64_file_func (voidpf opaque, voidpf stream,ZPOS64_T offset,int origin)
 {
-	DWORD dwMoveMethod = 0xFFFFFFFF;
-	HANDLE hFile = NULL;
-	long ret = -1;
+    DWORD dwMoveMethod=0xFFFFFFFF;
+    HANDLE hFile = NULL;
+    long ret=-1;
 
-	if (stream != NULL)
-		hFile = ((WIN32FILE_IOWIN*)stream)->hf;
+    if (stream!=NULL)
+        hFile = ((WIN32FILE_IOWIN*)stream)->hf;
 
-	switch (origin) {
-	case ZLIB_FILEFUNC_SEEK_CUR:
-		dwMoveMethod = FILE_CURRENT;
-		break;
-	case ZLIB_FILEFUNC_SEEK_END:
-		dwMoveMethod = FILE_END;
-		break;
-	case ZLIB_FILEFUNC_SEEK_SET:
-		dwMoveMethod = FILE_BEGIN;
-		break;
-	default: return -1;
-	}
+    switch (origin)
+    {
+        case ZLIB_FILEFUNC_SEEK_CUR :
+            dwMoveMethod = FILE_CURRENT;
+            break;
+        case ZLIB_FILEFUNC_SEEK_END :
+            dwMoveMethod = FILE_END;
+            break;
+        case ZLIB_FILEFUNC_SEEK_SET :
+            dwMoveMethod = FILE_BEGIN;
+            break;
+        default: return -1;
+    }
 
-	if (hFile) {
-		LARGE_INTEGER pos;
-		pos.QuadPart = offset;
-		if (!MySetFilePointerEx(hFile, pos, NULL, FILE_CURRENT)) {
-			DWORD dwErr = GetLastError();
-			((WIN32FILE_IOWIN*)stream)->error = (int)dwErr;
-			ret = -1;
-		}
-		else
-			ret = 0;
-	}
-	return ret;
+    if (hFile)
+    {
+        LARGE_INTEGER pos;
+        pos.QuadPart = offset;
+        if (!MySetFilePointerEx(hFile, pos, NULL, dwMoveMethod))
+        {
+            DWORD dwErr = GetLastError();
+            ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
+            ret = -1;
+        }
+        else
+            ret=0;
+    }
+    return ret;
 }
 
-int ZCALLBACK win32_close_file_func(voidpf opaque, voidpf stream)
+int ZCALLBACK win32_close_file_func (voidpf opaque, voidpf stream)
 {
-	int ret = -1;
+    int ret=-1;
 
-	if (stream != NULL) {
-		HANDLE hFile;
-		hFile = ((WIN32FILE_IOWIN*)stream)->hf;
-		if (hFile != NULL) {
-			CloseHandle(hFile);
-			ret = 0;
-		}
-		free(stream);
-	}
-	return ret;
+    if (stream!=NULL)
+    {
+        HANDLE hFile;
+        hFile = ((WIN32FILE_IOWIN*)stream) -> hf;
+        if (hFile != NULL)
+        {
+            CloseHandle(hFile);
+            ret=0;
+        }
+        free(stream);
+    }
+    return ret;
 }
 
-int ZCALLBACK win32_error_file_func(voidpf opaque, voidpf stream)
+int ZCALLBACK win32_error_file_func (voidpf opaque,voidpf stream)
 {
-	int ret = -1;
-	if (stream != NULL) {
-		ret = ((WIN32FILE_IOWIN*)stream)->error;
-	}
-	return ret;
+    int ret=-1;
+    if (stream!=NULL)
+    {
+        ret = ((WIN32FILE_IOWIN*)stream) -> error;
+    }
+    return ret;
 }
 
-void fill_win32_filefunc(zlib_filefunc_def* pzlib_filefunc_def)
+void fill_win32_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
 {
-	pzlib_filefunc_def->zopen_file = win32_open_file_func;
-	pzlib_filefunc_def->zread_file = win32_read_file_func;
-	pzlib_filefunc_def->zwrite_file = win32_write_file_func;
-	pzlib_filefunc_def->ztell_file = win32_tell_file_func;
-	pzlib_filefunc_def->zseek_file = win32_seek_file_func;
-	pzlib_filefunc_def->zclose_file = win32_close_file_func;
-	pzlib_filefunc_def->zerror_file = win32_error_file_func;
-	pzlib_filefunc_def->opaque = NULL;
+    pzlib_filefunc_def->zopen_file = win32_open_file_func;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell_file = win32_tell_file_func;
+    pzlib_filefunc_def->zseek_file = win32_seek_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
 }
 
 void fill_win32_filefunc64(zlib_filefunc64_def* pzlib_filefunc_def)
 {
-	pzlib_filefunc_def->zopen64_file = win32_open64_file_func;
-	pzlib_filefunc_def->zread_file = win32_read_file_func;
-	pzlib_filefunc_def->zwrite_file = win32_write_file_func;
-	pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
-	pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
-	pzlib_filefunc_def->zclose_file = win32_close_file_func;
-	pzlib_filefunc_def->zerror_file = win32_error_file_func;
-	pzlib_filefunc_def->opaque = NULL;
+    pzlib_filefunc_def->zopen64_file = win32_open64_file_func;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
+    pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
 }
+
 
 void fill_win32_filefunc64A(zlib_filefunc64_def* pzlib_filefunc_def)
 {
-	pzlib_filefunc_def->zopen64_file = win32_open64_file_funcA;
-	pzlib_filefunc_def->zread_file = win32_read_file_func;
-	pzlib_filefunc_def->zwrite_file = win32_write_file_func;
-	pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
-	pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
-	pzlib_filefunc_def->zclose_file = win32_close_file_func;
-	pzlib_filefunc_def->zerror_file = win32_error_file_func;
-	pzlib_filefunc_def->opaque = NULL;
+    pzlib_filefunc_def->zopen64_file = win32_open64_file_funcA;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
+    pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
 }
+
 
 void fill_win32_filefunc64W(zlib_filefunc64_def* pzlib_filefunc_def)
 {
-	pzlib_filefunc_def->zopen64_file = win32_open64_file_funcW;
-	pzlib_filefunc_def->zread_file = win32_read_file_func;
-	pzlib_filefunc_def->zwrite_file = win32_write_file_func;
-	pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
-	pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
-	pzlib_filefunc_def->zclose_file = win32_close_file_func;
-	pzlib_filefunc_def->zerror_file = win32_error_file_func;
-	pzlib_filefunc_def->opaque = NULL;
+    pzlib_filefunc_def->zopen64_file = win32_open64_file_funcW;
+    pzlib_filefunc_def->zread_file = win32_read_file_func;
+    pzlib_filefunc_def->zwrite_file = win32_write_file_func;
+    pzlib_filefunc_def->ztell64_file = win32_tell64_file_func;
+    pzlib_filefunc_def->zseek64_file = win32_seek64_file_func;
+    pzlib_filefunc_def->zclose_file = win32_close_file_func;
+    pzlib_filefunc_def->zerror_file = win32_error_file_func;
+    pzlib_filefunc_def->opaque = NULL;
 }

--- a/libs/zlib/src/mztools.c
+++ b/libs/zlib/src/mztools.c
@@ -34,277 +34,258 @@ const char* fileOutTmp;
 uLong* nRecovered;
 uLong* bytesRecovered;
 {
-	int err = Z_OK;
-	FILE* fpZip = fopen(file, "rb");
-	FILE* fpOut = fopen(fileOut, "wb");
-	FILE* fpOutCD = fopen(fileOutTmp, "wb");
-	if (fpZip != NULL &&  fpOut != NULL) {
-		int entries = 0;
-		uLong totalBytes = 0;
-		char header[30];
-		char filename[1024];
-		char extra[1024];
-		int offset = 0;
-		int offsetCD = 0;
-		while (fread(header, 1, 30, fpZip) == 30) {
-			int currentOffset = offset;
+  int err = Z_OK;
+  FILE* fpZip = fopen(file, "rb");
+  FILE* fpOut = fopen(fileOut, "wb");
+  FILE* fpOutCD = fopen(fileOutTmp, "wb");
+  if (fpZip != NULL &&  fpOut != NULL) {
+    int entries = 0;
+    uLong totalBytes = 0;
+    char header[30];
+    char filename[1024];
+    char extra[1024];
+    int offset = 0;
+    int offsetCD = 0;
+    while ( fread(header, 1, 30, fpZip) == 30 ) {
+      int currentOffset = offset;
 
-			/* File entry */
-			if (READ_32(header) == 0x04034b50) {
-				unsigned int version = READ_16(header + 4);
-				unsigned int gpflag = READ_16(header + 6);
-				unsigned int method = READ_16(header + 8);
-				unsigned int filetime = READ_16(header + 10);
-				unsigned int filedate = READ_16(header + 12);
-				unsigned int crc = READ_32(header + 14); /* crc */
-				unsigned int cpsize = READ_32(header + 18); /* compressed size */
-				unsigned int uncpsize = READ_32(header + 22); /* uncompressed sz */
-				unsigned int fnsize = READ_16(header + 26); /* file name length */
-				unsigned int extsize = READ_16(header + 28); /* extra field length */
-				filename[0] = extra[0] = '\0';
+      /* File entry */
+      if (READ_32(header) == 0x04034b50) {
+        unsigned int version = READ_16(header + 4);
+        unsigned int gpflag = READ_16(header + 6);
+        unsigned int method = READ_16(header + 8);
+        unsigned int filetime = READ_16(header + 10);
+        unsigned int filedate = READ_16(header + 12);
+        unsigned int crc = READ_32(header + 14); /* crc */
+        unsigned int cpsize = READ_32(header + 18); /* compressed size */
+        unsigned int uncpsize = READ_32(header + 22); /* uncompressed sz */
+        unsigned int fnsize = READ_16(header + 26); /* file name length */
+        unsigned int extsize = READ_16(header + 28); /* extra field length */
+        filename[0] = extra[0] = '\0';
 
-				/* Header */
-				if (fwrite(header, 1, 30, fpOut) == 30) {
-					offset += 30;
-				}
-				else {
-					err = Z_ERRNO;
-					break;
-				}
+        /* Header */
+        if (fwrite(header, 1, 30, fpOut) == 30) {
+          offset += 30;
+        } else {
+          err = Z_ERRNO;
+          break;
+        }
 
-				/* Filename */
-				if (fnsize > 0) {
-					if (fnsize < sizeof(filename)) {
-						if (fread(filename, 1, fnsize, fpZip) == fnsize) {
-							if (fwrite(filename, 1, fnsize, fpOut) == fnsize) {
-								offset += fnsize;
-							}
-							else {
-								err = Z_ERRNO;
-								break;
-							}
-						}
-						else {
-							err = Z_ERRNO;
-							break;
-						}
-					}
-					else {
-						err = Z_ERRNO;
-						break;
-					}
-				}
-				else {
-					err = Z_STREAM_ERROR;
-					break;
-				}
+        /* Filename */
+        if (fnsize > 0) {
+          if (fnsize < sizeof(filename)) {
+            if (fread(filename, 1, fnsize, fpZip) == fnsize) {
+                if (fwrite(filename, 1, fnsize, fpOut) == fnsize) {
+                offset += fnsize;
+              } else {
+                err = Z_ERRNO;
+                break;
+              }
+            } else {
+              err = Z_ERRNO;
+              break;
+            }
+          } else {
+            err = Z_ERRNO;
+            break;
+          }
+        } else {
+          err = Z_STREAM_ERROR;
+          break;
+        }
 
-				/* Extra field */
-				if (extsize > 0) {
-					if (extsize < sizeof(extra)) {
-						if (fread(extra, 1, extsize, fpZip) == extsize) {
-							if (fwrite(extra, 1, extsize, fpOut) == extsize) {
-								offset += extsize;
-							}
-							else {
-								err = Z_ERRNO;
-								break;
-							}
-						}
-						else {
-							err = Z_ERRNO;
-							break;
-						}
-					}
-					else {
-						err = Z_ERRNO;
-						break;
-					}
-				}
+        /* Extra field */
+        if (extsize > 0) {
+          if (extsize < sizeof(extra)) {
+            if (fread(extra, 1, extsize, fpZip) == extsize) {
+              if (fwrite(extra, 1, extsize, fpOut) == extsize) {
+                offset += extsize;
+                } else {
+                err = Z_ERRNO;
+                break;
+              }
+            } else {
+              err = Z_ERRNO;
+              break;
+            }
+          } else {
+            err = Z_ERRNO;
+            break;
+          }
+        }
 
-				/* Data */
-				{
-					int dataSize = cpsize;
-					if (dataSize == 0) {
-						dataSize = uncpsize;
-					}
-					if (dataSize > 0) {
-						char* data = malloc(dataSize);
-						if (data != NULL) {
-							if ((int)fread(data, 1, dataSize, fpZip) == dataSize) {
-								if ((int)fwrite(data, 1, dataSize, fpOut) == dataSize) {
-									offset += dataSize;
-									totalBytes += dataSize;
-								}
-								else {
-									err = Z_ERRNO;
-								}
-							}
-							else {
-								err = Z_ERRNO;
-							}
-							free(data);
-							if (err != Z_OK) {
-								break;
-							}
-						}
-						else {
-							err = Z_MEM_ERROR;
-							break;
-						}
-					}
-				}
+        /* Data */
+        {
+          int dataSize = cpsize;
+          if (dataSize == 0) {
+            dataSize = uncpsize;
+          }
+          if (dataSize > 0) {
+            char* data = malloc(dataSize);
+            if (data != NULL) {
+              if ((int)fread(data, 1, dataSize, fpZip) == dataSize) {
+                if ((int)fwrite(data, 1, dataSize, fpOut) == dataSize) {
+                  offset += dataSize;
+                  totalBytes += dataSize;
+                } else {
+                  err = Z_ERRNO;
+                }
+              } else {
+                err = Z_ERRNO;
+              }
+              free(data);
+              if (err != Z_OK) {
+                break;
+              }
+            } else {
+              err = Z_MEM_ERROR;
+              break;
+            }
+          }
+        }
 
-				/* Central directory entry */
-				{
-					char hdr[46];
-					char* comment = "";
-					int comsize = (int)strlen(comment);
-					WRITE_32(hdr, 0x02014b50);
-					WRITE_16(hdr + 4, version);
-					WRITE_16(hdr + 6, version);
-					WRITE_16(hdr + 8, gpflag);
-					WRITE_16(hdr + 10, method);
-					WRITE_16(hdr + 12, filetime);
-					WRITE_16(hdr + 14, filedate);
-					WRITE_32(hdr + 16, crc);
-					WRITE_32(hdr + 20, cpsize);
-					WRITE_32(hdr + 24, uncpsize);
-					WRITE_16(hdr + 28, fnsize);
-					WRITE_16(hdr + 30, extsize);
-					WRITE_16(hdr + 32, comsize);
-					WRITE_16(hdr + 34, 0);     /* disk # */
-					WRITE_16(hdr + 36, 0);     /* int attrb */
-					WRITE_32(hdr + 38, 0);     /* ext attrb */
-					WRITE_32(hdr + 42, currentOffset);
-					/* Header */
-					if (fwrite(hdr, 1, 46, fpOutCD) == 46) {
-						offsetCD += 46;
+        /* Central directory entry */
+        {
+          char header[46];
+          char* comment = "";
+          int comsize = (int) strlen(comment);
+          WRITE_32(header, 0x02014b50);
+          WRITE_16(header + 4, version);
+          WRITE_16(header + 6, version);
+          WRITE_16(header + 8, gpflag);
+          WRITE_16(header + 10, method);
+          WRITE_16(header + 12, filetime);
+          WRITE_16(header + 14, filedate);
+          WRITE_32(header + 16, crc);
+          WRITE_32(header + 20, cpsize);
+          WRITE_32(header + 24, uncpsize);
+          WRITE_16(header + 28, fnsize);
+          WRITE_16(header + 30, extsize);
+          WRITE_16(header + 32, comsize);
+          WRITE_16(header + 34, 0);     /* disk # */
+          WRITE_16(header + 36, 0);     /* int attrb */
+          WRITE_32(header + 38, 0);     /* ext attrb */
+          WRITE_32(header + 42, currentOffset);
+          /* Header */
+          if (fwrite(header, 1, 46, fpOutCD) == 46) {
+            offsetCD += 46;
 
-						/* Filename */
-						if (fnsize > 0) {
-							if (fwrite(filename, 1, fnsize, fpOutCD) == fnsize) {
-								offsetCD += fnsize;
-							}
-							else {
-								err = Z_ERRNO;
-								break;
-							}
-						}
-						else {
-							err = Z_STREAM_ERROR;
-							break;
-						}
+            /* Filename */
+            if (fnsize > 0) {
+              if (fwrite(filename, 1, fnsize, fpOutCD) == fnsize) {
+                offsetCD += fnsize;
+              } else {
+                err = Z_ERRNO;
+                break;
+              }
+            } else {
+              err = Z_STREAM_ERROR;
+              break;
+            }
 
-						/* Extra field */
-						if (extsize > 0) {
-							if (fwrite(extra, 1, extsize, fpOutCD) == extsize) {
-								offsetCD += extsize;
-							}
-							else {
-								err = Z_ERRNO;
-								break;
-							}
-						}
+            /* Extra field */
+            if (extsize > 0) {
+              if (fwrite(extra, 1, extsize, fpOutCD) == extsize) {
+                offsetCD += extsize;
+              } else {
+                err = Z_ERRNO;
+                break;
+              }
+            }
 
-						/* Comment field */
-						if (comsize > 0) {
-							if ((int)fwrite(comment, 1, comsize, fpOutCD) == comsize) {
-								offsetCD += comsize;
-							}
-							else {
-								err = Z_ERRNO;
-								break;
-							}
-						}
+            /* Comment field */
+            if (comsize > 0) {
+              if ((int)fwrite(comment, 1, comsize, fpOutCD) == comsize) {
+                offsetCD += comsize;
+              } else {
+                err = Z_ERRNO;
+                break;
+              }
+            }
 
 
-					}
-					else {
-						err = Z_ERRNO;
-						break;
-					}
-				}
+          } else {
+            err = Z_ERRNO;
+            break;
+          }
+        }
 
-				/* Success */
-				entries++;
+        /* Success */
+        entries++;
 
-			}
-			else {
-				break;
-			}
-		}
+      } else {
+        break;
+      }
+    }
 
-		/* Final central directory  */
-		{
-			int entriesZip = entries;
-			char hdr[22];
-			char* comment = ""; // "ZIP File recovered by zlib/minizip/mztools";
-			int comsize = (int)strlen(comment);
-			if (entriesZip > 0xffff) {
-				entriesZip = 0xffff;
-			}
-			WRITE_32(hdr, 0x06054b50);
-			WRITE_16(hdr + 4, 0);    /* disk # */
-			WRITE_16(hdr + 6, 0);    /* disk # */
-			WRITE_16(hdr + 8, entriesZip);   /* hack */
-			WRITE_16(hdr + 10, entriesZip);  /* hack */
-			WRITE_32(hdr + 12, offsetCD);    /* size of CD */
-			WRITE_32(hdr + 16, offset);      /* offset to CD */
-			WRITE_16(hdr + 20, comsize);     /* comment */
+    /* Final central directory  */
+    {
+      int entriesZip = entries;
+      char header[22];
+      char* comment = ""; // "ZIP File recovered by zlib/minizip/mztools";
+      int comsize = (int) strlen(comment);
+      if (entriesZip > 0xffff) {
+        entriesZip = 0xffff;
+      }
+      WRITE_32(header, 0x06054b50);
+      WRITE_16(header + 4, 0);    /* disk # */
+      WRITE_16(header + 6, 0);    /* disk # */
+      WRITE_16(header + 8, entriesZip);   /* hack */
+      WRITE_16(header + 10, entriesZip);  /* hack */
+      WRITE_32(header + 12, offsetCD);    /* size of CD */
+      WRITE_32(header + 16, offset);      /* offset to CD */
+      WRITE_16(header + 20, comsize);     /* comment */
 
-			/* Header */
-			if (fwrite(hdr, 1, 22, fpOutCD) == 22) {
+      /* Header */
+      if (fwrite(header, 1, 22, fpOutCD) == 22) {
 
-				/* Comment field */
-				if (comsize > 0) {
-					if ((int)fwrite(comment, 1, comsize, fpOutCD) != comsize) {
-						err = Z_ERRNO;
-					}
-				}
+        /* Comment field */
+        if (comsize > 0) {
+          if ((int)fwrite(comment, 1, comsize, fpOutCD) != comsize) {
+            err = Z_ERRNO;
+          }
+        }
 
-			}
-			else {
-				err = Z_ERRNO;
-			}
-		}
+      } else {
+        err = Z_ERRNO;
+      }
+    }
 
-		/* Final merge (file + central directory) */
-		fclose(fpOutCD);
-		if (err == Z_OK) {
-			fpOutCD = fopen(fileOutTmp, "rb");
-			if (fpOutCD != NULL) {
-				int nRead;
-				char buffer[8192];
-				while ((nRead = (int)fread(buffer, 1, sizeof(buffer), fpOutCD)) > 0) {
-					if ((int)fwrite(buffer, 1, nRead, fpOut) != nRead) {
-						err = Z_ERRNO;
-						break;
-					}
-				}
-				fclose(fpOutCD);
-			}
-		}
+    /* Final merge (file + central directory) */
+    fclose(fpOutCD);
+    if (err == Z_OK) {
+      fpOutCD = fopen(fileOutTmp, "rb");
+      if (fpOutCD != NULL) {
+        int nRead;
+        char buffer[8192];
+        while ( (nRead = (int)fread(buffer, 1, sizeof(buffer), fpOutCD)) > 0) {
+          if ((int)fwrite(buffer, 1, nRead, fpOut) != nRead) {
+            err = Z_ERRNO;
+            break;
+          }
+        }
+        fclose(fpOutCD);
+      }
+    }
 
-		/* Close */
-		fclose(fpZip);
-		fclose(fpOut);
+    /* Close */
+    fclose(fpZip);
+    fclose(fpOut);
 
-		/* Wipe temporary file */
-		(void)remove(fileOutTmp);
+    /* Wipe temporary file */
+    (void)remove(fileOutTmp);
 
-		/* Number of recovered entries */
-		if (err == Z_OK) {
-			if (nRecovered != NULL) {
-				*nRecovered = entries;
-			}
-			if (bytesRecovered != NULL) {
-				*bytesRecovered = totalBytes;
-			}
-		}
-	}
-	else {
-		err = Z_STREAM_ERROR;
-	}
-	return err;
+    /* Number of recovered entries */
+    if (err == Z_OK) {
+      if (nRecovered != NULL) {
+        *nRecovered = entries;
+      }
+      if (bytesRecovered != NULL) {
+        *bytesRecovered = totalBytes;
+      }
+    }
+  } else {
+    err = Z_STREAM_ERROR;
+  }
+  return err;
 }

--- a/libs/zlib/src/trees.c
+++ b/libs/zlib/src/trees.c
@@ -1,5 +1,5 @@
 /* trees.c -- output deflated data using Huffman coding
- * Copyright (C) 1995-2012 Jean-loup Gailly
+ * Copyright (C) 1995-2017 Jean-loup Gailly
  * detect_data_type() function provided freely by Cosmin Truta, 2006
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
@@ -36,7 +36,7 @@
 
 #include "deflate.h"
 
-#ifdef DEBUG
+#ifdef ZLIB_DEBUG
 #  include <ctype.h>
 #endif
 
@@ -60,30 +60,30 @@
 /* repeat a zero length 11-138 times  (7 bits of repeat count) */
 
 local const int extra_lbits[LENGTH_CODES] /* extra bits for each length code */
-= { 0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0 };
+   = {0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0};
 
 local const int extra_dbits[D_CODES] /* extra bits for each distance code */
-= { 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13 };
+   = {0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13};
 
 local const int extra_blbits[BL_CODES]/* extra bits for each bit length code */
-= { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,3,7 };
+   = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,3,7};
 
 local const uch bl_order[BL_CODES]
-= { 16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
+   = {16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15};
 /* The lengths of the bit length codes are sent in order of decreasing
  * probability, to avoid transmitting the lengths for unused bit length codes.
  */
 
- /* ===========================================================================
-  * Local data. These are initialized only once.
-  */
+/* ===========================================================================
+ * Local data. These are initialized only once.
+ */
 
 #define DIST_CODE_LEN  512 /* see definition of array dist_code below */
 
 #if defined(GEN_TREES_H) || !defined(STDC)
-  /* non ANSI compilers may not accept trees.h */
+/* non ANSI compilers may not accept trees.h */
 
-local ct_data static_ltree[L_CODES + 2];
+local ct_data static_ltree[L_CODES+2];
 /* The static literal tree. Since the bit lengths are imposed, there is no
  * need for the L_CODES extra codes used during heap construction. However
  * The codes 286 and 287 are needed to build a canonical tree (see _tr_init
@@ -101,7 +101,7 @@ uch _dist_code[DIST_CODE_LEN];
  * the 15 bit distances.
  */
 
-uch _length_code[MAX_MATCH - MIN_MATCH + 1];
+uch _length_code[MAX_MATCH-MIN_MATCH+1];
 /* length code for each normalized match length (0 == MIN_MATCH) */
 
 local int base_length[LENGTH_CODES];
@@ -114,23 +114,22 @@ local int base_dist[D_CODES];
 #  include "trees.h"
 #endif /* GEN_TREES_H */
 
-struct static_tree_desc_s
-{
-	const ct_data *static_tree;  /* static tree or NULL */
-	const intf *extra_bits;      /* extra bits for each code or NULL */
-	int     extra_base;          /* base index for extra_bits */
-	int     elems;               /* max number of elements in the tree */
-	int     max_length;          /* max bit length for the codes */
+struct static_tree_desc_s {
+    const ct_data *static_tree;  /* static tree or NULL */
+    const intf *extra_bits;      /* extra bits for each code or NULL */
+    int     extra_base;          /* base index for extra_bits */
+    int     elems;               /* max number of elements in the tree */
+    int     max_length;          /* max bit length for the codes */
 };
 
-local static_tree_desc  static_l_desc =
-{ static_ltree, extra_lbits, LITERALS + 1, L_CODES, MAX_BITS };
+local const static_tree_desc  static_l_desc =
+{static_ltree, extra_lbits, LITERALS+1, L_CODES, MAX_BITS};
 
-local static_tree_desc  static_d_desc =
-{ static_dtree, extra_dbits, 0,          D_CODES, MAX_BITS };
+local const static_tree_desc  static_d_desc =
+{static_dtree, extra_dbits, 0,          D_CODES, MAX_BITS};
 
-local static_tree_desc  static_bl_desc =
-{ (const ct_data *)0, extra_blbits, 0,   BL_CODES, MAX_BL_BITS };
+local const static_tree_desc  static_bl_desc =
+{(const ct_data *)0, extra_blbits, 0,   BL_CODES, MAX_BL_BITS};
 
 /* ===========================================================================
  * Local (static) routines in this file.
@@ -146,25 +145,23 @@ local void scan_tree      OF((deflate_state *s, ct_data *tree, int max_code));
 local void send_tree      OF((deflate_state *s, ct_data *tree, int max_code));
 local int  build_bl_tree  OF((deflate_state *s));
 local void send_all_trees OF((deflate_state *s, int lcodes, int dcodes,
-	int blcodes));
+                              int blcodes));
 local void compress_block OF((deflate_state *s, const ct_data *ltree,
-	const ct_data *dtree));
+                              const ct_data *dtree));
 local int  detect_data_type OF((deflate_state *s));
 local unsigned bi_reverse OF((unsigned value, int length));
 local void bi_windup      OF((deflate_state *s));
 local void bi_flush       OF((deflate_state *s));
-local void copy_block     OF((deflate_state *s, charf *buf, unsigned len,
-	int header));
 
 #ifdef GEN_TREES_H
 local void gen_trees_header OF((void));
 #endif
 
-#ifndef DEBUG
+#ifndef ZLIB_DEBUG
 #  define send_code(s, c, tree) send_bits(s, tree[c].Code, tree[c].Len)
-/* Send a code of the given tree. c and tree must not have side effects */
+   /* Send a code of the given tree. c and tree must not have side effects */
 
-#else /* DEBUG */
+#else /* !ZLIB_DEBUG */
 #  define send_code(s, c, tree) \
      { if (z_verbose>2) fprintf(stderr,"\ncd %3d ",(c)); \
        send_bits(s, tree[c].Code, tree[c].Len); }
@@ -179,43 +176,42 @@ local void gen_trees_header OF((void));
     put_byte(s, (uch)((ush)(w) >> 8)); \
 }
 
- /* ===========================================================================
-  * Send a value on a given number of bits.
-  * IN assertion: length <= 16 and value fits in length bits.
-  */
-#ifdef DEBUG
+/* ===========================================================================
+ * Send a value on a given number of bits.
+ * IN assertion: length <= 16 and value fits in length bits.
+ */
+#ifdef ZLIB_DEBUG
 local void send_bits      OF((deflate_state *s, int value, int length));
 
 local void send_bits(s, value, length)
-deflate_state *s;
-int value;  /* value to send */
-int length; /* number of bits */
+    deflate_state *s;
+    int value;  /* value to send */
+    int length; /* number of bits */
 {
-	Tracevv((stderr, " l %2d v %4x ", length, value));
-	Assert(length > 0 && length <= 15, "invalid length");
-	s->bits_sent += (ulg)length;
+    Tracevv((stderr," l %2d v %4x ", length, value));
+    Assert(length > 0 && length <= 15, "invalid length");
+    s->bits_sent += (ulg)length;
 
-	/* If not enough room in bi_buf, use (valid) bits from bi_buf and
-	 * (16 - bi_valid) bits from value, leaving (width - (16-bi_valid))
-	 * unused bits in value.
-	 */
-	if (s->bi_valid > (int)Buf_size - length) {
-		s->bi_buf |= (ush)value << s->bi_valid;
-		put_short(s, s->bi_buf);
-		s->bi_buf = (ush)value >> (Buf_size - s->bi_valid);
-		s->bi_valid += length - Buf_size;
-	}
-	else {
-		s->bi_buf |= (ush)value << s->bi_valid;
-		s->bi_valid += length;
-	}
+    /* If not enough room in bi_buf, use (valid) bits from bi_buf and
+     * (16 - bi_valid) bits from value, leaving (width - (16-bi_valid))
+     * unused bits in value.
+     */
+    if (s->bi_valid > (int)Buf_size - length) {
+        s->bi_buf |= (ush)value << s->bi_valid;
+        put_short(s, s->bi_buf);
+        s->bi_buf = (ush)value >> (Buf_size - s->bi_valid);
+        s->bi_valid += length - Buf_size;
+    } else {
+        s->bi_buf |= (ush)value << s->bi_valid;
+        s->bi_valid += length;
+    }
 }
-#else /* !DEBUG */
+#else /* !ZLIB_DEBUG */
 
 #define send_bits(s, value, length) \
 { int len = length;\
   if (s->bi_valid > (int)Buf_size - len) {\
-    int val = value;\
+    int val = (int)value;\
     s->bi_buf |= (ush)val << s->bi_valid;\
     put_short(s, s->bi_buf);\
     s->bi_buf = (ush)val >> (Buf_size - s->bi_valid);\
@@ -225,101 +221,101 @@ int length; /* number of bits */
     s->bi_valid += len;\
   }\
 }
-#endif /* DEBUG */
+#endif /* ZLIB_DEBUG */
 
 
-  /* the arguments must not have side effects */
+/* the arguments must not have side effects */
 
-  /* ===========================================================================
-	* Initialize the various 'constant' tables.
-	*/
+/* ===========================================================================
+ * Initialize the various 'constant' tables.
+ */
 local void tr_static_init()
 {
-	#if defined(GEN_TREES_H) || !defined(STDC)
-	static int static_init_done = 0;
-	int n;        /* iterates over tree elements */
-	int bits;     /* bit counter */
-	int length;   /* length value */
-	int code;     /* code value */
-	int dist;     /* distance index */
-	ush bl_count[MAX_BITS + 1];
-	/* number of codes at each bit length for an optimal tree */
+#if defined(GEN_TREES_H) || !defined(STDC)
+    static int static_init_done = 0;
+    int n;        /* iterates over tree elements */
+    int bits;     /* bit counter */
+    int length;   /* length value */
+    int code;     /* code value */
+    int dist;     /* distance index */
+    ush bl_count[MAX_BITS+1];
+    /* number of codes at each bit length for an optimal tree */
 
-	if (static_init_done) return;
+    if (static_init_done) return;
 
-	/* For some embedded targets, global variables are not initialized: */
-	#ifdef NO_INIT_GLOBAL_POINTERS
-	static_l_desc.static_tree = static_ltree;
-	static_l_desc.extra_bits = extra_lbits;
-	static_d_desc.static_tree = static_dtree;
-	static_d_desc.extra_bits = extra_dbits;
-	static_bl_desc.extra_bits = extra_blbits;
-	#endif
+    /* For some embedded targets, global variables are not initialized: */
+#ifdef NO_INIT_GLOBAL_POINTERS
+    static_l_desc.static_tree = static_ltree;
+    static_l_desc.extra_bits = extra_lbits;
+    static_d_desc.static_tree = static_dtree;
+    static_d_desc.extra_bits = extra_dbits;
+    static_bl_desc.extra_bits = extra_blbits;
+#endif
 
-	/* Initialize the mapping length (0..255) -> length code (0..28) */
-	length = 0;
-	for (code = 0; code < LENGTH_CODES - 1; code++) {
-		base_length[code] = length;
-		for (n = 0; n < (1 << extra_lbits[code]); n++) {
-			_length_code[length++] = (uch)code;
-		}
-	}
-	Assert(length == 256, "tr_static_init: length != 256");
-	/* Note that the length 255 (match length 258) can be represented
-	 * in two different ways: code 284 + 5 bits or code 285, so we
-	 * overwrite length_code[255] to use the best encoding:
-	 */
-	_length_code[length - 1] = (uch)code;
+    /* Initialize the mapping length (0..255) -> length code (0..28) */
+    length = 0;
+    for (code = 0; code < LENGTH_CODES-1; code++) {
+        base_length[code] = length;
+        for (n = 0; n < (1<<extra_lbits[code]); n++) {
+            _length_code[length++] = (uch)code;
+        }
+    }
+    Assert (length == 256, "tr_static_init: length != 256");
+    /* Note that the length 255 (match length 258) can be represented
+     * in two different ways: code 284 + 5 bits or code 285, so we
+     * overwrite length_code[255] to use the best encoding:
+     */
+    _length_code[length-1] = (uch)code;
 
-	/* Initialize the mapping dist (0..32K) -> dist code (0..29) */
-	dist = 0;
-	for (code = 0; code < 16; code++) {
-		base_dist[code] = dist;
-		for (n = 0; n < (1 << extra_dbits[code]); n++) {
-			_dist_code[dist++] = (uch)code;
-		}
-	}
-	Assert(dist == 256, "tr_static_init: dist != 256");
-	dist >>= 7; /* from now on, all distances are divided by 128 */
-	for (; code < D_CODES; code++) {
-		base_dist[code] = dist << 7;
-		for (n = 0; n < (1 << (extra_dbits[code] - 7)); n++) {
-			_dist_code[256 + dist++] = (uch)code;
-		}
-	}
-	Assert(dist == 256, "tr_static_init: 256+dist != 512");
+    /* Initialize the mapping dist (0..32K) -> dist code (0..29) */
+    dist = 0;
+    for (code = 0 ; code < 16; code++) {
+        base_dist[code] = dist;
+        for (n = 0; n < (1<<extra_dbits[code]); n++) {
+            _dist_code[dist++] = (uch)code;
+        }
+    }
+    Assert (dist == 256, "tr_static_init: dist != 256");
+    dist >>= 7; /* from now on, all distances are divided by 128 */
+    for ( ; code < D_CODES; code++) {
+        base_dist[code] = dist << 7;
+        for (n = 0; n < (1<<(extra_dbits[code]-7)); n++) {
+            _dist_code[256 + dist++] = (uch)code;
+        }
+    }
+    Assert (dist == 256, "tr_static_init: 256+dist != 512");
 
-	/* Construct the codes of the static literal tree */
-	for (bits = 0; bits <= MAX_BITS; bits++) bl_count[bits] = 0;
-	n = 0;
-	while (n <= 143) static_ltree[n++].Len = 8, bl_count[8]++;
-	while (n <= 255) static_ltree[n++].Len = 9, bl_count[9]++;
-	while (n <= 279) static_ltree[n++].Len = 7, bl_count[7]++;
-	while (n <= 287) static_ltree[n++].Len = 8, bl_count[8]++;
-	/* Codes 286 and 287 do not exist, but we must include them in the
-	 * tree construction to get a canonical Huffman tree (longest code
-	 * all ones)
-	 */
-	gen_codes((ct_data *)static_ltree, L_CODES + 1, bl_count);
+    /* Construct the codes of the static literal tree */
+    for (bits = 0; bits <= MAX_BITS; bits++) bl_count[bits] = 0;
+    n = 0;
+    while (n <= 143) static_ltree[n++].Len = 8, bl_count[8]++;
+    while (n <= 255) static_ltree[n++].Len = 9, bl_count[9]++;
+    while (n <= 279) static_ltree[n++].Len = 7, bl_count[7]++;
+    while (n <= 287) static_ltree[n++].Len = 8, bl_count[8]++;
+    /* Codes 286 and 287 do not exist, but we must include them in the
+     * tree construction to get a canonical Huffman tree (longest code
+     * all ones)
+     */
+    gen_codes((ct_data *)static_ltree, L_CODES+1, bl_count);
 
-	/* The static distance tree is trivial: */
-	for (n = 0; n < D_CODES; n++) {
-		static_dtree[n].Len = 5;
-		static_dtree[n].Code = bi_reverse((unsigned)n, 5);
-	}
-	static_init_done = 1;
+    /* The static distance tree is trivial: */
+    for (n = 0; n < D_CODES; n++) {
+        static_dtree[n].Len = 5;
+        static_dtree[n].Code = bi_reverse((unsigned)n, 5);
+    }
+    static_init_done = 1;
 
-	#  ifdef GEN_TREES_H
-	gen_trees_header();
-	#  endif
-	#endif /* defined(GEN_TREES_H) || !defined(STDC) */
+#  ifdef GEN_TREES_H
+    gen_trees_header();
+#  endif
+#endif /* defined(GEN_TREES_H) || !defined(STDC) */
 }
 
 /* ===========================================================================
  * Genererate the file trees.h describing the static trees.
  */
 #ifdef GEN_TREES_H
-#  ifndef DEBUG
+#  ifndef ZLIB_DEBUG
 #    include <stdio.h>
 #  endif
 
@@ -329,51 +325,51 @@ local void tr_static_init()
 
 void gen_trees_header()
 {
-	FILE *header = fopen("trees.h", "w");
-	int i;
+    FILE *header = fopen("trees.h", "w");
+    int i;
 
-	Assert(header != NULL, "Can't open trees.h");
-	fprintf(header,
-		"/* header created automatically with -DGEN_TREES_H */\n\n");
+    Assert (header != NULL, "Can't open trees.h");
+    fprintf(header,
+            "/* header created automatically with -DGEN_TREES_H */\n\n");
 
-	fprintf(header, "local const ct_data static_ltree[L_CODES+2] = {\n");
-	for (i = 0; i < L_CODES + 2; i++) {
-		fprintf(header, "{{%3u},{%3u}}%s", static_ltree[i].Code,
-			static_ltree[i].Len, SEPARATOR(i, L_CODES + 1, 5));
-	}
+    fprintf(header, "local const ct_data static_ltree[L_CODES+2] = {\n");
+    for (i = 0; i < L_CODES+2; i++) {
+        fprintf(header, "{{%3u},{%3u}}%s", static_ltree[i].Code,
+                static_ltree[i].Len, SEPARATOR(i, L_CODES+1, 5));
+    }
 
-	fprintf(header, "local const ct_data static_dtree[D_CODES] = {\n");
-	for (i = 0; i < D_CODES; i++) {
-		fprintf(header, "{{%2u},{%2u}}%s", static_dtree[i].Code,
-			static_dtree[i].Len, SEPARATOR(i, D_CODES - 1, 5));
-	}
+    fprintf(header, "local const ct_data static_dtree[D_CODES] = {\n");
+    for (i = 0; i < D_CODES; i++) {
+        fprintf(header, "{{%2u},{%2u}}%s", static_dtree[i].Code,
+                static_dtree[i].Len, SEPARATOR(i, D_CODES-1, 5));
+    }
 
-	fprintf(header, "const uch ZLIB_INTERNAL _dist_code[DIST_CODE_LEN] = {\n");
-	for (i = 0; i < DIST_CODE_LEN; i++) {
-		fprintf(header, "%2u%s", _dist_code[i],
-			SEPARATOR(i, DIST_CODE_LEN - 1, 20));
-	}
+    fprintf(header, "const uch ZLIB_INTERNAL _dist_code[DIST_CODE_LEN] = {\n");
+    for (i = 0; i < DIST_CODE_LEN; i++) {
+        fprintf(header, "%2u%s", _dist_code[i],
+                SEPARATOR(i, DIST_CODE_LEN-1, 20));
+    }
 
-	fprintf(header,
-		"const uch ZLIB_INTERNAL _length_code[MAX_MATCH-MIN_MATCH+1]= {\n");
-	for (i = 0; i < MAX_MATCH - MIN_MATCH + 1; i++) {
-		fprintf(header, "%2u%s", _length_code[i],
-			SEPARATOR(i, MAX_MATCH - MIN_MATCH, 20));
-	}
+    fprintf(header,
+        "const uch ZLIB_INTERNAL _length_code[MAX_MATCH-MIN_MATCH+1]= {\n");
+    for (i = 0; i < MAX_MATCH-MIN_MATCH+1; i++) {
+        fprintf(header, "%2u%s", _length_code[i],
+                SEPARATOR(i, MAX_MATCH-MIN_MATCH, 20));
+    }
 
-	fprintf(header, "local const int base_length[LENGTH_CODES] = {\n");
-	for (i = 0; i < LENGTH_CODES; i++) {
-		fprintf(header, "%1u%s", base_length[i],
-			SEPARATOR(i, LENGTH_CODES - 1, 20));
-	}
+    fprintf(header, "local const int base_length[LENGTH_CODES] = {\n");
+    for (i = 0; i < LENGTH_CODES; i++) {
+        fprintf(header, "%1u%s", base_length[i],
+                SEPARATOR(i, LENGTH_CODES-1, 20));
+    }
 
-	fprintf(header, "local const int base_dist[D_CODES] = {\n");
-	for (i = 0; i < D_CODES; i++) {
-		fprintf(header, "%5u%s", base_dist[i],
-			SEPARATOR(i, D_CODES - 1, 10));
-	}
+    fprintf(header, "local const int base_dist[D_CODES] = {\n");
+    for (i = 0; i < D_CODES; i++) {
+        fprintf(header, "%5u%s", base_dist[i],
+                SEPARATOR(i, D_CODES-1, 10));
+    }
 
-	fclose(header);
+    fclose(header);
 }
 #endif /* GEN_TREES_H */
 
@@ -381,46 +377,46 @@ void gen_trees_header()
  * Initialize the tree data structures for a new zlib stream.
  */
 void ZLIB_INTERNAL _tr_init(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	tr_static_init();
+    tr_static_init();
 
-	s->l_desc.dyn_tree = s->dyn_ltree;
-	s->l_desc.stat_desc = &static_l_desc;
+    s->l_desc.dyn_tree = s->dyn_ltree;
+    s->l_desc.stat_desc = &static_l_desc;
 
-	s->d_desc.dyn_tree = s->dyn_dtree;
-	s->d_desc.stat_desc = &static_d_desc;
+    s->d_desc.dyn_tree = s->dyn_dtree;
+    s->d_desc.stat_desc = &static_d_desc;
 
-	s->bl_desc.dyn_tree = s->bl_tree;
-	s->bl_desc.stat_desc = &static_bl_desc;
+    s->bl_desc.dyn_tree = s->bl_tree;
+    s->bl_desc.stat_desc = &static_bl_desc;
 
-	s->bi_buf = 0;
-	s->bi_valid = 0;
-	#ifdef DEBUG
-	s->compressed_len = 0L;
-	s->bits_sent = 0L;
-	#endif
+    s->bi_buf = 0;
+    s->bi_valid = 0;
+#ifdef ZLIB_DEBUG
+    s->compressed_len = 0L;
+    s->bits_sent = 0L;
+#endif
 
-	/* Initialize the first block of the first file: */
-	init_block(s);
+    /* Initialize the first block of the first file: */
+    init_block(s);
 }
 
 /* ===========================================================================
  * Initialize a new block.
  */
 local void init_block(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	int n; /* iterates over tree elements */
+    int n; /* iterates over tree elements */
 
-	/* Initialize the trees. */
-	for (n = 0; n < L_CODES; n++) s->dyn_ltree[n].Freq = 0;
-	for (n = 0; n < D_CODES; n++) s->dyn_dtree[n].Freq = 0;
-	for (n = 0; n < BL_CODES; n++) s->bl_tree[n].Freq = 0;
+    /* Initialize the trees. */
+    for (n = 0; n < L_CODES;  n++) s->dyn_ltree[n].Freq = 0;
+    for (n = 0; n < D_CODES;  n++) s->dyn_dtree[n].Freq = 0;
+    for (n = 0; n < BL_CODES; n++) s->bl_tree[n].Freq = 0;
 
-	s->dyn_ltree[END_BLOCK].Freq = 1;
-	s->opt_len = s->static_len = 0L;
-	s->last_lit = s->matches = 0;
+    s->dyn_ltree[END_BLOCK].Freq = 1;
+    s->opt_len = s->static_len = 0L;
+    s->last_lit = s->matches = 0;
 }
 
 #define SMALLEST 1
@@ -438,43 +434,43 @@ deflate_state *s;
     pqdownheap(s, tree, SMALLEST); \
 }
 
- /* ===========================================================================
-  * Compares to subtrees, using the tree depth as tie breaker when
-  * the subtrees have equal frequency. This minimizes the worst case length.
-  */
+/* ===========================================================================
+ * Compares to subtrees, using the tree depth as tie breaker when
+ * the subtrees have equal frequency. This minimizes the worst case length.
+ */
 #define smaller(tree, n, m, depth) \
    (tree[n].Freq < tree[m].Freq || \
    (tree[n].Freq == tree[m].Freq && depth[n] <= depth[m]))
 
-  /* ===========================================================================
-	* Restore the heap property by moving down the tree starting at node k,
-	* exchanging a node with the smallest of its two sons if necessary, stopping
-	* when the heap property is re-established (each father smaller than its
-	* two sons).
-	*/
+/* ===========================================================================
+ * Restore the heap property by moving down the tree starting at node k,
+ * exchanging a node with the smallest of its two sons if necessary, stopping
+ * when the heap property is re-established (each father smaller than its
+ * two sons).
+ */
 local void pqdownheap(s, tree, k)
-deflate_state *s;
-ct_data *tree;  /* the tree to restore */
-int k;               /* node to move down */
+    deflate_state *s;
+    ct_data *tree;  /* the tree to restore */
+    int k;               /* node to move down */
 {
-	int v = s->heap[k];
-	int j = k << 1;  /* left son of k */
-	while (j <= s->heap_len) {
-		/* Set j to the smallest of the two sons: */
-		if (j < s->heap_len &&
-			smaller(tree, s->heap[j + 1], s->heap[j], s->depth)) {
-			j++;
-		}
-		/* Exit if v is smaller than both sons */
-		if (smaller(tree, v, s->heap[j], s->depth)) break;
+    int v = s->heap[k];
+    int j = k << 1;  /* left son of k */
+    while (j <= s->heap_len) {
+        /* Set j to the smallest of the two sons: */
+        if (j < s->heap_len &&
+            smaller(tree, s->heap[j+1], s->heap[j], s->depth)) {
+            j++;
+        }
+        /* Exit if v is smaller than both sons */
+        if (smaller(tree, v, s->heap[j], s->depth)) break;
 
-		/* Exchange v with the smallest son */
-		s->heap[k] = s->heap[j];  k = j;
+        /* Exchange v with the smallest son */
+        s->heap[k] = s->heap[j];  k = j;
 
-		/* And continue down the tree, setting j to the left son of k */
-		j <<= 1;
-	}
-	s->heap[k] = v;
+        /* And continue down the tree, setting j to the left son of k */
+        j <<= 1;
+    }
+    s->heap[k] = v;
 }
 
 /* ===========================================================================
@@ -488,82 +484,81 @@ int k;               /* node to move down */
  *     not null.
  */
 local void gen_bitlen(s, desc)
-deflate_state *s;
-tree_desc *desc;    /* the tree descriptor */
+    deflate_state *s;
+    tree_desc *desc;    /* the tree descriptor */
 {
-	ct_data *tree = desc->dyn_tree;
-	int max_code = desc->max_code;
-	const ct_data *stree = desc->stat_desc->static_tree;
-	const intf *extra = desc->stat_desc->extra_bits;
-	int base = desc->stat_desc->extra_base;
-	int max_length = desc->stat_desc->max_length;
-	int h;              /* heap index */
-	int n, m;           /* iterate over the tree elements */
-	int bits;           /* bit length */
-	int xbits;          /* extra bits */
-	ush f;              /* frequency */
-	int overflow = 0;   /* number of elements with bit length too large */
+    ct_data *tree        = desc->dyn_tree;
+    int max_code         = desc->max_code;
+    const ct_data *stree = desc->stat_desc->static_tree;
+    const intf *extra    = desc->stat_desc->extra_bits;
+    int base             = desc->stat_desc->extra_base;
+    int max_length       = desc->stat_desc->max_length;
+    int h;              /* heap index */
+    int n, m;           /* iterate over the tree elements */
+    int bits;           /* bit length */
+    int xbits;          /* extra bits */
+    ush f;              /* frequency */
+    int overflow = 0;   /* number of elements with bit length too large */
 
-	for (bits = 0; bits <= MAX_BITS; bits++) s->bl_count[bits] = 0;
+    for (bits = 0; bits <= MAX_BITS; bits++) s->bl_count[bits] = 0;
 
-	/* In a first pass, compute the optimal bit lengths (which may
-	 * overflow in the case of the bit length tree).
-	 */
-	tree[s->heap[s->heap_max]].Len = 0; /* root of the heap */
+    /* In a first pass, compute the optimal bit lengths (which may
+     * overflow in the case of the bit length tree).
+     */
+    tree[s->heap[s->heap_max]].Len = 0; /* root of the heap */
 
-	for (h = s->heap_max + 1; h < HEAP_SIZE; h++) {
-		n = s->heap[h];
-		bits = tree[tree[n].Dad].Len + 1;
-		if (bits > max_length) bits = max_length, overflow++;
-		tree[n].Len = (ush)bits;
-		/* We overwrite tree[n].Dad which is no longer needed */
+    for (h = s->heap_max+1; h < HEAP_SIZE; h++) {
+        n = s->heap[h];
+        bits = tree[tree[n].Dad].Len + 1;
+        if (bits > max_length) bits = max_length, overflow++;
+        tree[n].Len = (ush)bits;
+        /* We overwrite tree[n].Dad which is no longer needed */
 
-		if (n > max_code) continue; /* not a leaf node */
+        if (n > max_code) continue; /* not a leaf node */
 
-		s->bl_count[bits]++;
-		xbits = 0;
-		if (n >= base) xbits = extra[n - base];
-		f = tree[n].Freq;
-		s->opt_len += (ulg)f * (bits + xbits);
-		if (stree) s->static_len += (ulg)f * (stree[n].Len + xbits);
-	}
-	if (overflow == 0) return;
+        s->bl_count[bits]++;
+        xbits = 0;
+        if (n >= base) xbits = extra[n-base];
+        f = tree[n].Freq;
+        s->opt_len += (ulg)f * (unsigned)(bits + xbits);
+        if (stree) s->static_len += (ulg)f * (unsigned)(stree[n].Len + xbits);
+    }
+    if (overflow == 0) return;
 
-	Trace((stderr, "\nbit length overflow\n"));
-	/* This happens for example on obj2 and pic of the Calgary corpus */
+    Tracev((stderr,"\nbit length overflow\n"));
+    /* This happens for example on obj2 and pic of the Calgary corpus */
 
-	/* Find the first bit length which could increase: */
-	do {
-		bits = max_length - 1;
-		while (s->bl_count[bits] == 0) bits--;
-		s->bl_count[bits]--;      /* move one leaf down the tree */
-		s->bl_count[bits + 1] += 2; /* move one overflow item as its brother */
-		s->bl_count[max_length]--;
-		/* The brother of the overflow item also moves one step up,
-		 * but this does not affect bl_count[max_length]
-		 */
-		overflow -= 2;
-	} while (overflow > 0);
+    /* Find the first bit length which could increase: */
+    do {
+        bits = max_length-1;
+        while (s->bl_count[bits] == 0) bits--;
+        s->bl_count[bits]--;      /* move one leaf down the tree */
+        s->bl_count[bits+1] += 2; /* move one overflow item as its brother */
+        s->bl_count[max_length]--;
+        /* The brother of the overflow item also moves one step up,
+         * but this does not affect bl_count[max_length]
+         */
+        overflow -= 2;
+    } while (overflow > 0);
 
-	/* Now recompute all bit lengths, scanning in increasing frequency.
-	 * h is still equal to HEAP_SIZE. (It is simpler to reconstruct all
-	 * lengths instead of fixing only the wrong ones. This idea is taken
-	 * from 'ar' written by Haruhiko Okumura.)
-	 */
-	for (bits = max_length; bits != 0; bits--) {
-		n = s->bl_count[bits];
-		while (n != 0) {
-			m = s->heap[--h];
-			if (m > max_code) continue;
-			if ((unsigned)tree[m].Len != (unsigned)bits) {
-				Trace((stderr, "code %d bits %d->%d\n", m, tree[m].Len, bits));
-				s->opt_len += ((long)bits - (long)tree[m].Len)
-					*(long)tree[m].Freq;
-				tree[m].Len = (ush)bits;
-			}
-			n--;
-		}
-	}
+    /* Now recompute all bit lengths, scanning in increasing frequency.
+     * h is still equal to HEAP_SIZE. (It is simpler to reconstruct all
+     * lengths instead of fixing only the wrong ones. This idea is taken
+     * from 'ar' written by Haruhiko Okumura.)
+     */
+    for (bits = max_length; bits != 0; bits--) {
+        n = s->bl_count[bits];
+        while (n != 0) {
+            m = s->heap[--h];
+            if (m > max_code) continue;
+            if ((unsigned) tree[m].Len != (unsigned) bits) {
+                Tracev((stderr,"code %d bits %d->%d\n", m, tree[m].Len, bits));
+                s->opt_len += ((ulg)bits - tree[m].Len) * tree[m].Freq;
+                tree[m].Len = (ush)bits;
+            }
+            n--;
+        }
+    }
 }
 
 /* ===========================================================================
@@ -574,38 +569,39 @@ tree_desc *desc;    /* the tree descriptor */
  * OUT assertion: the field code is set for all tree elements of non
  *     zero code length.
  */
-local void gen_codes(tree, max_code, bl_count)
-ct_data *tree;             /* the tree to decorate */
-int max_code;              /* largest code with non zero frequency */
-ushf *bl_count;            /* number of codes at each bit length */
+local void gen_codes (tree, max_code, bl_count)
+    ct_data *tree;             /* the tree to decorate */
+    int max_code;              /* largest code with non zero frequency */
+    ushf *bl_count;            /* number of codes at each bit length */
 {
-	ush next_code[MAX_BITS + 1]; /* next code value for each bit length */
-	ush code = 0;              /* running code value */
-	int bits;                  /* bit index */
-	int n;                     /* code index */
+    ush next_code[MAX_BITS+1]; /* next code value for each bit length */
+    unsigned code = 0;         /* running code value */
+    int bits;                  /* bit index */
+    int n;                     /* code index */
 
-	/* The distribution counts are first used to generate the code values
-	 * without bit reversal.
-	 */
-	for (bits = 1; bits <= MAX_BITS; bits++) {
-		next_code[bits] = code = (code + bl_count[bits - 1]) << 1;
-	}
-	/* Check that the bit counts in bl_count are consistent. The last code
-	 * must be all ones.
-	 */
-	Assert(code + bl_count[MAX_BITS] - 1 == (1 << MAX_BITS) - 1,
-		"inconsistent bit counts");
-	Tracev((stderr, "\ngen_codes: max_code %d ", max_code));
+    /* The distribution counts are first used to generate the code values
+     * without bit reversal.
+     */
+    for (bits = 1; bits <= MAX_BITS; bits++) {
+        code = (code + bl_count[bits-1]) << 1;
+        next_code[bits] = (ush)code;
+    }
+    /* Check that the bit counts in bl_count are consistent. The last code
+     * must be all ones.
+     */
+    Assert (code + bl_count[MAX_BITS]-1 == (1<<MAX_BITS)-1,
+            "inconsistent bit counts");
+    Tracev((stderr,"\ngen_codes: max_code %d ", max_code));
 
-	for (n = 0; n <= max_code; n++) {
-		int len = tree[n].Len;
-		if (len == 0) continue;
-		/* Now reverse the bits */
-		tree[n].Code = bi_reverse(next_code[len]++, len);
+    for (n = 0;  n <= max_code; n++) {
+        int len = tree[n].Len;
+        if (len == 0) continue;
+        /* Now reverse the bits */
+        tree[n].Code = (ush)bi_reverse(next_code[len]++, len);
 
-		Tracecv(tree != static_ltree, (stderr, "\nn %3d %c l %2d c %4x (%x) ",
-			n, (isgraph(n) ? n : ' '), len, tree[n].Code, next_code[len] - 1));
-	}
+        Tracecv(tree != static_ltree, (stderr,"\nn %3d %c l %2d c %4x (%x) ",
+             n, (isgraph(n) ? n : ' '), len, tree[n].Code, next_code[len]-1));
+    }
 }
 
 /* ===========================================================================
@@ -617,196 +613,183 @@ ushf *bl_count;            /* number of codes at each bit length */
  *     also updated if stree is not null. The field max_code is set.
  */
 local void build_tree(s, desc)
-deflate_state *s;
-tree_desc *desc; /* the tree descriptor */
+    deflate_state *s;
+    tree_desc *desc; /* the tree descriptor */
 {
-	ct_data *tree = desc->dyn_tree;
-	const ct_data *stree = desc->stat_desc->static_tree;
-	int elems = desc->stat_desc->elems;
-	int n, m;          /* iterate over heap elements */
-	int max_code = -1; /* largest code with non zero frequency */
-	int node;          /* new node being created */
+    ct_data *tree         = desc->dyn_tree;
+    const ct_data *stree  = desc->stat_desc->static_tree;
+    int elems             = desc->stat_desc->elems;
+    int n, m;          /* iterate over heap elements */
+    int max_code = -1; /* largest code with non zero frequency */
+    int node;          /* new node being created */
 
-	/* Construct the initial heap, with least frequent element in
-	 * heap[SMALLEST]. The sons of heap[n] are heap[2*n] and heap[2*n+1].
-	 * heap[0] is not used.
-	 */
-	s->heap_len = 0, s->heap_max = HEAP_SIZE;
+    /* Construct the initial heap, with least frequent element in
+     * heap[SMALLEST]. The sons of heap[n] are heap[2*n] and heap[2*n+1].
+     * heap[0] is not used.
+     */
+    s->heap_len = 0, s->heap_max = HEAP_SIZE;
 
-	for (n = 0; n < elems; n++) {
-		if (tree[n].Freq != 0) {
-			s->heap[++(s->heap_len)] = max_code = n;
-			s->depth[n] = 0;
-		}
-		else {
-			tree[n].Len = 0;
-		}
-	}
+    for (n = 0; n < elems; n++) {
+        if (tree[n].Freq != 0) {
+            s->heap[++(s->heap_len)] = max_code = n;
+            s->depth[n] = 0;
+        } else {
+            tree[n].Len = 0;
+        }
+    }
 
-	/* The pkzip format requires that at least one distance code exists,
-	 * and that at least one bit should be sent even if there is only one
-	 * possible code. So to avoid special checks later on we force at least
-	 * two codes of non zero frequency.
-	 */
-	while (s->heap_len < 2) {
-		node = s->heap[++(s->heap_len)] = (max_code < 2 ? ++max_code : 0);
-		tree[node].Freq = 1;
-		s->depth[node] = 0;
-		s->opt_len--; if (stree) s->static_len -= stree[node].Len;
-		/* node is 0 or 1 so it does not have extra bits */
-	}
-	desc->max_code = max_code;
+    /* The pkzip format requires that at least one distance code exists,
+     * and that at least one bit should be sent even if there is only one
+     * possible code. So to avoid special checks later on we force at least
+     * two codes of non zero frequency.
+     */
+    while (s->heap_len < 2) {
+        node = s->heap[++(s->heap_len)] = (max_code < 2 ? ++max_code : 0);
+        tree[node].Freq = 1;
+        s->depth[node] = 0;
+        s->opt_len--; if (stree) s->static_len -= stree[node].Len;
+        /* node is 0 or 1 so it does not have extra bits */
+    }
+    desc->max_code = max_code;
 
-	/* The elements heap[heap_len/2+1 .. heap_len] are leaves of the tree,
-	 * establish sub-heaps of increasing lengths:
-	 */
-	for (n = s->heap_len / 2; n >= 1; n--) pqdownheap(s, tree, n);
+    /* The elements heap[heap_len/2+1 .. heap_len] are leaves of the tree,
+     * establish sub-heaps of increasing lengths:
+     */
+    for (n = s->heap_len/2; n >= 1; n--) pqdownheap(s, tree, n);
 
-	/* Construct the Huffman tree by repeatedly combining the least two
-	 * frequent nodes.
-	 */
-	node = elems;              /* next internal node of the tree */
-	do {
-		pqremove(s, tree, n);  /* n = node of least frequency */
-		m = s->heap[SMALLEST]; /* m = node of next least frequency */
+    /* Construct the Huffman tree by repeatedly combining the least two
+     * frequent nodes.
+     */
+    node = elems;              /* next internal node of the tree */
+    do {
+        pqremove(s, tree, n);  /* n = node of least frequency */
+        m = s->heap[SMALLEST]; /* m = node of next least frequency */
 
-		s->heap[--(s->heap_max)] = n; /* keep the nodes sorted by frequency */
-		s->heap[--(s->heap_max)] = m;
+        s->heap[--(s->heap_max)] = n; /* keep the nodes sorted by frequency */
+        s->heap[--(s->heap_max)] = m;
 
-		/* Create a new node father of n and m */
-		tree[node].Freq = tree[n].Freq + tree[m].Freq;
-		s->depth[node] = (uch)((s->depth[n] >= s->depth[m] ?
-			s->depth[n] : s->depth[m]) + 1);
-		tree[n].Dad = tree[m].Dad = (ush)node;
-		#ifdef DUMP_BL_TREE
-		if (tree == s->bl_tree) {
-			fprintf(stderr, "\nnode %d(%d), sons %d(%d) %d(%d)",
-				node, tree[node].Freq, n, tree[n].Freq, m, tree[m].Freq);
-		}
-		#endif
-		/* and insert the new node in the heap */
-		s->heap[SMALLEST] = node++;
-		pqdownheap(s, tree, SMALLEST);
+        /* Create a new node father of n and m */
+        tree[node].Freq = tree[n].Freq + tree[m].Freq;
+        s->depth[node] = (uch)((s->depth[n] >= s->depth[m] ?
+                                s->depth[n] : s->depth[m]) + 1);
+        tree[n].Dad = tree[m].Dad = (ush)node;
+#ifdef DUMP_BL_TREE
+        if (tree == s->bl_tree) {
+            fprintf(stderr,"\nnode %d(%d), sons %d(%d) %d(%d)",
+                    node, tree[node].Freq, n, tree[n].Freq, m, tree[m].Freq);
+        }
+#endif
+        /* and insert the new node in the heap */
+        s->heap[SMALLEST] = node++;
+        pqdownheap(s, tree, SMALLEST);
 
-	} while (s->heap_len >= 2);
+    } while (s->heap_len >= 2);
 
-	s->heap[--(s->heap_max)] = s->heap[SMALLEST];
+    s->heap[--(s->heap_max)] = s->heap[SMALLEST];
 
-	/* At this point, the fields freq and dad are set. We can now
-	 * generate the bit lengths.
-	 */
-	gen_bitlen(s, (tree_desc *)desc);
+    /* At this point, the fields freq and dad are set. We can now
+     * generate the bit lengths.
+     */
+    gen_bitlen(s, (tree_desc *)desc);
 
-	/* The field len is now set, we can generate the bit codes */
-	gen_codes((ct_data *)tree, max_code, s->bl_count);
+    /* The field len is now set, we can generate the bit codes */
+    gen_codes ((ct_data *)tree, max_code, s->bl_count);
 }
 
 /* ===========================================================================
  * Scan a literal or distance tree to determine the frequencies of the codes
  * in the bit length tree.
  */
-local void scan_tree(s, tree, max_code)
-deflate_state *s;
-ct_data *tree;   /* the tree to be scanned */
-int max_code;    /* and its largest code of non zero frequency */
+local void scan_tree (s, tree, max_code)
+    deflate_state *s;
+    ct_data *tree;   /* the tree to be scanned */
+    int max_code;    /* and its largest code of non zero frequency */
 {
-	int n;                     /* iterates over all tree elements */
-	int prevlen = -1;          /* last emitted length */
-	int curlen;                /* length of current code */
-	int nextlen = tree[0].Len; /* length of next code */
-	int count = 0;             /* repeat count of the current code */
-	int max_count = 7;         /* max repeat count */
-	int min_count = 4;         /* min repeat count */
+    int n;                     /* iterates over all tree elements */
+    int prevlen = -1;          /* last emitted length */
+    int curlen;                /* length of current code */
+    int nextlen = tree[0].Len; /* length of next code */
+    int count = 0;             /* repeat count of the current code */
+    int max_count = 7;         /* max repeat count */
+    int min_count = 4;         /* min repeat count */
 
-	if (nextlen == 0) max_count = 138, min_count = 3;
-	tree[max_code + 1].Len = (ush)0xffff; /* guard */
+    if (nextlen == 0) max_count = 138, min_count = 3;
+    tree[max_code+1].Len = (ush)0xffff; /* guard */
 
-	for (n = 0; n <= max_code; n++) {
-		curlen = nextlen; nextlen = tree[n + 1].Len;
-		if (++count < max_count && curlen == nextlen) {
-			continue;
-		}
-		else if (count < min_count) {
-			s->bl_tree[curlen].Freq += count;
-		}
-		else if (curlen != 0) {
-			if (curlen != prevlen) s->bl_tree[curlen].Freq++;
-			s->bl_tree[REP_3_6].Freq++;
-		}
-		else if (count <= 10) {
-			s->bl_tree[REPZ_3_10].Freq++;
-		}
-		else {
-			s->bl_tree[REPZ_11_138].Freq++;
-		}
-		count = 0; prevlen = curlen;
-		if (nextlen == 0) {
-			max_count = 138, min_count = 3;
-		}
-		else if (curlen == nextlen) {
-			max_count = 6, min_count = 3;
-		}
-		else {
-			max_count = 7, min_count = 4;
-		}
-	}
+    for (n = 0; n <= max_code; n++) {
+        curlen = nextlen; nextlen = tree[n+1].Len;
+        if (++count < max_count && curlen == nextlen) {
+            continue;
+        } else if (count < min_count) {
+            s->bl_tree[curlen].Freq += count;
+        } else if (curlen != 0) {
+            if (curlen != prevlen) s->bl_tree[curlen].Freq++;
+            s->bl_tree[REP_3_6].Freq++;
+        } else if (count <= 10) {
+            s->bl_tree[REPZ_3_10].Freq++;
+        } else {
+            s->bl_tree[REPZ_11_138].Freq++;
+        }
+        count = 0; prevlen = curlen;
+        if (nextlen == 0) {
+            max_count = 138, min_count = 3;
+        } else if (curlen == nextlen) {
+            max_count = 6, min_count = 3;
+        } else {
+            max_count = 7, min_count = 4;
+        }
+    }
 }
 
 /* ===========================================================================
  * Send a literal or distance tree in compressed form, using the codes in
  * bl_tree.
  */
-local void send_tree(s, tree, max_code)
-deflate_state *s;
-ct_data *tree; /* the tree to be scanned */
-int max_code;       /* and its largest code of non zero frequency */
+local void send_tree (s, tree, max_code)
+    deflate_state *s;
+    ct_data *tree; /* the tree to be scanned */
+    int max_code;       /* and its largest code of non zero frequency */
 {
-	int n;                     /* iterates over all tree elements */
-	int prevlen = -1;          /* last emitted length */
-	int curlen;                /* length of current code */
-	int nextlen = tree[0].Len; /* length of next code */
-	int count = 0;             /* repeat count of the current code */
-	int max_count = 7;         /* max repeat count */
-	int min_count = 4;         /* min repeat count */
+    int n;                     /* iterates over all tree elements */
+    int prevlen = -1;          /* last emitted length */
+    int curlen;                /* length of current code */
+    int nextlen = tree[0].Len; /* length of next code */
+    int count = 0;             /* repeat count of the current code */
+    int max_count = 7;         /* max repeat count */
+    int min_count = 4;         /* min repeat count */
 
-	/* tree[max_code+1].Len = -1; */  /* guard already set */
-	if (nextlen == 0) max_count = 138, min_count = 3;
+    /* tree[max_code+1].Len = -1; */  /* guard already set */
+    if (nextlen == 0) max_count = 138, min_count = 3;
 
-	for (n = 0; n <= max_code; n++) {
-		curlen = nextlen; nextlen = tree[n + 1].Len;
-		if (++count < max_count && curlen == nextlen) {
-			continue;
-		}
-		else if (count < min_count) {
-			do { send_code(s, curlen, s->bl_tree); } while (--count != 0);
+    for (n = 0; n <= max_code; n++) {
+        curlen = nextlen; nextlen = tree[n+1].Len;
+        if (++count < max_count && curlen == nextlen) {
+            continue;
+        } else if (count < min_count) {
+            do { send_code(s, curlen, s->bl_tree); } while (--count != 0);
 
-		}
-		else if (curlen != 0) {
-			if (curlen != prevlen) {
-				send_code(s, curlen, s->bl_tree); count--;
-			}
-			Assert(count >= 3 && count <= 6, " 3_6?");
-			send_code(s, REP_3_6, s->bl_tree); send_bits(s, count - 3, 2);
+        } else if (curlen != 0) {
+            if (curlen != prevlen) {
+                send_code(s, curlen, s->bl_tree); count--;
+            }
+            Assert(count >= 3 && count <= 6, " 3_6?");
+            send_code(s, REP_3_6, s->bl_tree); send_bits(s, count-3, 2);
 
-		}
-		else if (count <= 10) {
-			send_code(s, REPZ_3_10, s->bl_tree); send_bits(s, count - 3, 3);
+        } else if (count <= 10) {
+            send_code(s, REPZ_3_10, s->bl_tree); send_bits(s, count-3, 3);
 
-		}
-		else {
-			send_code(s, REPZ_11_138, s->bl_tree); send_bits(s, count - 11, 7);
-		}
-		count = 0; prevlen = curlen;
-		if (nextlen == 0) {
-			max_count = 138, min_count = 3;
-		}
-		else if (curlen == nextlen) {
-			max_count = 6, min_count = 3;
-		}
-		else {
-			max_count = 7, min_count = 4;
-		}
-	}
+        } else {
+            send_code(s, REPZ_11_138, s->bl_tree); send_bits(s, count-11, 7);
+        }
+        count = 0; prevlen = curlen;
+        if (nextlen == 0) {
+            max_count = 138, min_count = 3;
+        } else if (curlen == nextlen) {
+            max_count = 6, min_count = 3;
+        } else {
+            max_count = 7, min_count = 4;
+        }
+    }
 }
 
 /* ===========================================================================
@@ -814,33 +797,33 @@ int max_code;       /* and its largest code of non zero frequency */
  * bl_order of the last bit length code to send.
  */
 local int build_bl_tree(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	int max_blindex;  /* index of last bit length code of non zero freq */
+    int max_blindex;  /* index of last bit length code of non zero freq */
 
-	/* Determine the bit length frequencies for literal and distance trees */
-	scan_tree(s, (ct_data *)s->dyn_ltree, s->l_desc.max_code);
-	scan_tree(s, (ct_data *)s->dyn_dtree, s->d_desc.max_code);
+    /* Determine the bit length frequencies for literal and distance trees */
+    scan_tree(s, (ct_data *)s->dyn_ltree, s->l_desc.max_code);
+    scan_tree(s, (ct_data *)s->dyn_dtree, s->d_desc.max_code);
 
-	/* Build the bit length tree: */
-	build_tree(s, (tree_desc *)(&(s->bl_desc)));
-	/* opt_len now includes the length of the tree representations, except
-	 * the lengths of the bit lengths codes and the 5+5+4 bits for the counts.
-	 */
+    /* Build the bit length tree: */
+    build_tree(s, (tree_desc *)(&(s->bl_desc)));
+    /* opt_len now includes the length of the tree representations, except
+     * the lengths of the bit lengths codes and the 5+5+4 bits for the counts.
+     */
 
-	 /* Determine the number of bit length codes to send. The pkzip format
-	  * requires that at least 4 bit length codes be sent. (appnote.txt says
-	  * 3 but the actual value used is 4.)
-	  */
-	for (max_blindex = BL_CODES - 1; max_blindex >= 3; max_blindex--) {
-		if (s->bl_tree[bl_order[max_blindex]].Len != 0) break;
-	}
-	/* Update opt_len to include the bit length tree and counts */
-	s->opt_len += 3 * (max_blindex + 1) + 5 + 5 + 4;
-	Tracev((stderr, "\ndyn trees: dyn %ld, stat %ld",
-		s->opt_len, s->static_len));
+    /* Determine the number of bit length codes to send. The pkzip format
+     * requires that at least 4 bit length codes be sent. (appnote.txt says
+     * 3 but the actual value used is 4.)
+     */
+    for (max_blindex = BL_CODES-1; max_blindex >= 3; max_blindex--) {
+        if (s->bl_tree[bl_order[max_blindex]].Len != 0) break;
+    }
+    /* Update opt_len to include the bit length tree and counts */
+    s->opt_len += 3*((ulg)max_blindex+1) + 5+5+4;
+    Tracev((stderr, "\ndyn trees: dyn %ld, stat %ld",
+            s->opt_len, s->static_len));
 
-	return max_blindex;
+    return max_blindex;
 }
 
 /* ===========================================================================
@@ -849,55 +832,61 @@ deflate_state *s;
  * IN assertion: lcodes >= 257, dcodes >= 1, blcodes >= 4.
  */
 local void send_all_trees(s, lcodes, dcodes, blcodes)
-deflate_state *s;
-int lcodes, dcodes, blcodes; /* number of codes for each tree */
+    deflate_state *s;
+    int lcodes, dcodes, blcodes; /* number of codes for each tree */
 {
-	int rank;                    /* index in bl_order */
+    int rank;                    /* index in bl_order */
 
-	Assert(lcodes >= 257 && dcodes >= 1 && blcodes >= 4, "not enough codes");
-	Assert(lcodes <= L_CODES && dcodes <= D_CODES && blcodes <= BL_CODES,
-		"too many codes");
-	Tracev((stderr, "\nbl counts: "));
-	send_bits(s, lcodes - 257, 5); /* not +255 as stated in appnote.txt */
-	send_bits(s, dcodes - 1, 5);
-	send_bits(s, blcodes - 4, 4); /* not -3 as stated in appnote.txt */
-	for (rank = 0; rank < blcodes; rank++) {
-		Tracev((stderr, "\nbl code %2d ", bl_order[rank]));
-		send_bits(s, s->bl_tree[bl_order[rank]].Len, 3);
-	}
-	Tracev((stderr, "\nbl tree: sent %ld", s->bits_sent));
+    Assert (lcodes >= 257 && dcodes >= 1 && blcodes >= 4, "not enough codes");
+    Assert (lcodes <= L_CODES && dcodes <= D_CODES && blcodes <= BL_CODES,
+            "too many codes");
+    Tracev((stderr, "\nbl counts: "));
+    send_bits(s, lcodes-257, 5); /* not +255 as stated in appnote.txt */
+    send_bits(s, dcodes-1,   5);
+    send_bits(s, blcodes-4,  4); /* not -3 as stated in appnote.txt */
+    for (rank = 0; rank < blcodes; rank++) {
+        Tracev((stderr, "\nbl code %2d ", bl_order[rank]));
+        send_bits(s, s->bl_tree[bl_order[rank]].Len, 3);
+    }
+    Tracev((stderr, "\nbl tree: sent %ld", s->bits_sent));
 
-	send_tree(s, (ct_data *)s->dyn_ltree, lcodes - 1); /* literal tree */
-	Tracev((stderr, "\nlit tree: sent %ld", s->bits_sent));
+    send_tree(s, (ct_data *)s->dyn_ltree, lcodes-1); /* literal tree */
+    Tracev((stderr, "\nlit tree: sent %ld", s->bits_sent));
 
-	send_tree(s, (ct_data *)s->dyn_dtree, dcodes - 1); /* distance tree */
-	Tracev((stderr, "\ndist tree: sent %ld", s->bits_sent));
+    send_tree(s, (ct_data *)s->dyn_dtree, dcodes-1); /* distance tree */
+    Tracev((stderr, "\ndist tree: sent %ld", s->bits_sent));
 }
 
 /* ===========================================================================
  * Send a stored block
  */
 void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
-deflate_state *s;
-charf *buf;       /* input block */
-ulg stored_len;   /* length of input block */
-int last;         /* one if this is the last block for a file */
+    deflate_state *s;
+    charf *buf;       /* input block */
+    ulg stored_len;   /* length of input block */
+    int last;         /* one if this is the last block for a file */
 {
-	send_bits(s, (STORED_BLOCK << 1) + last, 3);    /* send block type */
-	#ifdef DEBUG
-	s->compressed_len = (s->compressed_len + 3 + 7) & (ulg)~7L;
-	s->compressed_len += (stored_len + 4) << 3;
-	#endif
-	copy_block(s, buf, (unsigned)stored_len, 1); /* with header */
+    send_bits(s, (STORED_BLOCK<<1)+last, 3);    /* send block type */
+    bi_windup(s);        /* align on byte boundary */
+    put_short(s, (ush)stored_len);
+    put_short(s, (ush)~stored_len);
+    zmemcpy(s->pending_buf + s->pending, (Bytef *)buf, stored_len);
+    s->pending += stored_len;
+#ifdef ZLIB_DEBUG
+    s->compressed_len = (s->compressed_len + 3 + 7) & (ulg)~7L;
+    s->compressed_len += (stored_len + 4) << 3;
+    s->bits_sent += 2*16;
+    s->bits_sent += stored_len<<3;
+#endif
 }
 
 /* ===========================================================================
  * Flush the bits in the bit buffer to pending output (leaves at most 7 bits)
  */
 void ZLIB_INTERNAL _tr_flush_bits(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	bi_flush(s);
+    bi_flush(s);
 }
 
 /* ===========================================================================
@@ -905,224 +894,218 @@ deflate_state *s;
  * This takes 10 bits, of which 7 may remain in the bit buffer.
  */
 void ZLIB_INTERNAL _tr_align(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	send_bits(s, STATIC_TREES << 1, 3);
-	send_code(s, END_BLOCK, static_ltree);
-	#ifdef DEBUG
-	s->compressed_len += 10L; /* 3 for block type, 7 for EOB */
-	#endif
-	bi_flush(s);
+    send_bits(s, STATIC_TREES<<1, 3);
+    send_code(s, END_BLOCK, static_ltree);
+#ifdef ZLIB_DEBUG
+    s->compressed_len += 10L; /* 3 for block type, 7 for EOB */
+#endif
+    bi_flush(s);
 }
 
 /* ===========================================================================
  * Determine the best encoding for the current block: dynamic trees, static
- * trees or store, and output the encoded block to the zip file.
+ * trees or store, and write out the encoded block.
  */
 void ZLIB_INTERNAL _tr_flush_block(s, buf, stored_len, last)
-deflate_state *s;
-charf *buf;       /* input block, or NULL if too old */
-ulg stored_len;   /* length of input block */
-int last;         /* one if this is the last block for a file */
+    deflate_state *s;
+    charf *buf;       /* input block, or NULL if too old */
+    ulg stored_len;   /* length of input block */
+    int last;         /* one if this is the last block for a file */
 {
-	ulg opt_lenb, static_lenb; /* opt_len and static_len in bytes */
-	int max_blindex = 0;  /* index of last bit length code of non zero freq */
+    ulg opt_lenb, static_lenb; /* opt_len and static_len in bytes */
+    int max_blindex = 0;  /* index of last bit length code of non zero freq */
 
-	/* Build the Huffman trees unless a stored block is forced */
-	if (s->level > 0) {
+    /* Build the Huffman trees unless a stored block is forced */
+    if (s->level > 0) {
 
-		/* Check if the file is binary or text */
-		if (s->strm->data_type == Z_UNKNOWN)
-			s->strm->data_type = detect_data_type(s);
+        /* Check if the file is binary or text */
+        if (s->strm->data_type == Z_UNKNOWN)
+            s->strm->data_type = detect_data_type(s);
 
-		/* Construct the literal and distance trees */
-		build_tree(s, (tree_desc *)(&(s->l_desc)));
-		Tracev((stderr, "\nlit data: dyn %ld, stat %ld", s->opt_len,
-			s->static_len));
+        /* Construct the literal and distance trees */
+        build_tree(s, (tree_desc *)(&(s->l_desc)));
+        Tracev((stderr, "\nlit data: dyn %ld, stat %ld", s->opt_len,
+                s->static_len));
 
-		build_tree(s, (tree_desc *)(&(s->d_desc)));
-		Tracev((stderr, "\ndist data: dyn %ld, stat %ld", s->opt_len,
-			s->static_len));
-		/* At this point, opt_len and static_len are the total bit lengths of
-		 * the compressed block data, excluding the tree representations.
-		 */
+        build_tree(s, (tree_desc *)(&(s->d_desc)));
+        Tracev((stderr, "\ndist data: dyn %ld, stat %ld", s->opt_len,
+                s->static_len));
+        /* At this point, opt_len and static_len are the total bit lengths of
+         * the compressed block data, excluding the tree representations.
+         */
 
-		 /* Build the bit length tree for the above two trees, and get the index
-		  * in bl_order of the last bit length code to send.
-		  */
-		max_blindex = build_bl_tree(s);
+        /* Build the bit length tree for the above two trees, and get the index
+         * in bl_order of the last bit length code to send.
+         */
+        max_blindex = build_bl_tree(s);
 
-		/* Determine the best encoding. Compute the block lengths in bytes. */
-		opt_lenb = (s->opt_len + 3 + 7) >> 3;
-		static_lenb = (s->static_len + 3 + 7) >> 3;
+        /* Determine the best encoding. Compute the block lengths in bytes. */
+        opt_lenb = (s->opt_len+3+7)>>3;
+        static_lenb = (s->static_len+3+7)>>3;
 
-		Tracev((stderr, "\nopt %lu(%lu) stat %lu(%lu) stored %lu lit %u ",
-			opt_lenb, s->opt_len, static_lenb, s->static_len, stored_len,
-			s->last_lit));
+        Tracev((stderr, "\nopt %lu(%lu) stat %lu(%lu) stored %lu lit %u ",
+                opt_lenb, s->opt_len, static_lenb, s->static_len, stored_len,
+                s->last_lit));
 
-		if (static_lenb <= opt_lenb) opt_lenb = static_lenb;
+        if (static_lenb <= opt_lenb) opt_lenb = static_lenb;
 
-	}
-	else {
-		Assert(buf != (char*)0, "lost buf");
-		opt_lenb = static_lenb = stored_len + 5; /* force a stored block */
-	}
+    } else {
+        Assert(buf != (char*)0, "lost buf");
+        opt_lenb = static_lenb = stored_len + 5; /* force a stored block */
+    }
 
-	#ifdef FORCE_STORED
-	if (buf != (char*)0) { /* force stored block */
-		#else
-	if (stored_len + 4 <= opt_lenb && buf != (char*)0) {
-		/* 4: two words for the lengths */
-		#endif
-				  /* The test buf != NULL is only necessary if LIT_BUFSIZE > WSIZE.
-					* Otherwise we can't have processed more than WSIZE input bytes since
-					* the last block flush, because compression would have been
-					* successful. If LIT_BUFSIZE <= WSIZE, it is never too late to
-					* transform a block into a stored block.
-					*/
-		_tr_stored_block(s, buf, stored_len, last);
+#ifdef FORCE_STORED
+    if (buf != (char*)0) { /* force stored block */
+#else
+    if (stored_len+4 <= opt_lenb && buf != (char*)0) {
+                       /* 4: two words for the lengths */
+#endif
+        /* The test buf != NULL is only necessary if LIT_BUFSIZE > WSIZE.
+         * Otherwise we can't have processed more than WSIZE input bytes since
+         * the last block flush, because compression would have been
+         * successful. If LIT_BUFSIZE <= WSIZE, it is never too late to
+         * transform a block into a stored block.
+         */
+        _tr_stored_block(s, buf, stored_len, last);
 
-		#ifdef FORCE_STATIC
-	}
-	else if (static_lenb >= 0) { /* force static trees */
-		#else
-	}
-	else if (s->strategy == Z_FIXED || static_lenb == opt_lenb) {
-		#endif
-		send_bits(s, (STATIC_TREES << 1) + last, 3);
-		compress_block(s, (const ct_data *)static_ltree,
-			(const ct_data *)static_dtree);
-		#ifdef DEBUG
-		s->compressed_len += 3 + s->static_len;
-		#endif
-	}
-	else {
-		send_bits(s, (DYN_TREES << 1) + last, 3);
-		send_all_trees(s, s->l_desc.max_code + 1, s->d_desc.max_code + 1,
-			max_blindex + 1);
-		compress_block(s, (const ct_data *)s->dyn_ltree,
-			(const ct_data *)s->dyn_dtree);
-		#ifdef DEBUG
-		s->compressed_len += 3 + s->opt_len;
-		#endif
-	}
-	Assert(s->compressed_len == s->bits_sent, "bad compressed size");
-	/* The above check is made mod 2^32, for files larger than 512 MB
-	 * and uLong implemented on 32 bits.
-	 */
-	init_block(s);
+#ifdef FORCE_STATIC
+    } else if (static_lenb >= 0) { /* force static trees */
+#else
+    } else if (s->strategy == Z_FIXED || static_lenb == opt_lenb) {
+#endif
+        send_bits(s, (STATIC_TREES<<1)+last, 3);
+        compress_block(s, (const ct_data *)static_ltree,
+                       (const ct_data *)static_dtree);
+#ifdef ZLIB_DEBUG
+        s->compressed_len += 3 + s->static_len;
+#endif
+    } else {
+        send_bits(s, (DYN_TREES<<1)+last, 3);
+        send_all_trees(s, s->l_desc.max_code+1, s->d_desc.max_code+1,
+                       max_blindex+1);
+        compress_block(s, (const ct_data *)s->dyn_ltree,
+                       (const ct_data *)s->dyn_dtree);
+#ifdef ZLIB_DEBUG
+        s->compressed_len += 3 + s->opt_len;
+#endif
+    }
+    Assert (s->compressed_len == s->bits_sent, "bad compressed size");
+    /* The above check is made mod 2^32, for files larger than 512 MB
+     * and uLong implemented on 32 bits.
+     */
+    init_block(s);
 
-	if (last) {
-		bi_windup(s);
-		#ifdef DEBUG
-		s->compressed_len += 7;  /* align on byte boundary */
-		#endif
-	}
-	Tracev((stderr, "\ncomprlen %lu(%lu) ", s->compressed_len >> 3,
-		s->compressed_len - 7 * last));
+    if (last) {
+        bi_windup(s);
+#ifdef ZLIB_DEBUG
+        s->compressed_len += 7;  /* align on byte boundary */
+#endif
+    }
+    Tracev((stderr,"\ncomprlen %lu(%lu) ", s->compressed_len>>3,
+           s->compressed_len-7*last));
 }
 
 /* ===========================================================================
  * Save the match info and tally the frequency counts. Return true if
  * the current block must be flushed.
  */
-int ZLIB_INTERNAL _tr_tally(s, dist, lc)
-deflate_state *s;
-unsigned dist;  /* distance of matched string */
-unsigned lc;    /* match length-MIN_MATCH or unmatched char (if dist==0) */
+int ZLIB_INTERNAL _tr_tally (s, dist, lc)
+    deflate_state *s;
+    unsigned dist;  /* distance of matched string */
+    unsigned lc;    /* match length-MIN_MATCH or unmatched char (if dist==0) */
 {
-	s->d_buf[s->last_lit] = (ush)dist;
-	s->l_buf[s->last_lit++] = (uch)lc;
-	if (dist == 0) {
-		/* lc is the unmatched char */
-		s->dyn_ltree[lc].Freq++;
-	}
-	else {
-		s->matches++;
-		/* Here, lc is the match length - MIN_MATCH */
-		dist--;             /* dist = match distance - 1 */
-		Assert((ush)dist < (ush)MAX_DIST(s) &&
-			(ush)lc <= (ush)(MAX_MATCH - MIN_MATCH) &&
-			(ush)d_code(dist) < (ush)D_CODES, "_tr_tally: bad match");
+    s->d_buf[s->last_lit] = (ush)dist;
+    s->l_buf[s->last_lit++] = (uch)lc;
+    if (dist == 0) {
+        /* lc is the unmatched char */
+        s->dyn_ltree[lc].Freq++;
+    } else {
+        s->matches++;
+        /* Here, lc is the match length - MIN_MATCH */
+        dist--;             /* dist = match distance - 1 */
+        Assert((ush)dist < (ush)MAX_DIST(s) &&
+               (ush)lc <= (ush)(MAX_MATCH-MIN_MATCH) &&
+               (ush)d_code(dist) < (ush)D_CODES,  "_tr_tally: bad match");
 
-		s->dyn_ltree[_length_code[lc] + LITERALS + 1].Freq++;
-		s->dyn_dtree[d_code(dist)].Freq++;
-	}
+        s->dyn_ltree[_length_code[lc]+LITERALS+1].Freq++;
+        s->dyn_dtree[d_code(dist)].Freq++;
+    }
 
-	#ifdef TRUNCATE_BLOCK
-	/* Try to guess if it is profitable to stop the current block here */
-	if ((s->last_lit & 0x1fff) == 0 && s->level > 2) {
-		/* Compute an upper bound for the compressed length */
-		ulg out_length = (ulg)s->last_lit * 8L;
-		ulg in_length = (ulg)((long)s->strstart - s->block_start);
-		int dcode;
-		for (dcode = 0; dcode < D_CODES; dcode++) {
-			out_length += (ulg)s->dyn_dtree[dcode].Freq *
-				(5L + extra_dbits[dcode]);
-		}
-		out_length >>= 3;
-		Tracev((stderr, "\nlast_lit %u, in %ld, out ~%ld(%ld%%) ",
-			s->last_lit, in_length, out_length,
-			100L - out_length * 100L / in_length));
-		if (s->matches < s->last_lit / 2 && out_length < in_length / 2) return 1;
-	}
-	#endif
-	return (s->last_lit == s->lit_bufsize - 1);
-	/* We avoid equality with lit_bufsize because of wraparound at 64K
-	 * on 16 bit machines and because stored blocks are restricted to
-	 * 64K-1 bytes.
-	 */
+#ifdef TRUNCATE_BLOCK
+    /* Try to guess if it is profitable to stop the current block here */
+    if ((s->last_lit & 0x1fff) == 0 && s->level > 2) {
+        /* Compute an upper bound for the compressed length */
+        ulg out_length = (ulg)s->last_lit*8L;
+        ulg in_length = (ulg)((long)s->strstart - s->block_start);
+        int dcode;
+        for (dcode = 0; dcode < D_CODES; dcode++) {
+            out_length += (ulg)s->dyn_dtree[dcode].Freq *
+                (5L+extra_dbits[dcode]);
+        }
+        out_length >>= 3;
+        Tracev((stderr,"\nlast_lit %u, in %ld, out ~%ld(%ld%%) ",
+               s->last_lit, in_length, out_length,
+               100L - out_length*100L/in_length));
+        if (s->matches < s->last_lit/2 && out_length < in_length/2) return 1;
+    }
+#endif
+    return (s->last_lit == s->lit_bufsize-1);
+    /* We avoid equality with lit_bufsize because of wraparound at 64K
+     * on 16 bit machines and because stored blocks are restricted to
+     * 64K-1 bytes.
+     */
 }
 
 /* ===========================================================================
  * Send the block data compressed using the given Huffman trees
  */
 local void compress_block(s, ltree, dtree)
-deflate_state *s;
-const ct_data *ltree; /* literal tree */
-const ct_data *dtree; /* distance tree */
+    deflate_state *s;
+    const ct_data *ltree; /* literal tree */
+    const ct_data *dtree; /* distance tree */
 {
-	unsigned dist;      /* distance of matched string */
-	int lc;             /* match length or unmatched char (if dist == 0) */
-	unsigned lx = 0;    /* running index in l_buf */
-	unsigned code;      /* the code to send */
-	int extra;          /* number of extra bits to send */
+    unsigned dist;      /* distance of matched string */
+    int lc;             /* match length or unmatched char (if dist == 0) */
+    unsigned lx = 0;    /* running index in l_buf */
+    unsigned code;      /* the code to send */
+    int extra;          /* number of extra bits to send */
 
-	if (s->last_lit != 0) do {
-		dist = s->d_buf[lx];
-		lc = s->l_buf[lx++];
-		if (dist == 0) {
-			send_code(s, lc, ltree); /* send a literal byte */
-			Tracecv(isgraph(lc), (stderr, " '%c' ", lc));
-		}
-		else {
-			/* Here, lc is the match length - MIN_MATCH */
-			code = _length_code[lc];
-			send_code(s, code + LITERALS + 1, ltree); /* send the length code */
-			extra = extra_lbits[code];
-			if (extra != 0) {
-				lc -= base_length[code];
-				send_bits(s, lc, extra);       /* send the extra length bits */
-			}
-			dist--; /* dist is now the match distance - 1 */
-			code = d_code(dist);
-			Assert(code < D_CODES, "bad d_code");
+    if (s->last_lit != 0) do {
+        dist = s->d_buf[lx];
+        lc = s->l_buf[lx++];
+        if (dist == 0) {
+            send_code(s, lc, ltree); /* send a literal byte */
+            Tracecv(isgraph(lc), (stderr," '%c' ", lc));
+        } else {
+            /* Here, lc is the match length - MIN_MATCH */
+            code = _length_code[lc];
+            send_code(s, code+LITERALS+1, ltree); /* send the length code */
+            extra = extra_lbits[code];
+            if (extra != 0) {
+                lc -= base_length[code];
+                send_bits(s, lc, extra);       /* send the extra length bits */
+            }
+            dist--; /* dist is now the match distance - 1 */
+            code = d_code(dist);
+            Assert (code < D_CODES, "bad d_code");
 
-			send_code(s, code, dtree);       /* send the distance code */
-			extra = extra_dbits[code];
-			if (extra != 0) {
-				dist -= base_dist[code];
-				send_bits(s, dist, extra);   /* send the extra distance bits */
-			}
-		} /* literal or match pair ? */
+            send_code(s, code, dtree);       /* send the distance code */
+            extra = extra_dbits[code];
+            if (extra != 0) {
+                dist -= (unsigned)base_dist[code];
+                send_bits(s, dist, extra);   /* send the extra distance bits */
+            }
+        } /* literal or match pair ? */
 
-		/* Check that the overlay between pending_buf and d_buf+l_buf is ok: */
-		Assert((uInt)(s->pending) < s->lit_bufsize + 2 * lx,
-			"pendingBuf overflow");
+        /* Check that the overlay between pending_buf and d_buf+l_buf is ok: */
+        Assert((uInt)(s->pending) < s->lit_bufsize + 2*lx,
+               "pendingBuf overflow");
 
-	} while (lx < s->last_lit);
+    } while (lx < s->last_lit);
 
-	send_code(s, END_BLOCK, ltree);
+    send_code(s, END_BLOCK, ltree);
 }
 
 /* ===========================================================================
@@ -1139,32 +1122,32 @@ const ct_data *dtree; /* distance tree */
  * IN assertion: the fields Freq of dyn_ltree are set.
  */
 local int detect_data_type(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	/* black_mask is the bit mask of black-listed bytes
-	 * set bits 0..6, 14..25, and 28..31
-	 * 0xf3ffc07f = binary 11110011111111111100000001111111
-	 */
-	unsigned long black_mask = 0xf3ffc07fUL;
-	int n;
+    /* black_mask is the bit mask of black-listed bytes
+     * set bits 0..6, 14..25, and 28..31
+     * 0xf3ffc07f = binary 11110011111111111100000001111111
+     */
+    unsigned long black_mask = 0xf3ffc07fUL;
+    int n;
 
-	/* Check for non-textual ("black-listed") bytes. */
-	for (n = 0; n <= 31; n++, black_mask >>= 1)
-		if ((black_mask & 1) && (s->dyn_ltree[n].Freq != 0))
-			return Z_BINARY;
+    /* Check for non-textual ("black-listed") bytes. */
+    for (n = 0; n <= 31; n++, black_mask >>= 1)
+        if ((black_mask & 1) && (s->dyn_ltree[n].Freq != 0))
+            return Z_BINARY;
 
-	/* Check for textual ("white-listed") bytes. */
-	if (s->dyn_ltree[9].Freq != 0 || s->dyn_ltree[10].Freq != 0
-		|| s->dyn_ltree[13].Freq != 0)
-		return Z_TEXT;
-	for (n = 32; n < LITERALS; n++)
-		if (s->dyn_ltree[n].Freq != 0)
-			return Z_TEXT;
+    /* Check for textual ("white-listed") bytes. */
+    if (s->dyn_ltree[9].Freq != 0 || s->dyn_ltree[10].Freq != 0
+            || s->dyn_ltree[13].Freq != 0)
+        return Z_TEXT;
+    for (n = 32; n < LITERALS; n++)
+        if (s->dyn_ltree[n].Freq != 0)
+            return Z_TEXT;
 
-	/* There are no "black-listed" or "white-listed" bytes:
-	 * this stream either is empty or has tolerated ("gray-listed") bytes only.
-	 */
-	return Z_BINARY;
+    /* There are no "black-listed" or "white-listed" bytes:
+     * this stream either is empty or has tolerated ("gray-listed") bytes only.
+     */
+    return Z_BINARY;
 }
 
 /* ===========================================================================
@@ -1173,77 +1156,48 @@ deflate_state *s;
  * IN assertion: 1 <= len <= 15
  */
 local unsigned bi_reverse(code, len)
-unsigned code; /* the value to invert */
-int len;       /* its bit length */
+    unsigned code; /* the value to invert */
+    int len;       /* its bit length */
 {
-	register unsigned res = 0;
-	do {
-		res |= code & 1;
-		code >>= 1, res <<= 1;
-	} while (--len > 0);
-	return res >> 1;
+    register unsigned res = 0;
+    do {
+        res |= code & 1;
+        code >>= 1, res <<= 1;
+    } while (--len > 0);
+    return res >> 1;
 }
 
 /* ===========================================================================
  * Flush the bit buffer, keeping at most 7 bits in it.
  */
 local void bi_flush(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	if (s->bi_valid == 16) {
-		put_short(s, s->bi_buf);
-		s->bi_buf = 0;
-		s->bi_valid = 0;
-	}
-	else if (s->bi_valid >= 8) {
-		put_byte(s, (Byte)s->bi_buf);
-		s->bi_buf >>= 8;
-		s->bi_valid -= 8;
-	}
+    if (s->bi_valid == 16) {
+        put_short(s, s->bi_buf);
+        s->bi_buf = 0;
+        s->bi_valid = 0;
+    } else if (s->bi_valid >= 8) {
+        put_byte(s, (Byte)s->bi_buf);
+        s->bi_buf >>= 8;
+        s->bi_valid -= 8;
+    }
 }
 
 /* ===========================================================================
  * Flush the bit buffer and align the output on a byte boundary
  */
 local void bi_windup(s)
-deflate_state *s;
+    deflate_state *s;
 {
-	if (s->bi_valid > 8) {
-		put_short(s, s->bi_buf);
-	}
-	else if (s->bi_valid > 0) {
-		put_byte(s, (Byte)s->bi_buf);
-	}
-	s->bi_buf = 0;
-	s->bi_valid = 0;
-	#ifdef DEBUG
-	s->bits_sent = (s->bits_sent + 7) & ~7;
-	#endif
-}
-
-/* ===========================================================================
- * Copy a stored block, storing first the length and its
- * one's complement if requested.
- */
-local void copy_block(s, buf, len, header)
-deflate_state *s;
-charf    *buf;    /* the input data */
-unsigned len;     /* its length */
-int      header;  /* true if block header must be written */
-{
-	bi_windup(s);        /* align on byte boundary */
-
-	if (header) {
-		put_short(s, (ush)len);
-		put_short(s, (ush)~len);
-		#ifdef DEBUG
-		s->bits_sent += 2 * 16;
-		#endif
-	}
-	#ifdef DEBUG
-	s->bits_sent += (ulg)len << 3;
-	#endif
-	while (len--) {
-		put_byte(s, *buf++);
-	}
+    if (s->bi_valid > 8) {
+        put_short(s, s->bi_buf);
+    } else if (s->bi_valid > 0) {
+        put_byte(s, (Byte)s->bi_buf);
+    }
+    s->bi_buf = 0;
+    s->bi_valid = 0;
+#ifdef ZLIB_DEBUG
+    s->bits_sent = (s->bits_sent+7) & ~7;
+#endif
 }

--- a/libs/zlib/src/uncompr.c
+++ b/libs/zlib/src/uncompr.c
@@ -1,5 +1,5 @@
 /* uncompr.c -- decompress a memory buffer
- * Copyright (C) 1995-2003, 2010 Jean-loup Gailly.
+ * Copyright (C) 1995-2003, 2010, 2014, 2016 Jean-loup Gailly, Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -9,51 +9,85 @@
 #include "zlib.h"
 
 /* ===========================================================================
-     Decompresses the source buffer into the destination buffer.  sourceLen is
-   the byte length of the source buffer. Upon entry, destLen is the total
-   size of the destination buffer, which must be large enough to hold the
-   entire uncompressed data. (The size of the uncompressed data must have
-   been saved previously by the compressor and transmitted to the decompressor
-   by some mechanism outside the scope of this compression library.)
-   Upon exit, destLen is the actual size of the compressed buffer.
+     Decompresses the source buffer into the destination buffer.  *sourceLen is
+   the byte length of the source buffer. Upon entry, *destLen is the total size
+   of the destination buffer, which must be large enough to hold the entire
+   uncompressed data. (The size of the uncompressed data must have been saved
+   previously by the compressor and transmitted to the decompressor by some
+   mechanism outside the scope of this compression library.) Upon exit,
+   *destLen is the size of the decompressed data and *sourceLen is the number
+   of source bytes consumed. Upon return, source + *sourceLen points to the
+   first unused input byte.
 
-     uncompress returns Z_OK if success, Z_MEM_ERROR if there was not
-   enough memory, Z_BUF_ERROR if there was not enough room in the output
-   buffer, or Z_DATA_ERROR if the input data was corrupted.
+     uncompress returns Z_OK if success, Z_MEM_ERROR if there was not enough
+   memory, Z_BUF_ERROR if there was not enough room in the output buffer, or
+   Z_DATA_ERROR if the input data was corrupted, including if the input data is
+   an incomplete zlib stream.
 */
-int ZEXPORT uncompress(dest, destLen, source, sourceLen)
-Bytef *dest;
-uLongf *destLen;
-const Bytef *source;
-uLong sourceLen;
+int ZEXPORT uncompress2 (dest, destLen, source, sourceLen)
+    Bytef *dest;
+    uLongf *destLen;
+    const Bytef *source;
+    uLong *sourceLen;
 {
-	z_stream stream;
-	int err;
+    z_stream stream;
+    int err;
+    const uInt max = (uInt)-1;
+    uLong len, left;
+    Byte buf[1];    /* for detection of incomplete stream when *destLen == 0 */
 
-	stream.next_in = (z_const Bytef *)source;
-	stream.avail_in = (uInt)sourceLen;
-	/* Check for source > 64K on 16-bit machine: */
-	if ((uLong)stream.avail_in != sourceLen) return Z_BUF_ERROR;
+    len = *sourceLen;
+    if (*destLen) {
+        left = *destLen;
+        *destLen = 0;
+    }
+    else {
+        left = 1;
+        dest = buf;
+    }
 
-	stream.next_out = dest;
-	stream.avail_out = (uInt)*destLen;
-	if ((uLong)stream.avail_out != *destLen) return Z_BUF_ERROR;
+    stream.next_in = (z_const Bytef *)source;
+    stream.avail_in = 0;
+    stream.zalloc = (alloc_func)0;
+    stream.zfree = (free_func)0;
+    stream.opaque = (voidpf)0;
 
-	stream.zalloc = (alloc_func)0;
-	stream.zfree = (free_func)0;
+    err = inflateInit(&stream);
+    if (err != Z_OK) return err;
 
-	err = inflateInit(&stream);
-	if (err != Z_OK) return err;
+    stream.next_out = dest;
+    stream.avail_out = 0;
 
-	err = inflate(&stream, Z_FINISH);
-	if (err != Z_STREAM_END) {
-		inflateEnd(&stream);
-		if (err == Z_NEED_DICT || (err == Z_BUF_ERROR && stream.avail_in == 0))
-			return Z_DATA_ERROR;
-		return err;
-	}
-	*destLen = stream.total_out;
+    do {
+        if (stream.avail_out == 0) {
+            stream.avail_out = left > (uLong)max ? max : (uInt)left;
+            left -= stream.avail_out;
+        }
+        if (stream.avail_in == 0) {
+            stream.avail_in = len > (uLong)max ? max : (uInt)len;
+            len -= stream.avail_in;
+        }
+        err = inflate(&stream, Z_NO_FLUSH);
+    } while (err == Z_OK);
 
-	err = inflateEnd(&stream);
-	return err;
+    *sourceLen -= len + stream.avail_in;
+    if (dest != buf)
+        *destLen = stream.total_out;
+    else if (stream.total_out && err == Z_BUF_ERROR)
+        left = 1;
+
+    inflateEnd(&stream);
+    return err == Z_STREAM_END ? Z_OK :
+           err == Z_NEED_DICT ? Z_DATA_ERROR  :
+           err == Z_BUF_ERROR && left + stream.avail_out ? Z_DATA_ERROR :
+           err;
+}
+
+int ZEXPORT uncompress (dest, destLen, source, sourceLen)
+    Bytef *dest;
+    uLongf *destLen;
+    const Bytef *source;
+    uLong sourceLen;
+{
+    return uncompress2(dest, destLen, source, &sourceLen);
 }

--- a/libs/zlib/src/unzip.c
+++ b/libs/zlib/src/unzip.c
@@ -63,12 +63,13 @@
 
 */
 
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifndef NOUNCRYPT
-#define NOUNCRYPT
+        #define NOUNCRYPT
 #endif
 
 #include "zlib.h"
@@ -80,7 +81,7 @@
 #  include <stdlib.h>
 #endif
 #ifdef NO_ERRNO_H
-extern int errno;
+    extern int errno;
 #else
 #   include <errno.h>
 #endif
@@ -119,43 +120,43 @@ extern int errno;
 
 
 const char unz_copyright[] =
-" unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
+   " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
 /* unz_file_info_interntal contain internal info about a file in zipfile*/
 typedef struct unz_file_info64_internal_s
 {
-	ZPOS64_T offset_curfile;/* relative offset of local header 8 bytes */
+    ZPOS64_T offset_curfile;/* relative offset of local header 8 bytes */
 } unz_file_info64_internal;
 
 
 /* file_in_zip_read_info_s contain internal information about a file in zipfile,
-	 when reading and decompress it */
+    when reading and decompress it */
 typedef struct
 {
-	char  *read_buffer;         /* internal buffer for compressed data */
-	z_stream stream;            /* zLib stream structure for inflate */
+    char  *read_buffer;         /* internal buffer for compressed data */
+    z_stream stream;            /* zLib stream structure for inflate */
 
-	#ifdef HAVE_BZIP2
-	bz_stream bstream;          /* bzLib stream structure for bziped */
-	#endif
+#ifdef HAVE_BZIP2
+    bz_stream bstream;          /* bzLib stream structure for bziped */
+#endif
 
-	ZPOS64_T pos_in_zipfile;       /* position in byte on the zipfile, for fseek*/
-	uLong stream_initialised;   /* flag set if stream structure is initialised*/
+    ZPOS64_T pos_in_zipfile;       /* position in byte on the zipfile, for fseek*/
+    uLong stream_initialised;   /* flag set if stream structure is initialised*/
 
-	ZPOS64_T offset_local_extrafield;/* offset of the local extra field */
-	uInt  size_local_extrafield;/* size of the local extra field */
-	ZPOS64_T pos_local_extrafield;   /* position in the local extra field in read*/
-	ZPOS64_T total_out_64;
+    ZPOS64_T offset_local_extrafield;/* offset of the local extra field */
+    uInt  size_local_extrafield;/* size of the local extra field */
+    ZPOS64_T pos_local_extrafield;   /* position in the local extra field in read*/
+    ZPOS64_T total_out_64;
 
-	uLong crc32;                /* crc32 of all data uncompressed */
-	uLong crc32_wait;           /* crc32 we must obtain after decompress all */
-	ZPOS64_T rest_read_compressed; /* number of byte to be decompressed */
-	ZPOS64_T rest_read_uncompressed;/*number of byte to be obtained after decomp*/
-	zlib_filefunc64_32_def z_filefunc;
-	voidpf filestream;        /* io structore of the zipfile */
-	uLong compression_method;   /* compression method (0==store) */
-	ZPOS64_T byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
-	int   raw;
+    uLong crc32;                /* crc32 of all data uncompressed */
+    uLong crc32_wait;           /* crc32 we must obtain after decompress all */
+    ZPOS64_T rest_read_compressed; /* number of byte to be decompressed */
+    ZPOS64_T rest_read_uncompressed;/*number of byte to be obtained after decomp*/
+    zlib_filefunc64_32_def z_filefunc;
+    voidpf filestream;        /* io structore of the zipfile */
+    uLong compression_method;   /* compression method (0==store) */
+    ZPOS64_T byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+    int   raw;
 } file_in_zip64_read_info_s;
 
 
@@ -163,32 +164,32 @@ typedef struct
 */
 typedef struct
 {
-	zlib_filefunc64_32_def z_filefunc;
-	int is64bitOpenFunction;
-	voidpf filestream;        /* io structore of the zipfile */
-	unz_global_info64 gi;       /* public global information */
-	ZPOS64_T byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
-	ZPOS64_T num_file;             /* number of the current file in the zipfile*/
-	ZPOS64_T pos_in_central_dir;   /* pos of the current file in the central dir*/
-	ZPOS64_T current_file_ok;      /* flag about the usability of the current file*/
-	ZPOS64_T central_pos;          /* position of the beginning of the central dir*/
+    zlib_filefunc64_32_def z_filefunc;
+    int is64bitOpenFunction;
+    voidpf filestream;        /* io structore of the zipfile */
+    unz_global_info64 gi;       /* public global information */
+    ZPOS64_T byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+    ZPOS64_T num_file;             /* number of the current file in the zipfile*/
+    ZPOS64_T pos_in_central_dir;   /* pos of the current file in the central dir*/
+    ZPOS64_T current_file_ok;      /* flag about the usability of the current file*/
+    ZPOS64_T central_pos;          /* position of the beginning of the central dir*/
 
-	ZPOS64_T size_central_dir;     /* size of the central directory  */
-	ZPOS64_T offset_central_dir;   /* offset of start of central directory with
-											 respect to the starting disk number */
+    ZPOS64_T size_central_dir;     /* size of the central directory  */
+    ZPOS64_T offset_central_dir;   /* offset of start of central directory with
+                                   respect to the starting disk number */
 
-	unz_file_info64 cur_file_info; /* public info about the current file in zip*/
-	unz_file_info64_internal cur_file_info_internal; /* private info about it*/
-	file_in_zip64_read_info_s* pfile_in_zip_read; /* structure about the current
-													file if we are decompressing it */
-	int encrypted;
+    unz_file_info64 cur_file_info; /* public info about the current file in zip*/
+    unz_file_info64_internal cur_file_info_internal; /* private info about it*/
+    file_in_zip64_read_info_s* pfile_in_zip_read; /* structure about the current
+                                        file if we are decompressing it */
+    int encrypted;
 
-	int isZip64;
+    int isZip64;
 
-	#    ifndef NOUNCRYPT
-	unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-	const z_crc_t* pcrc_32_tab;
-	#    endif
+#    ifndef NOUNCRYPT
+    unsigned long keys[3];     /* keys defining the pseudo-random sequence */
+    const z_crc_t* pcrc_32_tab;
+#    endif
 } unz64_s;
 
 
@@ -197,170 +198,173 @@ typedef struct
 #endif
 
 /* ===========================================================================
-	  Read a byte from a gz_stream; update next_in and avail_in. Return EOF
-	for end of file.
-	IN assertion: the stream s has been sucessfully opened for reading.
+     Read a byte from a gz_stream; update next_in and avail_in. Return EOF
+   for end of file.
+   IN assertion: the stream s has been successfully opened for reading.
 */
 
 
 local int unz64local_getByte OF((
-	const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream,
-	int *pi));
+    const zlib_filefunc64_32_def* pzlib_filefunc_def,
+    voidpf filestream,
+    int *pi));
 
 local int unz64local_getByte(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, int *pi)
 {
-	unsigned char c;
-	int err = (int)ZREAD64(*pzlib_filefunc_def, filestream, &c, 1);
-	if (err == 1) {
-		*pi = (int)c;
-		return UNZ_OK;
-	}
-	else {
-		if (ZERROR64(*pzlib_filefunc_def, filestream))
-			return UNZ_ERRNO;
-		else
-			return UNZ_EOF;
-	}
+    unsigned char c;
+    int err = (int)ZREAD64(*pzlib_filefunc_def,filestream,&c,1);
+    if (err==1)
+    {
+        *pi = (int)c;
+        return UNZ_OK;
+    }
+    else
+    {
+        if (ZERROR64(*pzlib_filefunc_def,filestream))
+            return UNZ_ERRNO;
+        else
+            return UNZ_EOF;
+    }
 }
 
 
 /* ===========================================================================
-	Reads a long in LSB order from the given gz_stream. Sets
+   Reads a long in LSB order from the given gz_stream. Sets
 */
 local int unz64local_getShort OF((
-	const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream,
-	uLong *pX));
+    const zlib_filefunc64_32_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
 
-local int unz64local_getShort(const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream,
-	uLong *pX)
+local int unz64local_getShort (const zlib_filefunc64_32_def* pzlib_filefunc_def,
+                             voidpf filestream,
+                             uLong *pX)
 {
-	uLong x;
-	int i = 0;
-	int err;
+    uLong x ;
+    int i = 0;
+    int err;
 
-	err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x = (uLong)i;
+    err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((uLong)i) << 8;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((uLong)i)<<8;
 
-	if (err == UNZ_OK)
-		*pX = x;
-	else
-		*pX = 0;
-	return err;
+    if (err==UNZ_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
 }
 
 local int unz64local_getLong OF((
-	const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream,
-	uLong *pX));
+    const zlib_filefunc64_32_def* pzlib_filefunc_def,
+    voidpf filestream,
+    uLong *pX));
 
-local int unz64local_getLong(const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream,
-	uLong *pX)
+local int unz64local_getLong (const zlib_filefunc64_32_def* pzlib_filefunc_def,
+                            voidpf filestream,
+                            uLong *pX)
 {
-	uLong x;
-	int i = 0;
-	int err;
+    uLong x ;
+    int i = 0;
+    int err;
 
-	err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x = (uLong)i;
+    err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((uLong)i) << 8;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((uLong)i)<<8;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((uLong)i) << 16;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((uLong)i)<<16;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((uLong)i) << 24;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<24;
 
-	if (err == UNZ_OK)
-		*pX = x;
-	else
-		*pX = 0;
-	return err;
+    if (err==UNZ_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
 }
 
 local int unz64local_getLong64 OF((
-	const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream,
-	ZPOS64_T *pX));
+    const zlib_filefunc64_32_def* pzlib_filefunc_def,
+    voidpf filestream,
+    ZPOS64_T *pX));
 
 
-local int unz64local_getLong64(const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream,
-	ZPOS64_T *pX)
+local int unz64local_getLong64 (const zlib_filefunc64_32_def* pzlib_filefunc_def,
+                            voidpf filestream,
+                            ZPOS64_T *pX)
 {
-	ZPOS64_T x;
-	int i = 0;
-	int err;
+    ZPOS64_T x ;
+    int i = 0;
+    int err;
 
-	err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x = (ZPOS64_T)i;
+    err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (ZPOS64_T)i;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((ZPOS64_T)i) << 8;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((ZPOS64_T)i)<<8;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((ZPOS64_T)i) << 16;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((ZPOS64_T)i)<<16;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((ZPOS64_T)i) << 24;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((ZPOS64_T)i)<<24;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((ZPOS64_T)i) << 32;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((ZPOS64_T)i)<<32;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((ZPOS64_T)i) << 40;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((ZPOS64_T)i)<<40;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((ZPOS64_T)i) << 48;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((ZPOS64_T)i)<<48;
 
-	if (err == UNZ_OK)
-		err = unz64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x |= ((ZPOS64_T)i) << 56;
+    if (err==UNZ_OK)
+        err = unz64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x |= ((ZPOS64_T)i)<<56;
 
-	if (err == UNZ_OK)
-		*pX = x;
-	else
-		*pX = 0;
-	return err;
+    if (err==UNZ_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
 }
 
 /* My own strcmpi / strcasecmp */
-local int strcmpcasenosensitive_internal(const char* fileName1, const char* fileName2)
+local int strcmpcasenosensitive_internal (const char* fileName1, const char* fileName2)
 {
-	for (;;) {
-		char c1 = *(fileName1++);
-		char c2 = *(fileName2++);
-		if ((c1 >= 'a') && (c1 <= 'z'))
-			c1 -= 0x20;
-		if ((c2 >= 'a') && (c2 <= 'z'))
-			c2 -= 0x20;
-		if (c1 == '\0')
-			return ((c2 == '\0') ? 0 : -1);
-		if (c2 == '\0')
-			return 1;
-		if (c1 < c2)
-			return -1;
-		if (c1 > c2)
-			return 1;
-	}
+    for (;;)
+    {
+        char c1=*(fileName1++);
+        char c2=*(fileName2++);
+        if ((c1>='a') && (c1<='z'))
+            c1 -= 0x20;
+        if ((c2>='a') && (c2<='z'))
+            c2 -= 0x20;
+        if (c1=='\0')
+            return ((c2=='\0') ? 0 : -1);
+        if (c2=='\0')
+            return 1;
+        if (c1<c2)
+            return -1;
+        if (c1>c2)
+            return 1;
+    }
 }
 
 
@@ -375,26 +379,26 @@ local int strcmpcasenosensitive_internal(const char* fileName1, const char* file
 #endif
 
 /*
-	Compare two filename (fileName1,fileName2).
-	If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
-	If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
-																					 or strcasecmp)
-	If iCaseSenisivity = 0, case sensitivity is default of your operating system
-		  (like 1 on Unix, 2 on Windows)
+   Compare two filename (fileName1,fileName2).
+   If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
+   If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
+                                                                or strcasecmp)
+   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
+        (like 1 on Unix, 2 on Windows)
 
 */
-extern int ZEXPORT unzStringFileNameCompare(const char*  fileName1,
-	const char*  fileName2,
-	int iCaseSensitivity)
+extern int ZEXPORT unzStringFileNameCompare (const char*  fileName1,
+                                                 const char*  fileName2,
+                                                 int iCaseSensitivity)
 
 {
-	if (iCaseSensitivity == 0)
-		iCaseSensitivity = CASESENSITIVITYDEFAULTVALUE;
+    if (iCaseSensitivity==0)
+        iCaseSensitivity=CASESENSITIVITYDEFAULTVALUE;
 
-	if (iCaseSensitivity == 1)
-		return strcmp(fileName1, fileName2);
+    if (iCaseSensitivity==1)
+        return strcmp(fileName1,fileName2);
 
-	return STRCMPCASENOSENTIVEFUNCTION(fileName1, fileName2);
+    return STRCMPCASENOSENTIVEFUNCTION(fileName1,fileName2);
 }
 
 #ifndef BUFREADCOMMENT
@@ -403,407 +407,417 @@ extern int ZEXPORT unzStringFileNameCompare(const char*  fileName1,
 
 /*
   Locate the Central directory of a zipfile (at the end, just before
-	 the global comment)
+    the global comment)
 */
 local ZPOS64_T unz64local_SearchCentralDir OF((const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream));
 local ZPOS64_T unz64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream)
 {
-	unsigned char* buf;
-	ZPOS64_T uSizeFile;
-	ZPOS64_T uBackRead;
-	ZPOS64_T uMaxBack = 0xffff; /* maximum size of global comment */
-	ZPOS64_T uPosFound = 0;
+    unsigned char* buf;
+    ZPOS64_T uSizeFile;
+    ZPOS64_T uBackRead;
+    ZPOS64_T uMaxBack=0xffff; /* maximum size of global comment */
+    ZPOS64_T uPosFound=0;
 
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, 0, ZLIB_FILEFUNC_SEEK_END) != 0)
-		return 0;
+    if (ZSEEK64(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
+        return 0;
 
 
-	uSizeFile = ZTELL64(*pzlib_filefunc_def, filestream);
+    uSizeFile = ZTELL64(*pzlib_filefunc_def,filestream);
 
-	if (uMaxBack > uSizeFile)
-		uMaxBack = uSizeFile;
+    if (uMaxBack>uSizeFile)
+        uMaxBack = uSizeFile;
 
-	buf = (unsigned char*)ALLOC(BUFREADCOMMENT + 4);
-	if (buf == NULL)
-		return 0;
+    buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+    if (buf==NULL)
+        return 0;
 
-	uBackRead = 4;
-	while (uBackRead<uMaxBack) {
-		uLong uReadSize;
-		ZPOS64_T uReadPos;
-		int i;
-		if (uBackRead + BUFREADCOMMENT>uMaxBack)
-			uBackRead = uMaxBack;
-		else
-			uBackRead += BUFREADCOMMENT;
-		uReadPos = uSizeFile - uBackRead;
+    uBackRead = 4;
+    while (uBackRead<uMaxBack)
+    {
+        uLong uReadSize;
+        ZPOS64_T uReadPos ;
+        int i;
+        if (uBackRead+BUFREADCOMMENT>uMaxBack)
+            uBackRead = uMaxBack;
+        else
+            uBackRead+=BUFREADCOMMENT;
+        uReadPos = uSizeFile-uBackRead ;
 
-		uReadSize = ((BUFREADCOMMENT + 4) < (uSizeFile - uReadPos)) ?
-			(BUFREADCOMMENT + 4) : (uLong)(uSizeFile - uReadPos);
-		if (ZSEEK64(*pzlib_filefunc_def, filestream, uReadPos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			break;
+        uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
+                     (BUFREADCOMMENT+4) : (uLong)(uSizeFile-uReadPos);
+        if (ZSEEK64(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            break;
 
-		if (ZREAD64(*pzlib_filefunc_def, filestream, buf, uReadSize) != uReadSize)
-			break;
+        if (ZREAD64(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
+            break;
 
-		for (i = (int)uReadSize - 3; (i--) > 0;)
-			if (((*(buf + i)) == 0x50) && ((*(buf + i + 1)) == 0x4b) &&
-				((*(buf + i + 2)) == 0x05) && ((*(buf + i + 3)) == 0x06)) {
-				uPosFound = uReadPos + i;
-				break;
-			}
+        for (i=(int)uReadSize-3; (i--)>0;)
+            if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
+                ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
+            {
+                uPosFound = uReadPos+i;
+                break;
+            }
 
-		if (uPosFound != 0)
-			break;
-	}
-	TRYFREE(buf);
-	return uPosFound;
+        if (uPosFound!=0)
+            break;
+    }
+    TRYFREE(buf);
+    return uPosFound;
 }
 
 
 /*
   Locate the Central directory 64 of a zipfile (at the end, just before
-	 the global comment)
+    the global comment)
 */
 local ZPOS64_T unz64local_SearchCentralDir64 OF((
-	const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream));
+    const zlib_filefunc64_32_def* pzlib_filefunc_def,
+    voidpf filestream));
 
 local ZPOS64_T unz64local_SearchCentralDir64(const zlib_filefunc64_32_def* pzlib_filefunc_def,
-	voidpf filestream)
+                                      voidpf filestream)
 {
-	unsigned char* buf;
-	ZPOS64_T uSizeFile;
-	ZPOS64_T uBackRead;
-	ZPOS64_T uMaxBack = 0xffff; /* maximum size of global comment */
-	ZPOS64_T uPosFound = 0;
-	uLong uL;
-	ZPOS64_T relativeOffset;
+    unsigned char* buf;
+    ZPOS64_T uSizeFile;
+    ZPOS64_T uBackRead;
+    ZPOS64_T uMaxBack=0xffff; /* maximum size of global comment */
+    ZPOS64_T uPosFound=0;
+    uLong uL;
+                ZPOS64_T relativeOffset;
 
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, 0, ZLIB_FILEFUNC_SEEK_END) != 0)
-		return 0;
+    if (ZSEEK64(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
+        return 0;
 
 
-	uSizeFile = ZTELL64(*pzlib_filefunc_def, filestream);
+    uSizeFile = ZTELL64(*pzlib_filefunc_def,filestream);
 
-	if (uMaxBack > uSizeFile)
-		uMaxBack = uSizeFile;
+    if (uMaxBack>uSizeFile)
+        uMaxBack = uSizeFile;
 
-	buf = (unsigned char*)ALLOC(BUFREADCOMMENT + 4);
-	if (buf == NULL)
-		return 0;
+    buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+    if (buf==NULL)
+        return 0;
 
-	uBackRead = 4;
-	while (uBackRead<uMaxBack) {
-		uLong uReadSize;
-		ZPOS64_T uReadPos;
-		int i;
-		if (uBackRead + BUFREADCOMMENT>uMaxBack)
-			uBackRead = uMaxBack;
-		else
-			uBackRead += BUFREADCOMMENT;
-		uReadPos = uSizeFile - uBackRead;
+    uBackRead = 4;
+    while (uBackRead<uMaxBack)
+    {
+        uLong uReadSize;
+        ZPOS64_T uReadPos;
+        int i;
+        if (uBackRead+BUFREADCOMMENT>uMaxBack)
+            uBackRead = uMaxBack;
+        else
+            uBackRead+=BUFREADCOMMENT;
+        uReadPos = uSizeFile-uBackRead ;
 
-		uReadSize = ((BUFREADCOMMENT + 4) < (uSizeFile - uReadPos)) ?
-			(BUFREADCOMMENT + 4) : (uLong)(uSizeFile - uReadPos);
-		if (ZSEEK64(*pzlib_filefunc_def, filestream, uReadPos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			break;
+        uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
+                     (BUFREADCOMMENT+4) : (uLong)(uSizeFile-uReadPos);
+        if (ZSEEK64(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            break;
 
-		if (ZREAD64(*pzlib_filefunc_def, filestream, buf, uReadSize) != uReadSize)
-			break;
+        if (ZREAD64(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
+            break;
 
-		for (i = (int)uReadSize - 3; (i--) > 0;)
-			if (((*(buf + i)) == 0x50) && ((*(buf + i + 1)) == 0x4b) &&
-				((*(buf + i + 2)) == 0x06) && ((*(buf + i + 3)) == 0x07)) {
-				uPosFound = uReadPos + i;
-				break;
-			}
+        for (i=(int)uReadSize-3; (i--)>0;)
+            if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
+                ((*(buf+i+2))==0x06) && ((*(buf+i+3))==0x07))
+            {
+                uPosFound = uReadPos+i;
+                break;
+            }
 
-		if (uPosFound != 0)
-			break;
-	}
-	TRYFREE(buf);
-	if (uPosFound == 0)
-		return 0;
+        if (uPosFound!=0)
+            break;
+    }
+    TRYFREE(buf);
+    if (uPosFound == 0)
+        return 0;
 
-	/* Zip64 end of central directory locator */
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, uPosFound, ZLIB_FILEFUNC_SEEK_SET) != 0)
-		return 0;
+    /* Zip64 end of central directory locator */
+    if (ZSEEK64(*pzlib_filefunc_def,filestream, uPosFound,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return 0;
 
-	/* the signature, already checked */
-	if (unz64local_getLong(pzlib_filefunc_def, filestream, &uL) != UNZ_OK)
-		return 0;
+    /* the signature, already checked */
+    if (unz64local_getLong(pzlib_filefunc_def,filestream,&uL)!=UNZ_OK)
+        return 0;
 
-	/* number of the disk with the start of the zip64 end of  central directory */
-	if (unz64local_getLong(pzlib_filefunc_def, filestream, &uL) != UNZ_OK)
-		return 0;
-	if (uL != 0)
-		return 0;
+    /* number of the disk with the start of the zip64 end of  central directory */
+    if (unz64local_getLong(pzlib_filefunc_def,filestream,&uL)!=UNZ_OK)
+        return 0;
+    if (uL != 0)
+        return 0;
 
-	/* relative offset of the zip64 end of central directory record */
-	if (unz64local_getLong64(pzlib_filefunc_def, filestream, &relativeOffset) != UNZ_OK)
-		return 0;
+    /* relative offset of the zip64 end of central directory record */
+    if (unz64local_getLong64(pzlib_filefunc_def,filestream,&relativeOffset)!=UNZ_OK)
+        return 0;
 
-	/* total number of disks */
-	if (unz64local_getLong(pzlib_filefunc_def, filestream, &uL) != UNZ_OK)
-		return 0;
-	if (uL != 1)
-		return 0;
+    /* total number of disks */
+    if (unz64local_getLong(pzlib_filefunc_def,filestream,&uL)!=UNZ_OK)
+        return 0;
+    if (uL != 1)
+        return 0;
 
-	/* Goto end of central directory record */
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, relativeOffset, ZLIB_FILEFUNC_SEEK_SET) != 0)
-		return 0;
+    /* Goto end of central directory record */
+    if (ZSEEK64(*pzlib_filefunc_def,filestream, relativeOffset,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return 0;
 
-	/* the signature */
-	if (unz64local_getLong(pzlib_filefunc_def, filestream, &uL) != UNZ_OK)
-		return 0;
+     /* the signature */
+    if (unz64local_getLong(pzlib_filefunc_def,filestream,&uL)!=UNZ_OK)
+        return 0;
 
-	if (uL != 0x06064b50)
-		return 0;
+    if (uL != 0x06064b50)
+        return 0;
 
-	return relativeOffset;
+    return relativeOffset;
 }
 
 /*
   Open a Zip file. path contain the full pathname (by example,
-	  on a Windows NT computer "c:\\test\\zlib114.zip" or on an Unix computer
-	  "zlib/zlib114.zip".
-	  If the zipfile cannot be opened (file doesn't exist or in not valid), the
-		 return value is NULL.
-	  Else, the return value is a unzFile Handle, usable with other function
-		 of this unzip package.
+     on a Windows NT computer "c:\\test\\zlib114.zip" or on an Unix computer
+     "zlib/zlib114.zip".
+     If the zipfile cannot be opened (file doesn't exist or in not valid), the
+       return value is NULL.
+     Else, the return value is a unzFile Handle, usable with other function
+       of this unzip package.
 */
-local unzFile unzOpenInternal(const void *path,
-	zlib_filefunc64_32_def* pzlib_filefunc64_32_def,
-	int is64bitOpenFunction)
+local unzFile unzOpenInternal (const void *path,
+                               zlib_filefunc64_32_def* pzlib_filefunc64_32_def,
+                               int is64bitOpenFunction)
 {
-	unz64_s us;
-	unz64_s *s;
-	ZPOS64_T central_pos;
-	uLong   uL;
+    unz64_s us;
+    unz64_s *s;
+    ZPOS64_T central_pos;
+    uLong   uL;
 
-	uLong number_disk;          /* number of the current dist, used for
-											 spaning ZIP, unsupported, always 0*/
-	uLong number_disk_with_CD;  /* number the the disk with central dir, used
-											 for spaning ZIP, unsupported, always 0*/
-	ZPOS64_T number_entry_CD;      /* total number of entries in
-											 the central dir
-											 (same than number_entry on nospan) */
+    uLong number_disk;          /* number of the current dist, used for
+                                   spaning ZIP, unsupported, always 0*/
+    uLong number_disk_with_CD;  /* number the the disk with central dir, used
+                                   for spaning ZIP, unsupported, always 0*/
+    ZPOS64_T number_entry_CD;      /* total number of entries in
+                                   the central dir
+                                   (same than number_entry on nospan) */
 
-	int err = UNZ_OK;
+    int err=UNZ_OK;
 
-	if (unz_copyright[0] != ' ')
-		return NULL;
+    if (unz_copyright[0]!=' ')
+        return NULL;
 
-	us.z_filefunc.zseek32_file = NULL;
-	us.z_filefunc.ztell32_file = NULL;
-	if (pzlib_filefunc64_32_def == NULL)
-		fill_fopen64_filefunc(&us.z_filefunc.zfile_func64);
-	else
-		us.z_filefunc = *pzlib_filefunc64_32_def;
-	us.is64bitOpenFunction = is64bitOpenFunction;
-
-
-
-	us.filestream = ZOPEN64(us.z_filefunc,
-		path,
-		ZLIB_FILEFUNC_MODE_READ |
-		ZLIB_FILEFUNC_MODE_EXISTING);
-	if (us.filestream == NULL)
-		return NULL;
-
-	central_pos = unz64local_SearchCentralDir64(&us.z_filefunc, us.filestream);
-	if (central_pos) {
-		uLong uS;
-		ZPOS64_T uL64;
-
-		us.isZip64 = 1;
-
-		if (ZSEEK64(us.z_filefunc, us.filestream,
-			central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			err = UNZ_ERRNO;
-
-		/* the signature, already checked */
-		if (unz64local_getLong(&us.z_filefunc, us.filestream, &uL) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* size of zip64 end of central directory record */
-		if (unz64local_getLong64(&us.z_filefunc, us.filestream, &uL64) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* version made by */
-		if (unz64local_getShort(&us.z_filefunc, us.filestream, &uS) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* version needed to extract */
-		if (unz64local_getShort(&us.z_filefunc, us.filestream, &uS) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* number of this disk */
-		if (unz64local_getLong(&us.z_filefunc, us.filestream, &number_disk) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* number of the disk with the start of the central directory */
-		if (unz64local_getLong(&us.z_filefunc, us.filestream, &number_disk_with_CD) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* total number of entries in the central directory on this disk */
-		if (unz64local_getLong64(&us.z_filefunc, us.filestream, &us.gi.number_entry) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* total number of entries in the central directory */
-		if (unz64local_getLong64(&us.z_filefunc, us.filestream, &number_entry_CD) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		if ((number_entry_CD != us.gi.number_entry) ||
-			(number_disk_with_CD != 0) ||
-			(number_disk != 0))
-			err = UNZ_BADZIPFILE;
-
-		/* size of the central directory */
-		if (unz64local_getLong64(&us.z_filefunc, us.filestream, &us.size_central_dir) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* offset of start of central directory with respect to the
-		  starting disk number */
-		if (unz64local_getLong64(&us.z_filefunc, us.filestream, &us.offset_central_dir) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		us.gi.size_comment = 0;
-	}
-	else {
-		central_pos = unz64local_SearchCentralDir(&us.z_filefunc, us.filestream);
-		if (central_pos == 0)
-			err = UNZ_ERRNO;
-
-		us.isZip64 = 0;
-
-		if (ZSEEK64(us.z_filefunc, us.filestream,
-			central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			err = UNZ_ERRNO;
-
-		/* the signature, already checked */
-		if (unz64local_getLong(&us.z_filefunc, us.filestream, &uL) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* number of this disk */
-		if (unz64local_getShort(&us.z_filefunc, us.filestream, &number_disk) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* number of the disk with the start of the central directory */
-		if (unz64local_getShort(&us.z_filefunc, us.filestream, &number_disk_with_CD) != UNZ_OK)
-			err = UNZ_ERRNO;
-
-		/* total number of entries in the central dir on this disk */
-		if (unz64local_getShort(&us.z_filefunc, us.filestream, &uL) != UNZ_OK)
-			err = UNZ_ERRNO;
-		us.gi.number_entry = uL;
-
-		/* total number of entries in the central dir */
-		if (unz64local_getShort(&us.z_filefunc, us.filestream, &uL) != UNZ_OK)
-			err = UNZ_ERRNO;
-		number_entry_CD = uL;
-
-		if ((number_entry_CD != us.gi.number_entry) ||
-			(number_disk_with_CD != 0) ||
-			(number_disk != 0))
-			err = UNZ_BADZIPFILE;
-
-		/* size of the central directory */
-		if (unz64local_getLong(&us.z_filefunc, us.filestream, &uL) != UNZ_OK)
-			err = UNZ_ERRNO;
-		us.size_central_dir = uL;
-
-		/* offset of start of central directory with respect to the
-			 starting disk number */
-		if (unz64local_getLong(&us.z_filefunc, us.filestream, &uL) != UNZ_OK)
-			err = UNZ_ERRNO;
-		us.offset_central_dir = uL;
-
-		/* zipfile comment length */
-		if (unz64local_getShort(&us.z_filefunc, us.filestream, &us.gi.size_comment) != UNZ_OK)
-			err = UNZ_ERRNO;
-	}
-
-	if ((central_pos < us.offset_central_dir + us.size_central_dir) &&
-		(err == UNZ_OK))
-		err = UNZ_BADZIPFILE;
-
-	if (err != UNZ_OK) {
-		ZCLOSE64(us.z_filefunc, us.filestream);
-		return NULL;
-	}
-
-	us.byte_before_the_zipfile = central_pos -
-		(us.offset_central_dir + us.size_central_dir);
-	us.central_pos = central_pos;
-	us.pfile_in_zip_read = NULL;
-	us.encrypted = 0;
+    us.z_filefunc.zseek32_file = NULL;
+    us.z_filefunc.ztell32_file = NULL;
+    if (pzlib_filefunc64_32_def==NULL)
+        fill_fopen64_filefunc(&us.z_filefunc.zfile_func64);
+    else
+        us.z_filefunc = *pzlib_filefunc64_32_def;
+    us.is64bitOpenFunction = is64bitOpenFunction;
 
 
-	s = (unz64_s*)ALLOC(sizeof(unz64_s));
-	if (s != NULL) {
-		*s = us;
-		unzGoToFirstFile((unzFile)s);
-	}
-	return (unzFile)s;
+
+    us.filestream = ZOPEN64(us.z_filefunc,
+                                                 path,
+                                                 ZLIB_FILEFUNC_MODE_READ |
+                                                 ZLIB_FILEFUNC_MODE_EXISTING);
+    if (us.filestream==NULL)
+        return NULL;
+
+    central_pos = unz64local_SearchCentralDir64(&us.z_filefunc,us.filestream);
+    if (central_pos)
+    {
+        uLong uS;
+        ZPOS64_T uL64;
+
+        us.isZip64 = 1;
+
+        if (ZSEEK64(us.z_filefunc, us.filestream,
+                                      central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        err=UNZ_ERRNO;
+
+        /* the signature, already checked */
+        if (unz64local_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* size of zip64 end of central directory record */
+        if (unz64local_getLong64(&us.z_filefunc, us.filestream,&uL64)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* version made by */
+        if (unz64local_getShort(&us.z_filefunc, us.filestream,&uS)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* version needed to extract */
+        if (unz64local_getShort(&us.z_filefunc, us.filestream,&uS)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* number of this disk */
+        if (unz64local_getLong(&us.z_filefunc, us.filestream,&number_disk)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* number of the disk with the start of the central directory */
+        if (unz64local_getLong(&us.z_filefunc, us.filestream,&number_disk_with_CD)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* total number of entries in the central directory on this disk */
+        if (unz64local_getLong64(&us.z_filefunc, us.filestream,&us.gi.number_entry)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* total number of entries in the central directory */
+        if (unz64local_getLong64(&us.z_filefunc, us.filestream,&number_entry_CD)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        if ((number_entry_CD!=us.gi.number_entry) ||
+            (number_disk_with_CD!=0) ||
+            (number_disk!=0))
+            err=UNZ_BADZIPFILE;
+
+        /* size of the central directory */
+        if (unz64local_getLong64(&us.z_filefunc, us.filestream,&us.size_central_dir)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* offset of start of central directory with respect to the
+          starting disk number */
+        if (unz64local_getLong64(&us.z_filefunc, us.filestream,&us.offset_central_dir)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        us.gi.size_comment = 0;
+    }
+    else
+    {
+        central_pos = unz64local_SearchCentralDir(&us.z_filefunc,us.filestream);
+        if (central_pos==0)
+            err=UNZ_ERRNO;
+
+        us.isZip64 = 0;
+
+        if (ZSEEK64(us.z_filefunc, us.filestream,
+                                        central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            err=UNZ_ERRNO;
+
+        /* the signature, already checked */
+        if (unz64local_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* number of this disk */
+        if (unz64local_getShort(&us.z_filefunc, us.filestream,&number_disk)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* number of the disk with the start of the central directory */
+        if (unz64local_getShort(&us.z_filefunc, us.filestream,&number_disk_with_CD)!=UNZ_OK)
+            err=UNZ_ERRNO;
+
+        /* total number of entries in the central dir on this disk */
+        if (unz64local_getShort(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+            err=UNZ_ERRNO;
+        us.gi.number_entry = uL;
+
+        /* total number of entries in the central dir */
+        if (unz64local_getShort(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+            err=UNZ_ERRNO;
+        number_entry_CD = uL;
+
+        if ((number_entry_CD!=us.gi.number_entry) ||
+            (number_disk_with_CD!=0) ||
+            (number_disk!=0))
+            err=UNZ_BADZIPFILE;
+
+        /* size of the central directory */
+        if (unz64local_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+            err=UNZ_ERRNO;
+        us.size_central_dir = uL;
+
+        /* offset of start of central directory with respect to the
+            starting disk number */
+        if (unz64local_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
+            err=UNZ_ERRNO;
+        us.offset_central_dir = uL;
+
+        /* zipfile comment length */
+        if (unz64local_getShort(&us.z_filefunc, us.filestream,&us.gi.size_comment)!=UNZ_OK)
+            err=UNZ_ERRNO;
+    }
+
+    if ((central_pos<us.offset_central_dir+us.size_central_dir) &&
+        (err==UNZ_OK))
+        err=UNZ_BADZIPFILE;
+
+    if (err!=UNZ_OK)
+    {
+        ZCLOSE64(us.z_filefunc, us.filestream);
+        return NULL;
+    }
+
+    us.byte_before_the_zipfile = central_pos -
+                            (us.offset_central_dir+us.size_central_dir);
+    us.central_pos = central_pos;
+    us.pfile_in_zip_read = NULL;
+    us.encrypted = 0;
+
+
+    s=(unz64_s*)ALLOC(sizeof(unz64_s));
+    if( s != NULL)
+    {
+        *s=us;
+        unzGoToFirstFile((unzFile)s);
+    }
+    return (unzFile)s;
 }
 
 
-extern unzFile ZEXPORT unzOpen2(const char *path,
-	zlib_filefunc_def* pzlib_filefunc32_def)
+extern unzFile ZEXPORT unzOpen2 (const char *path,
+                                        zlib_filefunc_def* pzlib_filefunc32_def)
 {
-	if (pzlib_filefunc32_def != NULL) {
-		zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
-		fill_zlib_filefunc64_32_def_from_filefunc32(&zlib_filefunc64_32_def_fill, pzlib_filefunc32_def);
-		return unzOpenInternal(path, &zlib_filefunc64_32_def_fill, 0);
-	}
-	else
-		return unzOpenInternal(path, NULL, 0);
+    if (pzlib_filefunc32_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        fill_zlib_filefunc64_32_def_from_filefunc32(&zlib_filefunc64_32_def_fill,pzlib_filefunc32_def);
+        return unzOpenInternal(path, &zlib_filefunc64_32_def_fill, 0);
+    }
+    else
+        return unzOpenInternal(path, NULL, 0);
 }
 
-extern unzFile ZEXPORT unzOpen2_64(const void *path,
-	zlib_filefunc64_def* pzlib_filefunc_def)
+extern unzFile ZEXPORT unzOpen2_64 (const void *path,
+                                     zlib_filefunc64_def* pzlib_filefunc_def)
 {
-	if (pzlib_filefunc_def != NULL) {
-		zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
-		zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
-		zlib_filefunc64_32_def_fill.ztell32_file = NULL;
-		zlib_filefunc64_32_def_fill.zseek32_file = NULL;
-		return unzOpenInternal(path, &zlib_filefunc64_32_def_fill, 1);
-	}
-	else
-		return unzOpenInternal(path, NULL, 1);
+    if (pzlib_filefunc_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
+        zlib_filefunc64_32_def_fill.ztell32_file = NULL;
+        zlib_filefunc64_32_def_fill.zseek32_file = NULL;
+        return unzOpenInternal(path, &zlib_filefunc64_32_def_fill, 1);
+    }
+    else
+        return unzOpenInternal(path, NULL, 1);
 }
 
-extern unzFile ZEXPORT unzOpen(const char *path)
+extern unzFile ZEXPORT unzOpen (const char *path)
 {
-	return unzOpenInternal(path, NULL, 0);
+    return unzOpenInternal(path, NULL, 0);
 }
 
-extern unzFile ZEXPORT unzOpen64(const void *path)
+extern unzFile ZEXPORT unzOpen64 (const void *path)
 {
-	return unzOpenInternal(path, NULL, 1);
+    return unzOpenInternal(path, NULL, 1);
 }
 
 /*
   Close a ZipFile opened with unzOpen.
   If there is files inside the .Zip opened with unzOpenCurrentFile (see later),
-	 these files MUST be closed with unzCloseCurrentFile before call unzClose.
+    these files MUST be closed with unzCloseCurrentFile before call unzClose.
   return UNZ_OK if there is no problem. */
-extern int ZEXPORT unzClose(unzFile file)
+extern int ZEXPORT unzClose (unzFile file)
 {
-	unz64_s* s;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
+    unz64_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
 
-	if (s->pfile_in_zip_read != NULL)
-		unzCloseCurrentFile(file);
+    if (s->pfile_in_zip_read!=NULL)
+        unzCloseCurrentFile(file);
 
-	ZCLOSE64(s->z_filefunc, s->filestream);
-	TRYFREE(s);
-	return UNZ_OK;
+    ZCLOSE64(s->z_filefunc, s->filestream);
+    TRYFREE(s);
+    return UNZ_OK;
 }
 
 
@@ -811,276 +825,293 @@ extern int ZEXPORT unzClose(unzFile file)
   Write info about the ZipFile in the *pglobal_info structure.
   No preparation of the structure is needed
   return UNZ_OK if there is no problem. */
-extern int ZEXPORT unzGetGlobalInfo64(unzFile file, unz_global_info64* pglobal_info)
+extern int ZEXPORT unzGetGlobalInfo64 (unzFile file, unz_global_info64* pglobal_info)
 {
-	unz64_s* s;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	*pglobal_info = s->gi;
-	return UNZ_OK;
+    unz64_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    *pglobal_info=s->gi;
+    return UNZ_OK;
 }
 
-extern int ZEXPORT unzGetGlobalInfo(unzFile file, unz_global_info* pglobal_info32)
+extern int ZEXPORT unzGetGlobalInfo (unzFile file, unz_global_info* pglobal_info32)
 {
-	unz64_s* s;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	/* to do : check if number_entry is not truncated */
-	pglobal_info32->number_entry = (uLong)s->gi.number_entry;
-	pglobal_info32->size_comment = s->gi.size_comment;
-	return UNZ_OK;
+    unz64_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    /* to do : check if number_entry is not truncated */
+    pglobal_info32->number_entry = (uLong)s->gi.number_entry;
+    pglobal_info32->size_comment = s->gi.size_comment;
+    return UNZ_OK;
 }
 /*
-	Translate date/time from Dos format to tm_unz (readable more easilty)
+   Translate date/time from Dos format to tm_unz (readable more easilty)
 */
-local void unz64local_DosDateToTmuDate(ZPOS64_T ulDosDate, tm_unz* ptm)
+local void unz64local_DosDateToTmuDate (ZPOS64_T ulDosDate, tm_unz* ptm)
 {
-	ZPOS64_T uDate;
-	uDate = (ZPOS64_T)(ulDosDate >> 16);
-	ptm->tm_mday = (uInt)(uDate & 0x1f);
-	ptm->tm_mon = (uInt)((((uDate)& 0x1E0) / 0x20) - 1);
-	ptm->tm_year = (uInt)(((uDate & 0x0FE00) / 0x0200) + 1980);
+    ZPOS64_T uDate;
+    uDate = (ZPOS64_T)(ulDosDate>>16);
+    ptm->tm_mday = (uInt)(uDate&0x1f) ;
+    ptm->tm_mon =  (uInt)((((uDate)&0x1E0)/0x20)-1) ;
+    ptm->tm_year = (uInt)(((uDate&0x0FE00)/0x0200)+1980) ;
 
-	ptm->tm_hour = (uInt)((ulDosDate & 0xF800) / 0x800);
-	ptm->tm_min = (uInt)((ulDosDate & 0x7E0) / 0x20);
-	ptm->tm_sec = (uInt)(2 * (ulDosDate & 0x1f));
+    ptm->tm_hour = (uInt) ((ulDosDate &0xF800)/0x800);
+    ptm->tm_min =  (uInt) ((ulDosDate&0x7E0)/0x20) ;
+    ptm->tm_sec =  (uInt) (2*(ulDosDate&0x1f)) ;
 }
 
 /*
   Get Info about the current file in the zipfile, with internal only info
 */
 local int unz64local_GetCurrentFileInfoInternal OF((unzFile file,
-	unz_file_info64 *pfile_info,
-	unz_file_info64_internal
-	*pfile_info_internal,
-	char *szFileName,
-	uLong fileNameBufferSize,
-	void *extraField,
-	uLong extraFieldBufferSize,
-	char *szComment,
-	uLong commentBufferSize));
+                                                  unz_file_info64 *pfile_info,
+                                                  unz_file_info64_internal
+                                                  *pfile_info_internal,
+                                                  char *szFileName,
+                                                  uLong fileNameBufferSize,
+                                                  void *extraField,
+                                                  uLong extraFieldBufferSize,
+                                                  char *szComment,
+                                                  uLong commentBufferSize));
 
-local int unz64local_GetCurrentFileInfoInternal(unzFile file,
-	unz_file_info64 *pfile_info,
-	unz_file_info64_internal
-	*pfile_info_internal,
-	char *szFileName,
-	uLong fileNameBufferSize,
-	void *extraField,
-	uLong extraFieldBufferSize,
-	char *szComment,
-	uLong commentBufferSize)
+local int unz64local_GetCurrentFileInfoInternal (unzFile file,
+                                                  unz_file_info64 *pfile_info,
+                                                  unz_file_info64_internal
+                                                  *pfile_info_internal,
+                                                  char *szFileName,
+                                                  uLong fileNameBufferSize,
+                                                  void *extraField,
+                                                  uLong extraFieldBufferSize,
+                                                  char *szComment,
+                                                  uLong commentBufferSize)
 {
-	unz64_s* s;
-	unz_file_info64 file_info;
-	unz_file_info64_internal file_info_internal;
-	int err = UNZ_OK;
-	uLong uMagic;
-	long lSeek = 0;
-	uLong uL;
+    unz64_s* s;
+    unz_file_info64 file_info;
+    unz_file_info64_internal file_info_internal;
+    int err=UNZ_OK;
+    uLong uMagic;
+    long lSeek=0;
+    uLong uL;
 
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	if (ZSEEK64(s->z_filefunc, s->filestream,
-		s->pos_in_central_dir + s->byte_before_the_zipfile,
-		ZLIB_FILEFUNC_SEEK_SET) != 0)
-		err = UNZ_ERRNO;
-
-
-	/* we check the magic */
-	if (err == UNZ_OK) {
-		if (unz64local_getLong(&s->z_filefunc, s->filestream, &uMagic) != UNZ_OK)
-			err = UNZ_ERRNO;
-		else if (uMagic != 0x02014b50)
-			err = UNZ_BADZIPFILE;
-	}
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.version) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.version_needed) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.flag) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.compression_method) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &file_info.dosDate) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	unz64local_DosDateToTmuDate(file_info.dosDate, &file_info.tmu_date);
-
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &file_info.crc) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &uL) != UNZ_OK)
-		err = UNZ_ERRNO;
-	file_info.compressed_size = uL;
-
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &uL) != UNZ_OK)
-		err = UNZ_ERRNO;
-	file_info.uncompressed_size = uL;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.size_filename) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.size_file_extra) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.size_file_comment) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.disk_num_start) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &file_info.internal_fa) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &file_info.external_fa) != UNZ_OK)
-		err = UNZ_ERRNO;
-
-	// relative offset of local header
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &uL) != UNZ_OK)
-		err = UNZ_ERRNO;
-	file_info_internal.offset_curfile = uL;
-
-	lSeek += file_info.size_filename;
-	if ((err == UNZ_OK) && (szFileName != NULL)) {
-		uLong uSizeRead;
-		if (file_info.size_filename < fileNameBufferSize) {
-			*(szFileName + file_info.size_filename) = '\0';
-			uSizeRead = file_info.size_filename;
-		}
-		else
-			uSizeRead = fileNameBufferSize;
-
-		if ((file_info.size_filename>0) && (fileNameBufferSize > 0))
-			if (ZREAD64(s->z_filefunc, s->filestream, szFileName, uSizeRead) != uSizeRead)
-				err = UNZ_ERRNO;
-		lSeek -= uSizeRead;
-	}
-
-	// Read extrafield
-	if ((err == UNZ_OK) && (extraField != NULL)) {
-		ZPOS64_T uSizeRead;
-		if (file_info.size_file_extra < extraFieldBufferSize)
-			uSizeRead = file_info.size_file_extra;
-		else
-			uSizeRead = extraFieldBufferSize;
-
-		if (lSeek != 0) {
-			if (ZSEEK64(s->z_filefunc, s->filestream, lSeek, ZLIB_FILEFUNC_SEEK_CUR) == 0)
-				lSeek = 0;
-			else
-				err = UNZ_ERRNO;
-		}
-
-		if ((file_info.size_file_extra>0) && (extraFieldBufferSize > 0))
-			if (ZREAD64(s->z_filefunc, s->filestream, extraField, (uLong)uSizeRead) != uSizeRead)
-				err = UNZ_ERRNO;
-
-		lSeek += file_info.size_file_extra - (uLong)uSizeRead;
-	}
-	else
-		lSeek += file_info.size_file_extra;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    if (ZSEEK64(s->z_filefunc, s->filestream,
+              s->pos_in_central_dir+s->byte_before_the_zipfile,
+              ZLIB_FILEFUNC_SEEK_SET)!=0)
+        err=UNZ_ERRNO;
 
 
-	if ((err == UNZ_OK) && (file_info.size_file_extra != 0)) {
-		uLong acc = 0;
+    /* we check the magic */
+    if (err==UNZ_OK)
+    {
+        if (unz64local_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
+            err=UNZ_ERRNO;
+        else if (uMagic!=0x02014b50)
+            err=UNZ_BADZIPFILE;
+    }
 
-		// since lSeek now points to after the extra field we need to move back
-		lSeek -= file_info.size_file_extra;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.version) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-		if (lSeek != 0) {
-			if (ZSEEK64(s->z_filefunc, s->filestream, lSeek, ZLIB_FILEFUNC_SEEK_CUR) == 0)
-				lSeek = 0;
-			else
-				err = UNZ_ERRNO;
-		}
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.version_needed) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-		while (acc < file_info.size_file_extra) {
-			uLong headerId;
-			uLong dataSize;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.flag) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-			if (unz64local_getShort(&s->z_filefunc, s->filestream, &headerId) != UNZ_OK)
-				err = UNZ_ERRNO;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.compression_method) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-			if (unz64local_getShort(&s->z_filefunc, s->filestream, &dataSize) != UNZ_OK)
-				err = UNZ_ERRNO;
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&file_info.dosDate) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-			/* ZIP64 extra fields */
-			if (headerId == 0x0001) {
-				uLong uL2;
+    unz64local_DosDateToTmuDate(file_info.dosDate,&file_info.tmu_date);
 
-				if (file_info.uncompressed_size == MAXU32) {
-					if (unz64local_getLong64(&s->z_filefunc, s->filestream, &file_info.uncompressed_size) != UNZ_OK)
-						err = UNZ_ERRNO;
-				}
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&file_info.crc) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-				if (file_info.compressed_size == MAXU32) {
-					if (unz64local_getLong64(&s->z_filefunc, s->filestream, &file_info.compressed_size) != UNZ_OK)
-						err = UNZ_ERRNO;
-				}
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&uL) != UNZ_OK)
+        err=UNZ_ERRNO;
+    file_info.compressed_size = uL;
 
-				if (file_info_internal.offset_curfile == MAXU32) {
-					/* Relative Header offset */
-					if (unz64local_getLong64(&s->z_filefunc, s->filestream, &file_info_internal.offset_curfile) != UNZ_OK)
-						err = UNZ_ERRNO;
-				}
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&uL) != UNZ_OK)
+        err=UNZ_ERRNO;
+    file_info.uncompressed_size = uL;
 
-				if (file_info.disk_num_start == MAXU32) {
-					/* Disk Start Number */
-					if (unz64local_getLong(&s->z_filefunc, s->filestream, &uL2) != UNZ_OK)
-						err = UNZ_ERRNO;
-				}
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.size_filename) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-			}
-			else {
-				if (ZSEEK64(s->z_filefunc, s->filestream, dataSize, ZLIB_FILEFUNC_SEEK_CUR) != 0)
-					err = UNZ_ERRNO;
-			}
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_extra) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-			acc += 2 + 2 + dataSize;
-		}
-	}
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_comment) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-	if ((err == UNZ_OK) && (szComment != NULL)) {
-		uLong uSizeRead;
-		if (file_info.size_file_comment < commentBufferSize) {
-			*(szComment + file_info.size_file_comment) = '\0';
-			uSizeRead = file_info.size_file_comment;
-		}
-		else
-			uSizeRead = commentBufferSize;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.disk_num_start) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-		if (lSeek != 0) {
-			if (ZSEEK64(s->z_filefunc, s->filestream, lSeek, ZLIB_FILEFUNC_SEEK_CUR) == 0)
-				lSeek = 0;
-			else
-				err = UNZ_ERRNO;
-		}
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&file_info.internal_fa) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-		if ((file_info.size_file_comment>0) && (commentBufferSize > 0))
-			if (ZREAD64(s->z_filefunc, s->filestream, szComment, uSizeRead) != uSizeRead)
-				err = UNZ_ERRNO;
-		lSeek += file_info.size_file_comment - uSizeRead;
-	}
-	else
-		lSeek += file_info.size_file_comment;
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&file_info.external_fa) != UNZ_OK)
+        err=UNZ_ERRNO;
+
+                // relative offset of local header
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&uL) != UNZ_OK)
+        err=UNZ_ERRNO;
+    file_info_internal.offset_curfile = uL;
+
+    lSeek+=file_info.size_filename;
+    if ((err==UNZ_OK) && (szFileName!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_filename<fileNameBufferSize)
+        {
+            *(szFileName+file_info.size_filename)='\0';
+            uSizeRead = file_info.size_filename;
+        }
+        else
+            uSizeRead = fileNameBufferSize;
+
+        if ((file_info.size_filename>0) && (fileNameBufferSize>0))
+            if (ZREAD64(s->z_filefunc, s->filestream,szFileName,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        lSeek -= uSizeRead;
+    }
+
+    // Read extrafield
+    if ((err==UNZ_OK) && (extraField!=NULL))
+    {
+        ZPOS64_T uSizeRead ;
+        if (file_info.size_file_extra<extraFieldBufferSize)
+            uSizeRead = file_info.size_file_extra;
+        else
+            uSizeRead = extraFieldBufferSize;
+
+        if (lSeek!=0)
+        {
+            if (ZSEEK64(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
+                lSeek=0;
+            else
+                err=UNZ_ERRNO;
+        }
+
+        if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
+            if (ZREAD64(s->z_filefunc, s->filestream,extraField,(uLong)uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+
+        lSeek += file_info.size_file_extra - (uLong)uSizeRead;
+    }
+    else
+        lSeek += file_info.size_file_extra;
 
 
-	if ((err == UNZ_OK) && (pfile_info != NULL))
-		*pfile_info = file_info;
+    if ((err==UNZ_OK) && (file_info.size_file_extra != 0))
+    {
+                                uLong acc = 0;
 
-	if ((err == UNZ_OK) && (pfile_info_internal != NULL))
-		*pfile_info_internal = file_info_internal;
+        // since lSeek now points to after the extra field we need to move back
+        lSeek -= file_info.size_file_extra;
 
-	return err;
+        if (lSeek!=0)
+        {
+            if (ZSEEK64(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
+                lSeek=0;
+            else
+                err=UNZ_ERRNO;
+        }
+
+        while(acc < file_info.size_file_extra)
+        {
+            uLong headerId;
+                                                uLong dataSize;
+
+            if (unz64local_getShort(&s->z_filefunc, s->filestream,&headerId) != UNZ_OK)
+                err=UNZ_ERRNO;
+
+            if (unz64local_getShort(&s->z_filefunc, s->filestream,&dataSize) != UNZ_OK)
+                err=UNZ_ERRNO;
+
+            /* ZIP64 extra fields */
+            if (headerId == 0x0001)
+            {
+                                                        uLong uL;
+
+                                                                if(file_info.uncompressed_size == MAXU32)
+                                                                {
+                                                                        if (unz64local_getLong64(&s->z_filefunc, s->filestream,&file_info.uncompressed_size) != UNZ_OK)
+                                                                                        err=UNZ_ERRNO;
+                                                                }
+
+                                                                if(file_info.compressed_size == MAXU32)
+                                                                {
+                                                                        if (unz64local_getLong64(&s->z_filefunc, s->filestream,&file_info.compressed_size) != UNZ_OK)
+                                                                                  err=UNZ_ERRNO;
+                                                                }
+
+                                                                if(file_info_internal.offset_curfile == MAXU32)
+                                                                {
+                                                                        /* Relative Header offset */
+                                                                        if (unz64local_getLong64(&s->z_filefunc, s->filestream,&file_info_internal.offset_curfile) != UNZ_OK)
+                                                                                err=UNZ_ERRNO;
+                                                                }
+
+                                                                if(file_info.disk_num_start == MAXU32)
+                                                                {
+                                                                        /* Disk Start Number */
+                                                                        if (unz64local_getLong(&s->z_filefunc, s->filestream,&uL) != UNZ_OK)
+                                                                                err=UNZ_ERRNO;
+                                                                }
+
+            }
+            else
+            {
+                if (ZSEEK64(s->z_filefunc, s->filestream,dataSize,ZLIB_FILEFUNC_SEEK_CUR)!=0)
+                    err=UNZ_ERRNO;
+            }
+
+            acc += 2 + 2 + dataSize;
+        }
+    }
+
+    if ((err==UNZ_OK) && (szComment!=NULL))
+    {
+        uLong uSizeRead ;
+        if (file_info.size_file_comment<commentBufferSize)
+        {
+            *(szComment+file_info.size_file_comment)='\0';
+            uSizeRead = file_info.size_file_comment;
+        }
+        else
+            uSizeRead = commentBufferSize;
+
+        if (lSeek!=0)
+        {
+            if (ZSEEK64(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
+                lSeek=0;
+            else
+                err=UNZ_ERRNO;
+        }
+
+        if ((file_info.size_file_comment>0) && (commentBufferSize>0))
+            if (ZREAD64(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
+                err=UNZ_ERRNO;
+        lSeek+=file_info.size_file_comment - uSizeRead;
+    }
+    else
+        lSeek+=file_info.size_file_comment;
+
+
+    if ((err==UNZ_OK) && (pfile_info!=NULL))
+        *pfile_info=file_info;
+
+    if ((err==UNZ_OK) && (pfile_info_internal!=NULL))
+        *pfile_info_internal=file_info_internal;
+
+    return err;
 }
 
 
@@ -1090,73 +1121,74 @@ local int unz64local_GetCurrentFileInfoInternal(unzFile file,
   No preparation of the structure is needed
   return UNZ_OK if there is no problem.
 */
-extern int ZEXPORT unzGetCurrentFileInfo64(unzFile file,
-	unz_file_info64 * pfile_info,
-	char * szFileName, uLong fileNameBufferSize,
-	void *extraField, uLong extraFieldBufferSize,
-	char* szComment, uLong commentBufferSize)
+extern int ZEXPORT unzGetCurrentFileInfo64 (unzFile file,
+                                          unz_file_info64 * pfile_info,
+                                          char * szFileName, uLong fileNameBufferSize,
+                                          void *extraField, uLong extraFieldBufferSize,
+                                          char* szComment,  uLong commentBufferSize)
 {
-	return unz64local_GetCurrentFileInfoInternal(file, pfile_info, NULL,
-		szFileName, fileNameBufferSize,
-		extraField, extraFieldBufferSize,
-		szComment, commentBufferSize);
+    return unz64local_GetCurrentFileInfoInternal(file,pfile_info,NULL,
+                                                szFileName,fileNameBufferSize,
+                                                extraField,extraFieldBufferSize,
+                                                szComment,commentBufferSize);
 }
 
-extern int ZEXPORT unzGetCurrentFileInfo(unzFile file,
-	unz_file_info * pfile_info,
-	char * szFileName, uLong fileNameBufferSize,
-	void *extraField, uLong extraFieldBufferSize,
-	char* szComment, uLong commentBufferSize)
+extern int ZEXPORT unzGetCurrentFileInfo (unzFile file,
+                                          unz_file_info * pfile_info,
+                                          char * szFileName, uLong fileNameBufferSize,
+                                          void *extraField, uLong extraFieldBufferSize,
+                                          char* szComment,  uLong commentBufferSize)
 {
-	int err;
-	unz_file_info64 file_info64;
-	err = unz64local_GetCurrentFileInfoInternal(file, &file_info64, NULL,
-		szFileName, fileNameBufferSize,
-		extraField, extraFieldBufferSize,
-		szComment, commentBufferSize);
-	if ((err == UNZ_OK) && (pfile_info != NULL)) {
-		pfile_info->version = file_info64.version;
-		pfile_info->version_needed = file_info64.version_needed;
-		pfile_info->flag = file_info64.flag;
-		pfile_info->compression_method = file_info64.compression_method;
-		pfile_info->dosDate = file_info64.dosDate;
-		pfile_info->crc = file_info64.crc;
+    int err;
+    unz_file_info64 file_info64;
+    err = unz64local_GetCurrentFileInfoInternal(file,&file_info64,NULL,
+                                                szFileName,fileNameBufferSize,
+                                                extraField,extraFieldBufferSize,
+                                                szComment,commentBufferSize);
+    if ((err==UNZ_OK) && (pfile_info != NULL))
+    {
+        pfile_info->version = file_info64.version;
+        pfile_info->version_needed = file_info64.version_needed;
+        pfile_info->flag = file_info64.flag;
+        pfile_info->compression_method = file_info64.compression_method;
+        pfile_info->dosDate = file_info64.dosDate;
+        pfile_info->crc = file_info64.crc;
 
-		pfile_info->size_filename = file_info64.size_filename;
-		pfile_info->size_file_extra = file_info64.size_file_extra;
-		pfile_info->size_file_comment = file_info64.size_file_comment;
+        pfile_info->size_filename = file_info64.size_filename;
+        pfile_info->size_file_extra = file_info64.size_file_extra;
+        pfile_info->size_file_comment = file_info64.size_file_comment;
 
-		pfile_info->disk_num_start = file_info64.disk_num_start;
-		pfile_info->internal_fa = file_info64.internal_fa;
-		pfile_info->external_fa = file_info64.external_fa;
+        pfile_info->disk_num_start = file_info64.disk_num_start;
+        pfile_info->internal_fa = file_info64.internal_fa;
+        pfile_info->external_fa = file_info64.external_fa;
 
-		pfile_info->tmu_date = file_info64.tmu_date,
+        pfile_info->tmu_date = file_info64.tmu_date,
 
 
-			pfile_info->compressed_size = (uLong)file_info64.compressed_size;
-		pfile_info->uncompressed_size = (uLong)file_info64.uncompressed_size;
+        pfile_info->compressed_size = (uLong)file_info64.compressed_size;
+        pfile_info->uncompressed_size = (uLong)file_info64.uncompressed_size;
 
-	}
-	return err;
+    }
+    return err;
 }
 /*
   Set the current file of the zipfile to the first file.
   return UNZ_OK if there is no problem
 */
-extern int ZEXPORT unzGoToFirstFile(unzFile file)
+extern int ZEXPORT unzGoToFirstFile (unzFile file)
 {
-	int err = UNZ_OK;
-	unz64_s* s;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	s->pos_in_central_dir = s->offset_central_dir;
-	s->num_file = 0;
-	err = unz64local_GetCurrentFileInfoInternal(file, &s->cur_file_info,
-		&s->cur_file_info_internal,
-		NULL, 0, NULL, 0, NULL, 0);
-	s->current_file_ok = (err == UNZ_OK);
-	return err;
+    int err=UNZ_OK;
+    unz64_s* s;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    s->pos_in_central_dir=s->offset_central_dir;
+    s->num_file=0;
+    err=unz64local_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                             &s->cur_file_info_internal,
+                                             NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
 }
 
 /*
@@ -1164,28 +1196,28 @@ extern int ZEXPORT unzGoToFirstFile(unzFile file)
   return UNZ_OK if there is no problem
   return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
 */
-extern int ZEXPORT unzGoToNextFile(unzFile  file)
+extern int ZEXPORT unzGoToNextFile (unzFile  file)
 {
-	unz64_s* s;
-	int err;
+    unz64_s* s;
+    int err;
 
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	if (!s->current_file_ok)
-		return UNZ_END_OF_LIST_OF_FILE;
-	if (s->gi.number_entry != 0xffff)    /* 2^16 files overflow hack */
-		if (s->num_file + 1 == s->gi.number_entry)
-			return UNZ_END_OF_LIST_OF_FILE;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+    if (s->gi.number_entry != 0xffff)    /* 2^16 files overflow hack */
+      if (s->num_file+1==s->gi.number_entry)
+        return UNZ_END_OF_LIST_OF_FILE;
 
-	s->pos_in_central_dir += SIZECENTRALDIRITEM + s->cur_file_info.size_filename +
-		s->cur_file_info.size_file_extra + s->cur_file_info.size_file_comment;
-	s->num_file++;
-	err = unz64local_GetCurrentFileInfoInternal(file, &s->cur_file_info,
-		&s->cur_file_info_internal,
-		NULL, 0, NULL, 0, NULL, 0);
-	s->current_file_ok = (err == UNZ_OK);
-	return err;
+    s->pos_in_central_dir += SIZECENTRALDIRITEM + s->cur_file_info.size_filename +
+            s->cur_file_info.size_file_extra + s->cur_file_info.size_file_comment ;
+    s->num_file++;
+    err = unz64local_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                               &s->cur_file_info_internal,
+                                               NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
 }
 
 
@@ -1197,59 +1229,61 @@ extern int ZEXPORT unzGoToNextFile(unzFile  file)
   UNZ_OK if the file is found. It becomes the current file.
   UNZ_END_OF_LIST_OF_FILE if the file is not found
 */
-extern int ZEXPORT unzLocateFile(unzFile file, const char *szFileName, int iCaseSensitivity)
+extern int ZEXPORT unzLocateFile (unzFile file, const char *szFileName, int iCaseSensitivity)
 {
-	unz64_s* s;
-	int err;
+    unz64_s* s;
+    int err;
 
-	/* We remember the 'current' position in the file so that we can jump
-	 * back there if we fail.
-	 */
-	unz_file_info64 cur_file_infoSaved;
-	unz_file_info64_internal cur_file_info_internalSaved;
-	ZPOS64_T num_fileSaved;
-	ZPOS64_T pos_in_central_dirSaved;
+    /* We remember the 'current' position in the file so that we can jump
+     * back there if we fail.
+     */
+    unz_file_info64 cur_file_infoSaved;
+    unz_file_info64_internal cur_file_info_internalSaved;
+    ZPOS64_T num_fileSaved;
+    ZPOS64_T pos_in_central_dirSaved;
 
 
-	if (file == NULL)
-		return UNZ_PARAMERROR;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
 
-	if (strlen(szFileName) >= UNZ_MAXFILENAMEINZIP)
-		return UNZ_PARAMERROR;
+    if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
+        return UNZ_PARAMERROR;
 
-	s = (unz64_s*)file;
-	if (!s->current_file_ok)
-		return UNZ_END_OF_LIST_OF_FILE;
+    s=(unz64_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
 
-	/* Save the current state */
-	num_fileSaved = s->num_file;
-	pos_in_central_dirSaved = s->pos_in_central_dir;
-	cur_file_infoSaved = s->cur_file_info;
-	cur_file_info_internalSaved = s->cur_file_info_internal;
+    /* Save the current state */
+    num_fileSaved = s->num_file;
+    pos_in_central_dirSaved = s->pos_in_central_dir;
+    cur_file_infoSaved = s->cur_file_info;
+    cur_file_info_internalSaved = s->cur_file_info_internal;
 
-	err = unzGoToFirstFile(file);
+    err = unzGoToFirstFile(file);
 
-	while (err == UNZ_OK) {
-		char szCurrentFileName[UNZ_MAXFILENAMEINZIP + 1];
-		err = unzGetCurrentFileInfo64(file, NULL,
-			szCurrentFileName, sizeof(szCurrentFileName) - 1,
-			NULL, 0, NULL, 0);
-		if (err == UNZ_OK) {
-			if (unzStringFileNameCompare(szCurrentFileName,
-				szFileName, iCaseSensitivity) == 0)
-				return UNZ_OK;
-			err = unzGoToNextFile(file);
-		}
-	}
+    while (err == UNZ_OK)
+    {
+        char szCurrentFileName[UNZ_MAXFILENAMEINZIP+1];
+        err = unzGetCurrentFileInfo64(file,NULL,
+                                    szCurrentFileName,sizeof(szCurrentFileName)-1,
+                                    NULL,0,NULL,0);
+        if (err == UNZ_OK)
+        {
+            if (unzStringFileNameCompare(szCurrentFileName,
+                                            szFileName,iCaseSensitivity)==0)
+                return UNZ_OK;
+            err = unzGoToNextFile(file);
+        }
+    }
 
-	/* We failed, so restore the state of the 'current file' to where we
-	 * were.
-	 */
-	s->num_file = num_fileSaved;
-	s->pos_in_central_dir = pos_in_central_dirSaved;
-	s->cur_file_info = cur_file_infoSaved;
-	s->cur_file_info_internal = cur_file_info_internalSaved;
-	return err;
+    /* We failed, so restore the state of the 'current file' to where we
+     * were.
+     */
+    s->num_file = num_fileSaved ;
+    s->pos_in_central_dir = pos_in_central_dirSaved ;
+    s->cur_file_info = cur_file_infoSaved;
+    s->cur_file_info_internal = cur_file_info_internalSaved;
+    return err;
 }
 
 
@@ -1266,73 +1300,74 @@ extern int ZEXPORT unzLocateFile(unzFile file, const char *szFileName, int iCase
 /*
 typedef struct unz_file_pos_s
 {
-	 ZPOS64_T pos_in_zip_directory;   // offset in file
-	 ZPOS64_T num_of_file;            // # of file
+    ZPOS64_T pos_in_zip_directory;   // offset in file
+    ZPOS64_T num_of_file;            // # of file
 } unz_file_pos;
 */
 
 extern int ZEXPORT unzGetFilePos64(unzFile file, unz64_file_pos*  file_pos)
 {
-	unz64_s* s;
+    unz64_s* s;
 
-	if (file == NULL || file_pos == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	if (!s->current_file_ok)
-		return UNZ_END_OF_LIST_OF_FILE;
+    if (file==NULL || file_pos==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
 
-	file_pos->pos_in_zip_directory = s->pos_in_central_dir;
-	file_pos->num_of_file = s->num_file;
+    file_pos->pos_in_zip_directory  = s->pos_in_central_dir;
+    file_pos->num_of_file           = s->num_file;
 
-	return UNZ_OK;
+    return UNZ_OK;
 }
 
 extern int ZEXPORT unzGetFilePos(
-	unzFile file,
-	unz_file_pos* file_pos)
+    unzFile file,
+    unz_file_pos* file_pos)
 {
-	unz64_file_pos file_pos64;
-	int err = unzGetFilePos64(file, &file_pos64);
-	if (err == UNZ_OK) {
-		file_pos->pos_in_zip_directory = (uLong)file_pos64.pos_in_zip_directory;
-		file_pos->num_of_file = (uLong)file_pos64.num_of_file;
-	}
-	return err;
+    unz64_file_pos file_pos64;
+    int err = unzGetFilePos64(file,&file_pos64);
+    if (err==UNZ_OK)
+    {
+        file_pos->pos_in_zip_directory = (uLong)file_pos64.pos_in_zip_directory;
+        file_pos->num_of_file = (uLong)file_pos64.num_of_file;
+    }
+    return err;
 }
 
 extern int ZEXPORT unzGoToFilePos64(unzFile file, const unz64_file_pos* file_pos)
 {
-	unz64_s* s;
-	int err;
+    unz64_s* s;
+    int err;
 
-	if (file == NULL || file_pos == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
+    if (file==NULL || file_pos==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
 
-	/* jump to the right spot */
-	s->pos_in_central_dir = file_pos->pos_in_zip_directory;
-	s->num_file = file_pos->num_of_file;
+    /* jump to the right spot */
+    s->pos_in_central_dir = file_pos->pos_in_zip_directory;
+    s->num_file           = file_pos->num_of_file;
 
-	/* set the current file */
-	err = unz64local_GetCurrentFileInfoInternal(file, &s->cur_file_info,
-		&s->cur_file_info_internal,
-		NULL, 0, NULL, 0, NULL, 0);
-	/* return results */
-	s->current_file_ok = (err == UNZ_OK);
-	return err;
+    /* set the current file */
+    err = unz64local_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                               &s->cur_file_info_internal,
+                                               NULL,0,NULL,0,NULL,0);
+    /* return results */
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
 }
 
 extern int ZEXPORT unzGoToFilePos(
-	unzFile file,
-	unz_file_pos* file_pos)
+    unzFile file,
+    unz_file_pos* file_pos)
 {
-	unz64_file_pos file_pos64;
-	if (file_pos == NULL)
-		return UNZ_PARAMERROR;
+    unz64_file_pos file_pos64;
+    if (file_pos == NULL)
+        return UNZ_PARAMERROR;
 
-	file_pos64.pos_in_zip_directory = file_pos->pos_in_zip_directory;
-	file_pos64.num_of_file = file_pos->num_of_file;
-	return unzGoToFilePos64(file, &file_pos64);
+    file_pos64.pos_in_zip_directory = file_pos->pos_in_zip_directory;
+    file_pos64.num_of_file = file_pos->num_of_file;
+    return unzGoToFilePos64(file,&file_pos64);
 }
 
 /*
@@ -1343,286 +1378,295 @@ extern int ZEXPORT unzGoToFilePos(
 /*
   Read the local header of the current zipfile
   Check the coherency of the local header and info in the end of central
-		  directory about this file
+        directory about this file
   store in *piSizeVar the size of extra info in local header
-		  (filename and size of extra field data)
+        (filename and size of extra field data)
 */
-local int unz64local_CheckCurrentFileCoherencyHeader(unz64_s* s, uInt* piSizeVar,
-	ZPOS64_T * poffset_local_extrafield,
-	uInt  * psize_local_extrafield)
+local int unz64local_CheckCurrentFileCoherencyHeader (unz64_s* s, uInt* piSizeVar,
+                                                    ZPOS64_T * poffset_local_extrafield,
+                                                    uInt  * psize_local_extrafield)
 {
-	uLong uMagic, uData, uFlags;
-	uLong size_filename;
-	uLong size_extra_field;
-	int err = UNZ_OK;
+    uLong uMagic,uData,uFlags;
+    uLong size_filename;
+    uLong size_extra_field;
+    int err=UNZ_OK;
 
-	*piSizeVar = 0;
-	*poffset_local_extrafield = 0;
-	*psize_local_extrafield = 0;
+    *piSizeVar = 0;
+    *poffset_local_extrafield = 0;
+    *psize_local_extrafield = 0;
 
-	if (ZSEEK64(s->z_filefunc, s->filestream, s->cur_file_info_internal.offset_curfile +
-		s->byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
-		return UNZ_ERRNO;
+    if (ZSEEK64(s->z_filefunc, s->filestream,s->cur_file_info_internal.offset_curfile +
+                                s->byte_before_the_zipfile,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
 
 
-	if (err == UNZ_OK) {
-		if (unz64local_getLong(&s->z_filefunc, s->filestream, &uMagic) != UNZ_OK)
-			err = UNZ_ERRNO;
-		else if (uMagic != 0x04034b50)
-			err = UNZ_BADZIPFILE;
-	}
+    if (err==UNZ_OK)
+    {
+        if (unz64local_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
+            err=UNZ_ERRNO;
+        else if (uMagic!=0x04034b50)
+            err=UNZ_BADZIPFILE;
+    }
 
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &uData) != UNZ_OK)
-		err = UNZ_ERRNO;
-	/*
-		 else if ((err==UNZ_OK) && (uData!=s->cur_file_info.wVersion))
-			  err=UNZ_BADZIPFILE;
-	*/
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &uFlags) != UNZ_OK)
-		err = UNZ_ERRNO;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
+        err=UNZ_ERRNO;
+/*
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.wVersion))
+        err=UNZ_BADZIPFILE;
+*/
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&uFlags) != UNZ_OK)
+        err=UNZ_ERRNO;
 
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &uData) != UNZ_OK)
-		err = UNZ_ERRNO;
-	else if ((err == UNZ_OK) && (uData != s->cur_file_info.compression_method))
-		err = UNZ_BADZIPFILE;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compression_method))
+        err=UNZ_BADZIPFILE;
 
-	if ((err == UNZ_OK) && (s->cur_file_info.compression_method != 0) &&
-		/* #ifdef HAVE_BZIP2 */
-		(s->cur_file_info.compression_method != Z_BZIP2ED) &&
-		/* #endif */
-		(s->cur_file_info.compression_method != Z_DEFLATED))
-		err = UNZ_BADZIPFILE;
+    if ((err==UNZ_OK) && (s->cur_file_info.compression_method!=0) &&
+/* #ifdef HAVE_BZIP2 */
+                         (s->cur_file_info.compression_method!=Z_BZIP2ED) &&
+/* #endif */
+                         (s->cur_file_info.compression_method!=Z_DEFLATED))
+        err=UNZ_BADZIPFILE;
 
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &uData) != UNZ_OK) /* date/time */
-		err = UNZ_ERRNO;
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* date/time */
+        err=UNZ_ERRNO;
 
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &uData) != UNZ_OK) /* crc */
-		err = UNZ_ERRNO;
-	else if ((err == UNZ_OK) && (uData != s->cur_file_info.crc) && ((uFlags & 8) == 0))
-		err = UNZ_BADZIPFILE;
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* crc */
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.crc) && ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
 
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &uData) != UNZ_OK) /* size compr */
-		err = UNZ_ERRNO;
-	else if (uData != 0xFFFFFFFF && (err == UNZ_OK) && (uData != s->cur_file_info.compressed_size) && ((uFlags & 8) == 0))
-		err = UNZ_BADZIPFILE;
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size compr */
+        err=UNZ_ERRNO;
+    else if (uData != 0xFFFFFFFF && (err==UNZ_OK) && (uData!=s->cur_file_info.compressed_size) && ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
 
-	if (unz64local_getLong(&s->z_filefunc, s->filestream, &uData) != UNZ_OK) /* size uncompr */
-		err = UNZ_ERRNO;
-	else if (uData != 0xFFFFFFFF && (err == UNZ_OK) && (uData != s->cur_file_info.uncompressed_size) && ((uFlags & 8) == 0))
-		err = UNZ_BADZIPFILE;
+    if (unz64local_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size uncompr */
+        err=UNZ_ERRNO;
+    else if (uData != 0xFFFFFFFF && (err==UNZ_OK) && (uData!=s->cur_file_info.uncompressed_size) && ((uFlags & 8)==0))
+        err=UNZ_BADZIPFILE;
 
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &size_filename) != UNZ_OK)
-		err = UNZ_ERRNO;
-	else if ((err == UNZ_OK) && (size_filename != s->cur_file_info.size_filename))
-		err = UNZ_BADZIPFILE;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&size_filename) != UNZ_OK)
+        err=UNZ_ERRNO;
+    else if ((err==UNZ_OK) && (size_filename!=s->cur_file_info.size_filename))
+        err=UNZ_BADZIPFILE;
 
-	*piSizeVar += (uInt)size_filename;
+    *piSizeVar += (uInt)size_filename;
 
-	if (unz64local_getShort(&s->z_filefunc, s->filestream, &size_extra_field) != UNZ_OK)
-		err = UNZ_ERRNO;
-	*poffset_local_extrafield = s->cur_file_info_internal.offset_curfile +
-		SIZEZIPLOCALHEADER + size_filename;
-	*psize_local_extrafield = (uInt)size_extra_field;
+    if (unz64local_getShort(&s->z_filefunc, s->filestream,&size_extra_field) != UNZ_OK)
+        err=UNZ_ERRNO;
+    *poffset_local_extrafield= s->cur_file_info_internal.offset_curfile +
+                                    SIZEZIPLOCALHEADER + size_filename;
+    *psize_local_extrafield = (uInt)size_extra_field;
 
-	*piSizeVar += (uInt)size_extra_field;
+    *piSizeVar += (uInt)size_extra_field;
 
-	return err;
+    return err;
 }
 
 /*
   Open for reading data the current file in the zipfile.
   If there is no error and the file is opened, the return value is UNZ_OK.
 */
-extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int* method,
-	int* level, int raw, const char* password)
+extern int ZEXPORT unzOpenCurrentFile3 (unzFile file, int* method,
+                                            int* level, int raw, const char* password)
 {
-	int err = UNZ_OK;
-	uInt iSizeVar;
-	unz64_s* s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	ZPOS64_T offset_local_extrafield;  /* offset of the local extra field */
-	uInt  size_local_extrafield;    /* size of the local extra field */
-	#ifndef NOUNCRYPT
-	char source[12];
-	#else
-	if (password != NULL)
-		return UNZ_PARAMERROR;
-	#endif
+    int err=UNZ_OK;
+    uInt iSizeVar;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    ZPOS64_T offset_local_extrafield;  /* offset of the local extra field */
+    uInt  size_local_extrafield;    /* size of the local extra field */
+#    ifndef NOUNCRYPT
+    char source[12];
+#    else
+    if (password != NULL)
+        return UNZ_PARAMERROR;
+#    endif
 
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	if (!s->current_file_ok)
-		return UNZ_PARAMERROR;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    if (!s->current_file_ok)
+        return UNZ_PARAMERROR;
 
-	if (s->pfile_in_zip_read != NULL)
-		unzCloseCurrentFile(file);
+    if (s->pfile_in_zip_read != NULL)
+        unzCloseCurrentFile(file);
 
-	if (unz64local_CheckCurrentFileCoherencyHeader(s, &iSizeVar, &offset_local_extrafield, &size_local_extrafield) != UNZ_OK)
-		return UNZ_BADZIPFILE;
+    if (unz64local_CheckCurrentFileCoherencyHeader(s,&iSizeVar, &offset_local_extrafield,&size_local_extrafield)!=UNZ_OK)
+        return UNZ_BADZIPFILE;
 
-	pfile_in_zip_read_info = (file_in_zip64_read_info_s*)ALLOC(sizeof(file_in_zip64_read_info_s));
-	if (pfile_in_zip_read_info == NULL)
-		return UNZ_INTERNALERROR;
+    pfile_in_zip_read_info = (file_in_zip64_read_info_s*)ALLOC(sizeof(file_in_zip64_read_info_s));
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_INTERNALERROR;
 
-	pfile_in_zip_read_info->read_buffer = (char*)ALLOC(UNZ_BUFSIZE);
-	pfile_in_zip_read_info->offset_local_extrafield = offset_local_extrafield;
-	pfile_in_zip_read_info->size_local_extrafield = size_local_extrafield;
-	pfile_in_zip_read_info->pos_local_extrafield = 0;
-	pfile_in_zip_read_info->raw = raw;
+    pfile_in_zip_read_info->read_buffer=(char*)ALLOC(UNZ_BUFSIZE);
+    pfile_in_zip_read_info->offset_local_extrafield = offset_local_extrafield;
+    pfile_in_zip_read_info->size_local_extrafield = size_local_extrafield;
+    pfile_in_zip_read_info->pos_local_extrafield=0;
+    pfile_in_zip_read_info->raw=raw;
 
-	if (pfile_in_zip_read_info->read_buffer == NULL) {
-		TRYFREE(pfile_in_zip_read_info);
-		return UNZ_INTERNALERROR;
-	}
+    if (pfile_in_zip_read_info->read_buffer==NULL)
+    {
+        TRYFREE(pfile_in_zip_read_info);
+        return UNZ_INTERNALERROR;
+    }
 
-	pfile_in_zip_read_info->stream_initialised = 0;
+    pfile_in_zip_read_info->stream_initialised=0;
 
-	if (method != NULL)
-		*method = (int)s->cur_file_info.compression_method;
+    if (method!=NULL)
+        *method = (int)s->cur_file_info.compression_method;
 
-	if (level != NULL) {
-		*level = 6;
-		switch (s->cur_file_info.flag & 0x06) {
-		case 6: *level = 1; break;
-		case 4: *level = 2; break;
-		case 2: *level = 9; break;
-		}
-	}
+    if (level!=NULL)
+    {
+        *level = 6;
+        switch (s->cur_file_info.flag & 0x06)
+        {
+          case 6 : *level = 1; break;
+          case 4 : *level = 2; break;
+          case 2 : *level = 9; break;
+        }
+    }
 
-	if ((s->cur_file_info.compression_method != 0) &&
-		/* #ifdef HAVE_BZIP2 */
-		(s->cur_file_info.compression_method != Z_BZIP2ED) &&
-		/* #endif */
-		(s->cur_file_info.compression_method != Z_DEFLATED))
+    if ((s->cur_file_info.compression_method!=0) &&
+/* #ifdef HAVE_BZIP2 */
+        (s->cur_file_info.compression_method!=Z_BZIP2ED) &&
+/* #endif */
+        (s->cur_file_info.compression_method!=Z_DEFLATED))
 
-		err = UNZ_BADZIPFILE;
+        err=UNZ_BADZIPFILE;
 
-	pfile_in_zip_read_info->crc32_wait = s->cur_file_info.crc;
-	pfile_in_zip_read_info->crc32 = 0;
-	pfile_in_zip_read_info->total_out_64 = 0;
-	pfile_in_zip_read_info->compression_method = s->cur_file_info.compression_method;
-	pfile_in_zip_read_info->filestream = s->filestream;
-	pfile_in_zip_read_info->z_filefunc = s->z_filefunc;
-	pfile_in_zip_read_info->byte_before_the_zipfile = s->byte_before_the_zipfile;
+    pfile_in_zip_read_info->crc32_wait=s->cur_file_info.crc;
+    pfile_in_zip_read_info->crc32=0;
+    pfile_in_zip_read_info->total_out_64=0;
+    pfile_in_zip_read_info->compression_method = s->cur_file_info.compression_method;
+    pfile_in_zip_read_info->filestream=s->filestream;
+    pfile_in_zip_read_info->z_filefunc=s->z_filefunc;
+    pfile_in_zip_read_info->byte_before_the_zipfile=s->byte_before_the_zipfile;
 
-	pfile_in_zip_read_info->stream.total_out = 0;
+    pfile_in_zip_read_info->stream.total_out = 0;
 
-	if ((s->cur_file_info.compression_method == Z_BZIP2ED) && (!raw)) {
-		#ifdef HAVE_BZIP2
-		pfile_in_zip_read_info->bstream.bzalloc = (void *(*) (void *, int, int))0;
-		pfile_in_zip_read_info->bstream.bzfree = (free_func)0;
-		pfile_in_zip_read_info->bstream.opaque = (voidpf)0;
-		pfile_in_zip_read_info->bstream.state = (voidpf)0;
+    if ((s->cur_file_info.compression_method==Z_BZIP2ED) && (!raw))
+    {
+#ifdef HAVE_BZIP2
+      pfile_in_zip_read_info->bstream.bzalloc = (void *(*) (void *, int, int))0;
+      pfile_in_zip_read_info->bstream.bzfree = (free_func)0;
+      pfile_in_zip_read_info->bstream.opaque = (voidpf)0;
+      pfile_in_zip_read_info->bstream.state = (voidpf)0;
 
-		pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
-		pfile_in_zip_read_info->stream.zfree = (free_func)0;
-		pfile_in_zip_read_info->stream.opaque = (voidpf)0;
-		pfile_in_zip_read_info->stream.next_in = (voidpf)0;
-		pfile_in_zip_read_info->stream.avail_in = 0;
+      pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
+      pfile_in_zip_read_info->stream.zfree = (free_func)0;
+      pfile_in_zip_read_info->stream.opaque = (voidpf)0;
+      pfile_in_zip_read_info->stream.next_in = (voidpf)0;
+      pfile_in_zip_read_info->stream.avail_in = 0;
 
-		err = BZ2_bzDecompressInit(&pfile_in_zip_read_info->bstream, 0, 0);
-		if (err == Z_OK)
-			pfile_in_zip_read_info->stream_initialised = Z_BZIP2ED;
-		else {
-			TRYFREE(pfile_in_zip_read_info);
-			return err;
-		}
-		#else
-		pfile_in_zip_read_info->raw = 1;
-		#endif
-	}
-	else if ((s->cur_file_info.compression_method == Z_DEFLATED) && (!raw)) {
-		pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
-		pfile_in_zip_read_info->stream.zfree = (free_func)0;
-		pfile_in_zip_read_info->stream.opaque = (voidpf)0;
-		pfile_in_zip_read_info->stream.next_in = 0;
-		pfile_in_zip_read_info->stream.avail_in = 0;
+      err=BZ2_bzDecompressInit(&pfile_in_zip_read_info->bstream, 0, 0);
+      if (err == Z_OK)
+        pfile_in_zip_read_info->stream_initialised=Z_BZIP2ED;
+      else
+      {
+        TRYFREE(pfile_in_zip_read_info);
+        return err;
+      }
+#else
+      pfile_in_zip_read_info->raw=1;
+#endif
+    }
+    else if ((s->cur_file_info.compression_method==Z_DEFLATED) && (!raw))
+    {
+      pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
+      pfile_in_zip_read_info->stream.zfree = (free_func)0;
+      pfile_in_zip_read_info->stream.opaque = (voidpf)0;
+      pfile_in_zip_read_info->stream.next_in = 0;
+      pfile_in_zip_read_info->stream.avail_in = 0;
 
-		err = inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
-		if (err == Z_OK)
-			pfile_in_zip_read_info->stream_initialised = Z_DEFLATED;
-		else {
-			TRYFREE(pfile_in_zip_read_info);
-			return err;
-		}
-		/* windowBits is passed < 0 to tell that there is no zlib header.
-		 * Note that in this case inflate *requires* an extra "dummy" byte
-		 * after the compressed stream in order to complete decompression and
-		 * return Z_STREAM_END.
-		 * In unzip, i don't wait absolutely Z_STREAM_END because I known the
-		 * size of both compressed and uncompressed data
-		 */
-	}
-	pfile_in_zip_read_info->rest_read_compressed =
-		s->cur_file_info.compressed_size;
-	pfile_in_zip_read_info->rest_read_uncompressed =
-		s->cur_file_info.uncompressed_size;
-
-
-	pfile_in_zip_read_info->pos_in_zipfile =
-		s->cur_file_info_internal.offset_curfile + SIZEZIPLOCALHEADER +
-		iSizeVar;
-
-	pfile_in_zip_read_info->stream.avail_in = (uInt)0;
-
-	s->pfile_in_zip_read = pfile_in_zip_read_info;
-	s->encrypted = 0;
-
-	#    ifndef NOUNCRYPT
-	if (password != NULL) {
-		int i;
-		s->pcrc_32_tab = get_crc_table();
-		init_keys(password, s->keys, s->pcrc_32_tab);
-		if (ZSEEK64(s->z_filefunc, s->filestream,
-			s->pfile_in_zip_read->pos_in_zipfile +
-			s->pfile_in_zip_read->byte_before_the_zipfile,
-			SEEK_SET) != 0)
-			return UNZ_INTERNALERROR;
-		if (ZREAD64(s->z_filefunc, s->filestream, source, 12) < 12)
-			return UNZ_INTERNALERROR;
-
-		for (i = 0; i < 12; i++)
-			zdecode(s->keys, s->pcrc_32_tab, source[i]);
-
-		s->pfile_in_zip_read->pos_in_zipfile += 12;
-		s->encrypted = 1;
-	}
-	#    endif
+      err=inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
+      if (err == Z_OK)
+        pfile_in_zip_read_info->stream_initialised=Z_DEFLATED;
+      else
+      {
+        TRYFREE(pfile_in_zip_read_info);
+        return err;
+      }
+        /* windowBits is passed < 0 to tell that there is no zlib header.
+         * Note that in this case inflate *requires* an extra "dummy" byte
+         * after the compressed stream in order to complete decompression and
+         * return Z_STREAM_END.
+         * In unzip, i don't wait absolutely Z_STREAM_END because I known the
+         * size of both compressed and uncompressed data
+         */
+    }
+    pfile_in_zip_read_info->rest_read_compressed =
+            s->cur_file_info.compressed_size ;
+    pfile_in_zip_read_info->rest_read_uncompressed =
+            s->cur_file_info.uncompressed_size ;
 
 
-	return UNZ_OK;
+    pfile_in_zip_read_info->pos_in_zipfile =
+            s->cur_file_info_internal.offset_curfile + SIZEZIPLOCALHEADER +
+              iSizeVar;
+
+    pfile_in_zip_read_info->stream.avail_in = (uInt)0;
+
+    s->pfile_in_zip_read = pfile_in_zip_read_info;
+                s->encrypted = 0;
+
+#    ifndef NOUNCRYPT
+    if (password != NULL)
+    {
+        int i;
+        s->pcrc_32_tab = get_crc_table();
+        init_keys(password,s->keys,s->pcrc_32_tab);
+        if (ZSEEK64(s->z_filefunc, s->filestream,
+                  s->pfile_in_zip_read->pos_in_zipfile +
+                     s->pfile_in_zip_read->byte_before_the_zipfile,
+                  SEEK_SET)!=0)
+            return UNZ_INTERNALERROR;
+        if(ZREAD64(s->z_filefunc, s->filestream,source, 12)<12)
+            return UNZ_INTERNALERROR;
+
+        for (i = 0; i<12; i++)
+            zdecode(s->keys,s->pcrc_32_tab,source[i]);
+
+        s->pfile_in_zip_read->pos_in_zipfile+=12;
+        s->encrypted=1;
+    }
+#    endif
+
+
+    return UNZ_OK;
 }
 
-extern int ZEXPORT unzOpenCurrentFile(unzFile file)
+extern int ZEXPORT unzOpenCurrentFile (unzFile file)
 {
-	return unzOpenCurrentFile3(file, NULL, NULL, 0, NULL);
+    return unzOpenCurrentFile3(file, NULL, NULL, 0, NULL);
 }
 
-extern int ZEXPORT unzOpenCurrentFilePassword(unzFile file, const char*  password)
+extern int ZEXPORT unzOpenCurrentFilePassword (unzFile file, const char*  password)
 {
-	return unzOpenCurrentFile3(file, NULL, NULL, 0, password);
+    return unzOpenCurrentFile3(file, NULL, NULL, 0, password);
 }
 
-extern int ZEXPORT unzOpenCurrentFile2(unzFile file, int* method, int* level, int raw)
+extern int ZEXPORT unzOpenCurrentFile2 (unzFile file, int* method, int* level, int raw)
 {
-	return unzOpenCurrentFile3(file, method, level, raw, NULL);
+    return unzOpenCurrentFile3(file, method, level, raw, NULL);
 }
 
 /** Addition for GDAL : START */
 
-extern ZPOS64_T ZEXPORT unzGetCurrentFileZStreamPos64(unzFile file)
+extern ZPOS64_T ZEXPORT unzGetCurrentFileZStreamPos64( unzFile file)
 {
-	unz64_s *s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	s = (unz64_s*)file;
-	if (file == NULL)
-		return 0; //UNZ_PARAMERROR;
-	pfile_in_zip_read_info = s->pfile_in_zip_read;
-	if (pfile_in_zip_read_info == NULL)
-		return 0; //UNZ_PARAMERROR;
-	return pfile_in_zip_read_info->pos_in_zipfile +
-		pfile_in_zip_read_info->byte_before_the_zipfile;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    s=(unz64_s*)file;
+    if (file==NULL)
+        return 0; //UNZ_PARAMERROR;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
+    if (pfile_in_zip_read_info==NULL)
+        return 0; //UNZ_PARAMERROR;
+    return pfile_in_zip_read_info->pos_in_zipfile +
+                         pfile_in_zip_read_info->byte_before_the_zipfile;
 }
 
 /** Addition for GDAL : END */
@@ -1635,257 +1679,267 @@ extern ZPOS64_T ZEXPORT unzGetCurrentFileZStreamPos64(unzFile file)
   return the number of byte copied if somes bytes are copied
   return 0 if the end of file was reached
   return <0 with error code if there is an error
-	 (UNZ_ERRNO for IO error, or zLib error for uncompress error)
+    (UNZ_ERRNO for IO error, or zLib error for uncompress error)
 */
-extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, unsigned len)
+extern int ZEXPORT unzReadCurrentFile  (unzFile file, voidp buf, unsigned len)
 {
-	int err = UNZ_OK;
-	uInt iRead = 0;
-	unz64_s* s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	pfile_in_zip_read_info = s->pfile_in_zip_read;
+    int err=UNZ_OK;
+    uInt iRead = 0;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info == NULL)
-		return UNZ_PARAMERROR;
-
-
-	if (pfile_in_zip_read_info->read_buffer == NULL)
-		return UNZ_END_OF_LIST_OF_FILE;
-	if (len == 0)
-		return 0;
-
-	pfile_in_zip_read_info->stream.next_out = (Bytef*)buf;
-
-	pfile_in_zip_read_info->stream.avail_out = (uInt)len;
-
-	if ((len > pfile_in_zip_read_info->rest_read_uncompressed) &&
-		(!(pfile_in_zip_read_info->raw)))
-		pfile_in_zip_read_info->stream.avail_out =
-		(uInt)pfile_in_zip_read_info->rest_read_uncompressed;
-
-	if ((len > pfile_in_zip_read_info->rest_read_compressed +
-		pfile_in_zip_read_info->stream.avail_in) &&
-		(pfile_in_zip_read_info->raw))
-		pfile_in_zip_read_info->stream.avail_out =
-		(uInt)pfile_in_zip_read_info->rest_read_compressed +
-		pfile_in_zip_read_info->stream.avail_in;
-
-	while (pfile_in_zip_read_info->stream.avail_out > 0) {
-		if ((pfile_in_zip_read_info->stream.avail_in == 0) &&
-			(pfile_in_zip_read_info->rest_read_compressed > 0)) {
-			uInt uReadThis = UNZ_BUFSIZE;
-			if (pfile_in_zip_read_info->rest_read_compressed < uReadThis)
-				uReadThis = (uInt)pfile_in_zip_read_info->rest_read_compressed;
-			if (uReadThis == 0)
-				return UNZ_EOF;
-			if (ZSEEK64(pfile_in_zip_read_info->z_filefunc,
-				pfile_in_zip_read_info->filestream,
-				pfile_in_zip_read_info->pos_in_zipfile +
-				pfile_in_zip_read_info->byte_before_the_zipfile,
-				ZLIB_FILEFUNC_SEEK_SET) != 0)
-				return UNZ_ERRNO;
-			if (ZREAD64(pfile_in_zip_read_info->z_filefunc,
-				pfile_in_zip_read_info->filestream,
-				pfile_in_zip_read_info->read_buffer,
-				uReadThis) != uReadThis)
-				return UNZ_ERRNO;
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
 
 
-			#            ifndef NOUNCRYPT
-			if (s->encrypted) {
-				uInt i;
-				for (i = 0; i < uReadThis; i++)
-					pfile_in_zip_read_info->read_buffer[i] =
-					zdecode(s->keys, s->pcrc_32_tab,
-						pfile_in_zip_read_info->read_buffer[i]);
-			}
-			#            endif
+    if (pfile_in_zip_read_info->read_buffer == NULL)
+        return UNZ_END_OF_LIST_OF_FILE;
+    if (len==0)
+        return 0;
+
+    pfile_in_zip_read_info->stream.next_out = (Bytef*)buf;
+
+    pfile_in_zip_read_info->stream.avail_out = (uInt)len;
+
+    if ((len>pfile_in_zip_read_info->rest_read_uncompressed) &&
+        (!(pfile_in_zip_read_info->raw)))
+        pfile_in_zip_read_info->stream.avail_out =
+            (uInt)pfile_in_zip_read_info->rest_read_uncompressed;
+
+    if ((len>pfile_in_zip_read_info->rest_read_compressed+
+           pfile_in_zip_read_info->stream.avail_in) &&
+         (pfile_in_zip_read_info->raw))
+        pfile_in_zip_read_info->stream.avail_out =
+            (uInt)pfile_in_zip_read_info->rest_read_compressed+
+            pfile_in_zip_read_info->stream.avail_in;
+
+    while (pfile_in_zip_read_info->stream.avail_out>0)
+    {
+        if ((pfile_in_zip_read_info->stream.avail_in==0) &&
+            (pfile_in_zip_read_info->rest_read_compressed>0))
+        {
+            uInt uReadThis = UNZ_BUFSIZE;
+            if (pfile_in_zip_read_info->rest_read_compressed<uReadThis)
+                uReadThis = (uInt)pfile_in_zip_read_info->rest_read_compressed;
+            if (uReadThis == 0)
+                return UNZ_EOF;
+            if (ZSEEK64(pfile_in_zip_read_info->z_filefunc,
+                      pfile_in_zip_read_info->filestream,
+                      pfile_in_zip_read_info->pos_in_zipfile +
+                         pfile_in_zip_read_info->byte_before_the_zipfile,
+                         ZLIB_FILEFUNC_SEEK_SET)!=0)
+                return UNZ_ERRNO;
+            if (ZREAD64(pfile_in_zip_read_info->z_filefunc,
+                      pfile_in_zip_read_info->filestream,
+                      pfile_in_zip_read_info->read_buffer,
+                      uReadThis)!=uReadThis)
+                return UNZ_ERRNO;
 
 
-			pfile_in_zip_read_info->pos_in_zipfile += uReadThis;
+#            ifndef NOUNCRYPT
+            if(s->encrypted)
+            {
+                uInt i;
+                for(i=0;i<uReadThis;i++)
+                  pfile_in_zip_read_info->read_buffer[i] =
+                      zdecode(s->keys,s->pcrc_32_tab,
+                              pfile_in_zip_read_info->read_buffer[i]);
+            }
+#            endif
 
-			pfile_in_zip_read_info->rest_read_compressed -= uReadThis;
 
-			pfile_in_zip_read_info->stream.next_in =
-				(Bytef*)pfile_in_zip_read_info->read_buffer;
-			pfile_in_zip_read_info->stream.avail_in = (uInt)uReadThis;
-		}
+            pfile_in_zip_read_info->pos_in_zipfile += uReadThis;
 
-		if ((pfile_in_zip_read_info->compression_method == 0) || (pfile_in_zip_read_info->raw)) {
-			uInt uDoCopy, i;
+            pfile_in_zip_read_info->rest_read_compressed-=uReadThis;
 
-			if ((pfile_in_zip_read_info->stream.avail_in == 0) &&
-				(pfile_in_zip_read_info->rest_read_compressed == 0))
-				return (iRead == 0) ? UNZ_EOF : iRead;
+            pfile_in_zip_read_info->stream.next_in =
+                (Bytef*)pfile_in_zip_read_info->read_buffer;
+            pfile_in_zip_read_info->stream.avail_in = (uInt)uReadThis;
+        }
 
-			if (pfile_in_zip_read_info->stream.avail_out <
-				pfile_in_zip_read_info->stream.avail_in)
-				uDoCopy = pfile_in_zip_read_info->stream.avail_out;
-			else
-				uDoCopy = pfile_in_zip_read_info->stream.avail_in;
+        if ((pfile_in_zip_read_info->compression_method==0) || (pfile_in_zip_read_info->raw))
+        {
+            uInt uDoCopy,i ;
 
-			for (i = 0; i < uDoCopy; i++)
-				*(pfile_in_zip_read_info->stream.next_out + i) =
-				*(pfile_in_zip_read_info->stream.next_in + i);
+            if ((pfile_in_zip_read_info->stream.avail_in == 0) &&
+                (pfile_in_zip_read_info->rest_read_compressed == 0))
+                return (iRead==0) ? UNZ_EOF : iRead;
 
-			pfile_in_zip_read_info->total_out_64 = pfile_in_zip_read_info->total_out_64 + uDoCopy;
+            if (pfile_in_zip_read_info->stream.avail_out <
+                            pfile_in_zip_read_info->stream.avail_in)
+                uDoCopy = pfile_in_zip_read_info->stream.avail_out ;
+            else
+                uDoCopy = pfile_in_zip_read_info->stream.avail_in ;
 
-			pfile_in_zip_read_info->crc32 = crc32(pfile_in_zip_read_info->crc32,
-				pfile_in_zip_read_info->stream.next_out,
-				uDoCopy);
-			pfile_in_zip_read_info->rest_read_uncompressed -= uDoCopy;
-			pfile_in_zip_read_info->stream.avail_in -= uDoCopy;
-			pfile_in_zip_read_info->stream.avail_out -= uDoCopy;
-			pfile_in_zip_read_info->stream.next_out += uDoCopy;
-			pfile_in_zip_read_info->stream.next_in += uDoCopy;
-			pfile_in_zip_read_info->stream.total_out += uDoCopy;
-			iRead += uDoCopy;
-		}
-		else if (pfile_in_zip_read_info->compression_method == Z_BZIP2ED) {
-			#ifdef HAVE_BZIP2
-			uLong uTotalOutBefore, uTotalOutAfter;
-			const Bytef *bufBefore;
-			uLong uOutThis;
+            for (i=0;i<uDoCopy;i++)
+                *(pfile_in_zip_read_info->stream.next_out+i) =
+                        *(pfile_in_zip_read_info->stream.next_in+i);
 
-			pfile_in_zip_read_info->bstream.next_in = (char*)pfile_in_zip_read_info->stream.next_in;
-			pfile_in_zip_read_info->bstream.avail_in = pfile_in_zip_read_info->stream.avail_in;
-			pfile_in_zip_read_info->bstream.total_in_lo32 = pfile_in_zip_read_info->stream.total_in;
-			pfile_in_zip_read_info->bstream.total_in_hi32 = 0;
-			pfile_in_zip_read_info->bstream.next_out = (char*)pfile_in_zip_read_info->stream.next_out;
-			pfile_in_zip_read_info->bstream.avail_out = pfile_in_zip_read_info->stream.avail_out;
-			pfile_in_zip_read_info->bstream.total_out_lo32 = pfile_in_zip_read_info->stream.total_out;
-			pfile_in_zip_read_info->bstream.total_out_hi32 = 0;
+            pfile_in_zip_read_info->total_out_64 = pfile_in_zip_read_info->total_out_64 + uDoCopy;
 
-			uTotalOutBefore = pfile_in_zip_read_info->bstream.total_out_lo32;
-			bufBefore = (const Bytef *)pfile_in_zip_read_info->bstream.next_out;
+            pfile_in_zip_read_info->crc32 = crc32(pfile_in_zip_read_info->crc32,
+                                pfile_in_zip_read_info->stream.next_out,
+                                uDoCopy);
+            pfile_in_zip_read_info->rest_read_uncompressed-=uDoCopy;
+            pfile_in_zip_read_info->stream.avail_in -= uDoCopy;
+            pfile_in_zip_read_info->stream.avail_out -= uDoCopy;
+            pfile_in_zip_read_info->stream.next_out += uDoCopy;
+            pfile_in_zip_read_info->stream.next_in += uDoCopy;
+            pfile_in_zip_read_info->stream.total_out += uDoCopy;
+            iRead += uDoCopy;
+        }
+        else if (pfile_in_zip_read_info->compression_method==Z_BZIP2ED)
+        {
+#ifdef HAVE_BZIP2
+            uLong uTotalOutBefore,uTotalOutAfter;
+            const Bytef *bufBefore;
+            uLong uOutThis;
 
-			err = BZ2_bzDecompress(&pfile_in_zip_read_info->bstream);
+            pfile_in_zip_read_info->bstream.next_in        = (char*)pfile_in_zip_read_info->stream.next_in;
+            pfile_in_zip_read_info->bstream.avail_in       = pfile_in_zip_read_info->stream.avail_in;
+            pfile_in_zip_read_info->bstream.total_in_lo32  = pfile_in_zip_read_info->stream.total_in;
+            pfile_in_zip_read_info->bstream.total_in_hi32  = 0;
+            pfile_in_zip_read_info->bstream.next_out       = (char*)pfile_in_zip_read_info->stream.next_out;
+            pfile_in_zip_read_info->bstream.avail_out      = pfile_in_zip_read_info->stream.avail_out;
+            pfile_in_zip_read_info->bstream.total_out_lo32 = pfile_in_zip_read_info->stream.total_out;
+            pfile_in_zip_read_info->bstream.total_out_hi32 = 0;
 
-			uTotalOutAfter = pfile_in_zip_read_info->bstream.total_out_lo32;
-			uOutThis = uTotalOutAfter - uTotalOutBefore;
+            uTotalOutBefore = pfile_in_zip_read_info->bstream.total_out_lo32;
+            bufBefore = (const Bytef *)pfile_in_zip_read_info->bstream.next_out;
 
-			pfile_in_zip_read_info->total_out_64 = pfile_in_zip_read_info->total_out_64 + uOutThis;
+            err=BZ2_bzDecompress(&pfile_in_zip_read_info->bstream);
 
-			pfile_in_zip_read_info->crc32 = crc32(pfile_in_zip_read_info->crc32, bufBefore, (uInt)(uOutThis));
-			pfile_in_zip_read_info->rest_read_uncompressed -= uOutThis;
-			iRead += (uInt)(uTotalOutAfter - uTotalOutBefore);
+            uTotalOutAfter = pfile_in_zip_read_info->bstream.total_out_lo32;
+            uOutThis = uTotalOutAfter-uTotalOutBefore;
 
-			pfile_in_zip_read_info->stream.next_in = (Bytef*)pfile_in_zip_read_info->bstream.next_in;
-			pfile_in_zip_read_info->stream.avail_in = pfile_in_zip_read_info->bstream.avail_in;
-			pfile_in_zip_read_info->stream.total_in = pfile_in_zip_read_info->bstream.total_in_lo32;
-			pfile_in_zip_read_info->stream.next_out = (Bytef*)pfile_in_zip_read_info->bstream.next_out;
-			pfile_in_zip_read_info->stream.avail_out = pfile_in_zip_read_info->bstream.avail_out;
-			pfile_in_zip_read_info->stream.total_out = pfile_in_zip_read_info->bstream.total_out_lo32;
+            pfile_in_zip_read_info->total_out_64 = pfile_in_zip_read_info->total_out_64 + uOutThis;
 
-			if (err == BZ_STREAM_END)
-				return (iRead == 0) ? UNZ_EOF : iRead;
-			if (err != BZ_OK)
-				break;
-			#endif
-		} // end Z_BZIP2ED
-		else {
-			ZPOS64_T uTotalOutBefore, uTotalOutAfter;
-			const Bytef *bufBefore;
-			ZPOS64_T uOutThis;
-			int flush = Z_SYNC_FLUSH;
+            pfile_in_zip_read_info->crc32 = crc32(pfile_in_zip_read_info->crc32,bufBefore, (uInt)(uOutThis));
+            pfile_in_zip_read_info->rest_read_uncompressed -= uOutThis;
+            iRead += (uInt)(uTotalOutAfter - uTotalOutBefore);
 
-			uTotalOutBefore = pfile_in_zip_read_info->stream.total_out;
-			bufBefore = pfile_in_zip_read_info->stream.next_out;
+            pfile_in_zip_read_info->stream.next_in   = (Bytef*)pfile_in_zip_read_info->bstream.next_in;
+            pfile_in_zip_read_info->stream.avail_in  = pfile_in_zip_read_info->bstream.avail_in;
+            pfile_in_zip_read_info->stream.total_in  = pfile_in_zip_read_info->bstream.total_in_lo32;
+            pfile_in_zip_read_info->stream.next_out  = (Bytef*)pfile_in_zip_read_info->bstream.next_out;
+            pfile_in_zip_read_info->stream.avail_out = pfile_in_zip_read_info->bstream.avail_out;
+            pfile_in_zip_read_info->stream.total_out = pfile_in_zip_read_info->bstream.total_out_lo32;
 
-			/*
-			if ((pfile_in_zip_read_info->rest_read_uncompressed ==
-						pfile_in_zip_read_info->stream.avail_out) &&
-				 (pfile_in_zip_read_info->rest_read_compressed == 0))
-				 flush = Z_FINISH;
-			*/
-			err = inflate(&pfile_in_zip_read_info->stream, flush);
+            if (err==BZ_STREAM_END)
+              return (iRead==0) ? UNZ_EOF : iRead;
+            if (err!=BZ_OK)
+              break;
+#endif
+        } // end Z_BZIP2ED
+        else
+        {
+            ZPOS64_T uTotalOutBefore,uTotalOutAfter;
+            const Bytef *bufBefore;
+            ZPOS64_T uOutThis;
+            int flush=Z_SYNC_FLUSH;
 
-			if ((err >= 0) && (pfile_in_zip_read_info->stream.msg != NULL))
-				err = Z_DATA_ERROR;
+            uTotalOutBefore = pfile_in_zip_read_info->stream.total_out;
+            bufBefore = pfile_in_zip_read_info->stream.next_out;
 
-			uTotalOutAfter = pfile_in_zip_read_info->stream.total_out;
-			uOutThis = uTotalOutAfter - uTotalOutBefore;
+            /*
+            if ((pfile_in_zip_read_info->rest_read_uncompressed ==
+                     pfile_in_zip_read_info->stream.avail_out) &&
+                (pfile_in_zip_read_info->rest_read_compressed == 0))
+                flush = Z_FINISH;
+            */
+            err=inflate(&pfile_in_zip_read_info->stream,flush);
 
-			pfile_in_zip_read_info->total_out_64 = pfile_in_zip_read_info->total_out_64 + uOutThis;
+            if ((err>=0) && (pfile_in_zip_read_info->stream.msg!=NULL))
+              err = Z_DATA_ERROR;
 
-			pfile_in_zip_read_info->crc32 =
-				crc32(pfile_in_zip_read_info->crc32, bufBefore,
-					(uInt)(uOutThis));
+            uTotalOutAfter = pfile_in_zip_read_info->stream.total_out;
+            uOutThis = uTotalOutAfter-uTotalOutBefore;
 
-			pfile_in_zip_read_info->rest_read_uncompressed -=
-				uOutThis;
+            pfile_in_zip_read_info->total_out_64 = pfile_in_zip_read_info->total_out_64 + uOutThis;
 
-			iRead += (uInt)(uTotalOutAfter - uTotalOutBefore);
+            pfile_in_zip_read_info->crc32 =
+                crc32(pfile_in_zip_read_info->crc32,bufBefore,
+                        (uInt)(uOutThis));
 
-			if (err == Z_STREAM_END)
-				return (iRead == 0) ? UNZ_EOF : iRead;
-			if (err != Z_OK)
-				break;
-		}
-	}
+            pfile_in_zip_read_info->rest_read_uncompressed -=
+                uOutThis;
 
-	if (err == Z_OK)
-		return iRead;
-	return err;
+            iRead += (uInt)(uTotalOutAfter - uTotalOutBefore);
+
+            if (err==Z_STREAM_END)
+                return (iRead==0) ? UNZ_EOF : iRead;
+            if (err!=Z_OK)
+                break;
+        }
+    }
+
+    if (err==Z_OK)
+        return iRead;
+    return err;
 }
+
 
 /*
   Give the current position in uncompressed data
 */
-extern z_off_t ZEXPORT unztell(unzFile file)
+extern z_off_t ZEXPORT unztell (unzFile file)
 {
-	unz64_s* s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	pfile_in_zip_read_info = s->pfile_in_zip_read;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info == NULL)
-		return UNZ_PARAMERROR;
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
 
-	return (z_off_t)pfile_in_zip_read_info->stream.total_out;
+    return (z_off_t)pfile_in_zip_read_info->stream.total_out;
 }
 
-extern ZPOS64_T ZEXPORT unztell64(unzFile file)
+extern ZPOS64_T ZEXPORT unztell64 (unzFile file)
 {
 
-	unz64_s* s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	if (file == NULL)
-		return (ZPOS64_T)-1;
-	s = (unz64_s*)file;
-	pfile_in_zip_read_info = s->pfile_in_zip_read;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return (ZPOS64_T)-1;
+    s=(unz64_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info == NULL)
-		return (ZPOS64_T)-1;
+    if (pfile_in_zip_read_info==NULL)
+        return (ZPOS64_T)-1;
 
-	return pfile_in_zip_read_info->total_out_64;
+    return pfile_in_zip_read_info->total_out_64;
 }
+
 
 /*
   return 1 if the end of file was reached, 0 elsewhere
 */
-extern int ZEXPORT unzeof(unzFile file)
+extern int ZEXPORT unzeof (unzFile file)
 {
-	unz64_s* s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	pfile_in_zip_read_info = s->pfile_in_zip_read;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info == NULL)
-		return UNZ_PARAMERROR;
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
 
-	if (pfile_in_zip_read_info->rest_read_uncompressed == 0)
-		return 1;
-	else
-		return 0;
+    if (pfile_in_zip_read_info->rest_read_uncompressed == 0)
+        return 1;
+    else
+        return 0;
 }
+
+
 
 /*
 Read extra field from the current file (opened by unzOpenCurrentFile)
@@ -1895,96 +1949,97 @@ more info in the local-header version than in the central-header)
   if buf==NULL, it return the size of the local extra field that can be read
 
   if buf!=NULL, len is the size of the buffer, the extra header is copied in
-	 buf.
+    buf.
   the return value is the number of bytes copied in buf, or (if <0)
-	 the error code
+    the error code
 */
-extern int ZEXPORT unzGetLocalExtrafield(unzFile file, voidp buf, unsigned len)
+extern int ZEXPORT unzGetLocalExtrafield (unzFile file, voidp buf, unsigned len)
 {
-	unz64_s* s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	uInt read_now;
-	ZPOS64_T size_to_read;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    uInt read_now;
+    ZPOS64_T size_to_read;
 
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	pfile_in_zip_read_info = s->pfile_in_zip_read;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info == NULL)
-		return UNZ_PARAMERROR;
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
 
-	size_to_read = (pfile_in_zip_read_info->size_local_extrafield -
-		pfile_in_zip_read_info->pos_local_extrafield);
+    size_to_read = (pfile_in_zip_read_info->size_local_extrafield -
+                pfile_in_zip_read_info->pos_local_extrafield);
 
-	if (buf == NULL)
-		return (int)size_to_read;
+    if (buf==NULL)
+        return (int)size_to_read;
 
-	if (len > size_to_read)
-		read_now = (uInt)size_to_read;
-	else
-		read_now = (uInt)len;
+    if (len>size_to_read)
+        read_now = (uInt)size_to_read;
+    else
+        read_now = (uInt)len ;
 
-	if (read_now == 0)
-		return 0;
+    if (read_now==0)
+        return 0;
 
-	if (ZSEEK64(pfile_in_zip_read_info->z_filefunc,
-		pfile_in_zip_read_info->filestream,
-		pfile_in_zip_read_info->offset_local_extrafield +
-		pfile_in_zip_read_info->pos_local_extrafield,
-		ZLIB_FILEFUNC_SEEK_SET) != 0)
-		return UNZ_ERRNO;
+    if (ZSEEK64(pfile_in_zip_read_info->z_filefunc,
+              pfile_in_zip_read_info->filestream,
+              pfile_in_zip_read_info->offset_local_extrafield +
+              pfile_in_zip_read_info->pos_local_extrafield,
+              ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
 
-	if (ZREAD64(pfile_in_zip_read_info->z_filefunc,
-		pfile_in_zip_read_info->filestream,
-		buf, read_now) != read_now)
-		return UNZ_ERRNO;
+    if (ZREAD64(pfile_in_zip_read_info->z_filefunc,
+              pfile_in_zip_read_info->filestream,
+              buf,read_now)!=read_now)
+        return UNZ_ERRNO;
 
-	return (int)read_now;
+    return (int)read_now;
 }
 
 /*
   Close the file in zip opened with unzOpenCurrentFile
   Return UNZ_CRCERROR if all the file was read but the CRC is not good
 */
-extern int ZEXPORT unzCloseCurrentFile(unzFile file)
+extern int ZEXPORT unzCloseCurrentFile (unzFile file)
 {
-	int err = UNZ_OK;
+    int err=UNZ_OK;
 
-	unz64_s* s;
-	file_in_zip64_read_info_s* pfile_in_zip_read_info;
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	pfile_in_zip_read_info = s->pfile_in_zip_read;
+    unz64_s* s;
+    file_in_zip64_read_info_s* pfile_in_zip_read_info;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    pfile_in_zip_read_info=s->pfile_in_zip_read;
 
-	if (pfile_in_zip_read_info == NULL)
-		return UNZ_PARAMERROR;
-
-
-	if ((pfile_in_zip_read_info->rest_read_uncompressed == 0) &&
-		(!pfile_in_zip_read_info->raw)) {
-		if (pfile_in_zip_read_info->crc32 != pfile_in_zip_read_info->crc32_wait)
-			err = UNZ_CRCERROR;
-	}
+    if (pfile_in_zip_read_info==NULL)
+        return UNZ_PARAMERROR;
 
 
-	TRYFREE(pfile_in_zip_read_info->read_buffer);
-	pfile_in_zip_read_info->read_buffer = NULL;
-	if (pfile_in_zip_read_info->stream_initialised == Z_DEFLATED)
-		inflateEnd(&pfile_in_zip_read_info->stream);
-	#ifdef HAVE_BZIP2
-	else if (pfile_in_zip_read_info->stream_initialised == Z_BZIP2ED)
-		BZ2_bzDecompressEnd(&pfile_in_zip_read_info->bstream);
-	#endif
+    if ((pfile_in_zip_read_info->rest_read_uncompressed == 0) &&
+        (!pfile_in_zip_read_info->raw))
+    {
+        if (pfile_in_zip_read_info->crc32 != pfile_in_zip_read_info->crc32_wait)
+            err=UNZ_CRCERROR;
+    }
 
 
-	pfile_in_zip_read_info->stream_initialised = 0;
-	TRYFREE(pfile_in_zip_read_info);
+    TRYFREE(pfile_in_zip_read_info->read_buffer);
+    pfile_in_zip_read_info->read_buffer = NULL;
+    if (pfile_in_zip_read_info->stream_initialised == Z_DEFLATED)
+        inflateEnd(&pfile_in_zip_read_info->stream);
+#ifdef HAVE_BZIP2
+    else if (pfile_in_zip_read_info->stream_initialised == Z_BZIP2ED)
+        BZ2_bzDecompressEnd(&pfile_in_zip_read_info->bstream);
+#endif
 
-	s->pfile_in_zip_read = NULL;
 
-	return err;
+    pfile_in_zip_read_info->stream_initialised = 0;
+    TRYFREE(pfile_in_zip_read_info);
+
+    s->pfile_in_zip_read=NULL;
+
+    return err;
 }
 
 
@@ -1993,77 +2048,78 @@ extern int ZEXPORT unzCloseCurrentFile(unzFile file)
   uSizeBuf is the size of the szComment buffer.
   return the number of byte copied or an error code <0
 */
-extern int ZEXPORT unzGetGlobalComment(unzFile file, char * szComment, uLong uSizeBuf)
+extern int ZEXPORT unzGetGlobalComment (unzFile file, char * szComment, uLong uSizeBuf)
 {
-	unz64_s* s;
-	uLong uReadThis;
-	if (file == NULL)
-		return (int)UNZ_PARAMERROR;
-	s = (unz64_s*)file;
+    unz64_s* s;
+    uLong uReadThis ;
+    if (file==NULL)
+        return (int)UNZ_PARAMERROR;
+    s=(unz64_s*)file;
 
-	uReadThis = uSizeBuf;
-	if (uReadThis > s->gi.size_comment)
-		uReadThis = s->gi.size_comment;
+    uReadThis = uSizeBuf;
+    if (uReadThis>s->gi.size_comment)
+        uReadThis = s->gi.size_comment;
 
-	if (ZSEEK64(s->z_filefunc, s->filestream, s->central_pos + 22, ZLIB_FILEFUNC_SEEK_SET) != 0)
-		return UNZ_ERRNO;
+    if (ZSEEK64(s->z_filefunc,s->filestream,s->central_pos+22,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        return UNZ_ERRNO;
 
-	if (uReadThis > 0) {
-		*szComment = '\0';
-		if (ZREAD64(s->z_filefunc, s->filestream, szComment, uReadThis) != uReadThis)
-			return UNZ_ERRNO;
-	}
+    if (uReadThis>0)
+    {
+      *szComment='\0';
+      if (ZREAD64(s->z_filefunc,s->filestream,szComment,uReadThis)!=uReadThis)
+        return UNZ_ERRNO;
+    }
 
-	if ((szComment != NULL) && (uSizeBuf > s->gi.size_comment))
-		*(szComment + s->gi.size_comment) = '\0';
-	return (int)uReadThis;
+    if ((szComment != NULL) && (uSizeBuf > s->gi.size_comment))
+        *(szComment+s->gi.size_comment)='\0';
+    return (int)uReadThis;
 }
 
 /* Additions by RX '2004 */
 extern ZPOS64_T ZEXPORT unzGetOffset64(unzFile file)
 {
-	unz64_s* s;
+    unz64_s* s;
 
-	if (file == NULL)
-		return 0; //UNZ_PARAMERROR;
-	s = (unz64_s*)file;
-	if (!s->current_file_ok)
-		return 0;
-	if (s->gi.number_entry != 0 && s->gi.number_entry != 0xffff)
-		if (s->num_file == s->gi.number_entry)
-			return 0;
-	return s->pos_in_central_dir;
+    if (file==NULL)
+          return 0; //UNZ_PARAMERROR;
+    s=(unz64_s*)file;
+    if (!s->current_file_ok)
+      return 0;
+    if (s->gi.number_entry != 0 && s->gi.number_entry != 0xffff)
+      if (s->num_file==s->gi.number_entry)
+         return 0;
+    return s->pos_in_central_dir;
 }
 
-extern uLong ZEXPORT unzGetOffset(unzFile file)
+extern uLong ZEXPORT unzGetOffset (unzFile file)
 {
-	ZPOS64_T offset64;
+    ZPOS64_T offset64;
 
-	if (file == NULL)
-		return 0; //UNZ_PARAMERROR;
-	offset64 = unzGetOffset64(file);
-	return (uLong)offset64;
+    if (file==NULL)
+          return 0; //UNZ_PARAMERROR;
+    offset64 = unzGetOffset64(file);
+    return (uLong)offset64;
 }
 
 extern int ZEXPORT unzSetOffset64(unzFile file, ZPOS64_T pos)
 {
-	unz64_s* s;
-	int err;
+    unz64_s* s;
+    int err;
 
-	if (file == NULL)
-		return UNZ_PARAMERROR;
-	s = (unz64_s*)file;
+    if (file==NULL)
+        return UNZ_PARAMERROR;
+    s=(unz64_s*)file;
 
-	s->pos_in_central_dir = pos;
-	s->num_file = s->gi.number_entry;      /* hack */
-	err = unz64local_GetCurrentFileInfoInternal(file, &s->cur_file_info,
-		&s->cur_file_info_internal,
-		NULL, 0, NULL, 0, NULL, 0);
-	s->current_file_ok = (err == UNZ_OK);
-	return err;
+    s->pos_in_central_dir = pos;
+    s->num_file = s->gi.number_entry;      /* hack */
+    err = unz64local_GetCurrentFileInfoInternal(file,&s->cur_file_info,
+                                              &s->cur_file_info_internal,
+                                              NULL,0,NULL,0,NULL,0);
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
 }
 
-extern int ZEXPORT unzSetOffset(unzFile file, uLong pos)
+extern int ZEXPORT unzSetOffset (unzFile file, uLong pos)
 {
-	return unzSetOffset64(file, pos);
+    return unzSetOffset64(file,pos);
 }

--- a/libs/zlib/src/unzip.h
+++ b/libs/zlib/src/unzip.h
@@ -158,7 +158,7 @@ extern int ZEXPORT unzStringFileNameCompare OF ((const char* fileName1,
    If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
    If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
                                 or strcasecmp)
-   If iCaseSenisivity = 0, case sensitivity is default of your operating system
+   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
     (like 1 on Unix, 2 on Windows)
 */
 

--- a/libs/zlib/src/zconf.h
+++ b/libs/zlib/src/zconf.h
@@ -1,5 +1,5 @@
 /* zconf.h -- configuration of the zlib compression library
- * Copyright (C) 1995-2013 Jean-loup Gailly.
+ * Copyright (C) 1995-2016 Jean-loup Gailly, Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -17,7 +17,7 @@
 #ifdef Z_PREFIX     /* may be set to #if 1 by ./configure */
 #  define Z_PREFIX_SET
 
-/* all linked symbols */
+/* all linked symbols and init macros */
 #  define _dist_code            z__dist_code
 #  define _length_code          z__length_code
 #  define _tr_align             z__tr_align
@@ -29,6 +29,7 @@
 #  define adler32               z_adler32
 #  define adler32_combine       z_adler32_combine
 #  define adler32_combine64     z_adler32_combine64
+#  define adler32_z             z_adler32_z
 #  ifndef Z_SOLO
 #    define compress              z_compress
 #    define compress2             z_compress2
@@ -37,10 +38,14 @@
 #  define crc32                 z_crc32
 #  define crc32_combine         z_crc32_combine
 #  define crc32_combine64       z_crc32_combine64
+#  define crc32_z               z_crc32_z
 #  define deflate               z_deflate
 #  define deflateBound          z_deflateBound
 #  define deflateCopy           z_deflateCopy
 #  define deflateEnd            z_deflateEnd
+#  define deflateGetDictionary  z_deflateGetDictionary
+#  define deflateInit           z_deflateInit
+#  define deflateInit2          z_deflateInit2
 #  define deflateInit2_         z_deflateInit2_
 #  define deflateInit_          z_deflateInit_
 #  define deflateParams         z_deflateParams
@@ -67,6 +72,8 @@
 #    define gzeof                 z_gzeof
 #    define gzerror               z_gzerror
 #    define gzflush               z_gzflush
+#    define gzfread               z_gzfread
+#    define gzfwrite              z_gzfwrite
 #    define gzgetc                z_gzgetc
 #    define gzgetc_               z_gzgetc_
 #    define gzgets                z_gzgets
@@ -78,7 +85,6 @@
 #      define gzopen_w              z_gzopen_w
 #    endif
 #    define gzprintf              z_gzprintf
-#    define gzvprintf             z_gzvprintf
 #    define gzputc                z_gzputc
 #    define gzputs                z_gzputs
 #    define gzread                z_gzread
@@ -89,32 +95,39 @@
 #    define gztell                z_gztell
 #    define gztell64              z_gztell64
 #    define gzungetc              z_gzungetc
+#    define gzvprintf             z_gzvprintf
 #    define gzwrite               z_gzwrite
 #  endif
 #  define inflate               z_inflate
 #  define inflateBack           z_inflateBack
 #  define inflateBackEnd        z_inflateBackEnd
+#  define inflateBackInit       z_inflateBackInit
 #  define inflateBackInit_      z_inflateBackInit_
+#  define inflateCodesUsed      z_inflateCodesUsed
 #  define inflateCopy           z_inflateCopy
 #  define inflateEnd            z_inflateEnd
+#  define inflateGetDictionary  z_inflateGetDictionary
 #  define inflateGetHeader      z_inflateGetHeader
+#  define inflateInit           z_inflateInit
+#  define inflateInit2          z_inflateInit2
 #  define inflateInit2_         z_inflateInit2_
 #  define inflateInit_          z_inflateInit_
 #  define inflateMark           z_inflateMark
 #  define inflatePrime          z_inflatePrime
 #  define inflateReset          z_inflateReset
 #  define inflateReset2         z_inflateReset2
+#  define inflateResetKeep      z_inflateResetKeep
 #  define inflateSetDictionary  z_inflateSetDictionary
-#  define inflateGetDictionary  z_inflateGetDictionary
 #  define inflateSync           z_inflateSync
 #  define inflateSyncPoint      z_inflateSyncPoint
 #  define inflateUndermine      z_inflateUndermine
-#  define inflateResetKeep      z_inflateResetKeep
+#  define inflateValidate       z_inflateValidate
 #  define inflate_copyright     z_inflate_copyright
 #  define inflate_fast          z_inflate_fast
 #  define inflate_table         z_inflate_table
 #  ifndef Z_SOLO
 #    define uncompress            z_uncompress
+#    define uncompress2           z_uncompress2
 #  endif
 #  define zError                z_zError
 #  ifndef Z_SOLO
@@ -224,9 +237,19 @@
 #  define z_const
 #endif
 
-/* Some Mac compilers merge all .h files incorrectly: */
-#if defined(__MWERKS__)||defined(applec)||defined(THINK_C)||defined(__SC__)
-#  define NO_DUMMY_DECL
+#ifdef Z_SOLO
+   typedef unsigned long z_size_t;
+#else
+#  define z_longlong long long
+#  if defined(NO_SIZE_T)
+     typedef unsigned NO_SIZE_T z_size_t;
+#  elif defined(STDC)
+#    include <stddef.h>
+     typedef size_t z_size_t;
+#  else
+     typedef unsigned long z_size_t;
+#  endif
+#  undef z_longlong
 #endif
 
 /* Maximum value for memLevel in deflateInit2 */
@@ -256,7 +279,7 @@
  Of course this will generally degrade compression (there's no free lunch).
 
    The memory requirements for inflate are (in bytes) 1 << windowBits
- that is, 32K for windowBits=15 (default value) plus a few kilobytes
+ that is, 32K for windowBits=15 (default value) plus about 7 kilobytes
  for small objects.
 */
 

--- a/libs/zlib/src/zip.c
+++ b/libs/zlib/src/zip.c
@@ -15,7 +15,7 @@
    Oct-2009 - Mathias Svensson - Did some code cleanup and refactoring to get better overview of some functions.
    Oct-2009 - Mathias Svensson - Added zipRemoveExtraInfoBlock to strip extra field data from its ZIP64 data
                                  It is used when recreting zip archive with RAW when deleting items from a zip.
-                                 ZIP64 data is automaticly added to items that needs it, and existing ZIP64 data need to be removed.
+                                 ZIP64 data is automatically added to items that needs it, and existing ZIP64 data need to be removed.
    Oct-2009 - Mathias Svensson - Added support for BZIP2 as compression mode (bzip2 lib is required)
    Jan-2010 - back to unzip and minizip 1.0 name scheme, with compatibility layer
 
@@ -116,7 +116,7 @@ typedef struct linkedlist_datablock_internal_s
   struct linkedlist_datablock_internal_s* next_datablock;
   uLong  avail_in_this_block;
   uLong  filled_in_this_block;
-  uLong  unused; /* for future use and alignement */
+  uLong  unused; /* for future use and alignment */
   unsigned char data[SIZEDATA_INDATABLOCK];
 } linkedlist_datablock_internal;
 
@@ -129,54 +129,54 @@ typedef struct linkedlist_data_s
 
 typedef struct
 {
-	z_stream stream;            /* zLib stream structure for inflate */
-	#ifdef HAVE_BZIP2
-	bz_stream bstream;          /* bzLib stream structure for bziped */
-	#endif
+    z_stream stream;            /* zLib stream structure for inflate */
+#ifdef HAVE_BZIP2
+    bz_stream bstream;          /* bzLib stream structure for bziped */
+#endif
 
-	int  stream_initialised;    /* 1 is stream is initialised */
-	uInt pos_in_buffered_data;  /* last written byte in buffered_data */
+    int  stream_initialised;    /* 1 is stream is initialised */
+    uInt pos_in_buffered_data;  /* last written byte in buffered_data */
 
-	ZPOS64_T pos_local_header;     /* offset of the local header of the file
-												currenty writing */
-	char* central_header;       /* central header data for the current file */
-	uLong size_centralExtra;
-	uLong size_centralheader;   /* size of the central header for cur file */
-	uLong size_centralExtraFree; /* Extra bytes allocated to the centralheader but that are not used */
-	uLong flag;                 /* flag of the file currently writing */
+    ZPOS64_T pos_local_header;     /* offset of the local header of the file
+                                     currenty writing */
+    char* central_header;       /* central header data for the current file */
+    uLong size_centralExtra;
+    uLong size_centralheader;   /* size of the central header for cur file */
+    uLong size_centralExtraFree; /* Extra bytes allocated to the centralheader but that are not used */
+    uLong flag;                 /* flag of the file currently writing */
 
-	int  method;                /* compression method of file currenty wr.*/
-	int  raw;                   /* 1 for directly writing raw data */
-	Byte buffered_data[Z_BUFSIZE];/* buffer contain compressed data to be writ*/
-	uLong dosDate;
-	uLong crc32;
-	int  encrypt;
-	int  zip64;               /* Add ZIP64 extened information in the extra field */
-	ZPOS64_T pos_zip64extrainfo;
-	ZPOS64_T totalCompressedData;
-	ZPOS64_T totalUncompressedData;
-	#ifndef NOCRYPT
-	unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-	const z_crc_t* pcrc_32_tab;
-	int crypt_header_size;
-	#endif
+    int  method;                /* compression method of file currenty wr.*/
+    int  raw;                   /* 1 for directly writing raw data */
+    Byte buffered_data[Z_BUFSIZE];/* buffer contain compressed data to be writ*/
+    uLong dosDate;
+    uLong crc32;
+    int  encrypt;
+    int  zip64;               /* Add ZIP64 extened information in the extra field */
+    ZPOS64_T pos_zip64extrainfo;
+    ZPOS64_T totalCompressedData;
+    ZPOS64_T totalUncompressedData;
+#ifndef NOCRYPT
+    unsigned long keys[3];     /* keys defining the pseudo-random sequence */
+    const z_crc_t* pcrc_32_tab;
+    int crypt_header_size;
+#endif
 } curfile64_info;
 
 typedef struct
 {
-	zlib_filefunc64_32_def z_filefunc;
-	voidpf filestream;        /* io structore of the zipfile */
-	linkedlist_data central_dir;/* datablock with central dir in construction*/
-	int  in_opened_file_inzip;  /* 1 if a file in the zip is currently writ.*/
-	curfile64_info ci;            /* info on the file curretly writing */
+    zlib_filefunc64_32_def z_filefunc;
+    voidpf filestream;        /* io structore of the zipfile */
+    linkedlist_data central_dir;/* datablock with central dir in construction*/
+    int  in_opened_file_inzip;  /* 1 if a file in the zip is currently writ.*/
+    curfile64_info ci;            /* info on the file curretly writing */
 
-	ZPOS64_T begin_pos;            /* position of the beginning of the zipfile */
-	ZPOS64_T add_position_when_writting_offset;
-	ZPOS64_T number_entry;
+    ZPOS64_T begin_pos;            /* position of the beginning of the zipfile */
+    ZPOS64_T add_position_when_writing_offset;
+    ZPOS64_T number_entry;
 
-	#ifndef NO_ADDFILEINEXISTINGZIP
-	char *globalcomment;
-	#endif
+#ifndef NO_ADDFILEINEXISTINGZIP
+    char *globalcomment;
+#endif
 
 } zip64_internal;
 
@@ -188,84 +188,89 @@ typedef struct
 
 local linkedlist_datablock_internal* allocate_new_datablock()
 {
-	linkedlist_datablock_internal* ldi;
-	ldi = (linkedlist_datablock_internal*)
-		ALLOC(sizeof(linkedlist_datablock_internal));
-	if (ldi != NULL) {
-		ldi->next_datablock = NULL;
-		ldi->filled_in_this_block = 0;
-		ldi->avail_in_this_block = SIZEDATA_INDATABLOCK;
-	}
-	return ldi;
+    linkedlist_datablock_internal* ldi;
+    ldi = (linkedlist_datablock_internal*)
+                 ALLOC(sizeof(linkedlist_datablock_internal));
+    if (ldi!=NULL)
+    {
+        ldi->next_datablock = NULL ;
+        ldi->filled_in_this_block = 0 ;
+        ldi->avail_in_this_block = SIZEDATA_INDATABLOCK ;
+    }
+    return ldi;
 }
 
 local void free_datablock(linkedlist_datablock_internal* ldi)
 {
-	while (ldi != NULL) {
-		linkedlist_datablock_internal* ldinext = ldi->next_datablock;
-		TRYFREE(ldi);
-		ldi = ldinext;
-	}
+    while (ldi!=NULL)
+    {
+        linkedlist_datablock_internal* ldinext = ldi->next_datablock;
+        TRYFREE(ldi);
+        ldi = ldinext;
+    }
 }
 
 local void init_linkedlist(linkedlist_data* ll)
 {
-	ll->first_block = ll->last_block = NULL;
+    ll->first_block = ll->last_block = NULL;
 }
 
 local void free_linkedlist(linkedlist_data* ll)
 {
-	free_datablock(ll->first_block);
-	ll->first_block = ll->last_block = NULL;
+    free_datablock(ll->first_block);
+    ll->first_block = ll->last_block = NULL;
 }
 
 
 local int add_data_in_datablock(linkedlist_data* ll, const void* buf, uLong len)
 {
-	linkedlist_datablock_internal* ldi;
-	const unsigned char* from_copy;
+    linkedlist_datablock_internal* ldi;
+    const unsigned char* from_copy;
 
-	if (ll == NULL)
-		return ZIP_INTERNALERROR;
+    if (ll==NULL)
+        return ZIP_INTERNALERROR;
 
-	if (ll->last_block == NULL) {
-		ll->first_block = ll->last_block = allocate_new_datablock();
-		if (ll->first_block == NULL)
-			return ZIP_INTERNALERROR;
-	}
+    if (ll->last_block == NULL)
+    {
+        ll->first_block = ll->last_block = allocate_new_datablock();
+        if (ll->first_block == NULL)
+            return ZIP_INTERNALERROR;
+    }
 
-	ldi = ll->last_block;
-	from_copy = (unsigned char*)buf;
+    ldi = ll->last_block;
+    from_copy = (unsigned char*)buf;
 
-	while (len > 0) {
-		uInt copy_this;
-		uInt i;
-		unsigned char* to_copy;
+    while (len>0)
+    {
+        uInt copy_this;
+        uInt i;
+        unsigned char* to_copy;
 
-		if (ldi->avail_in_this_block == 0) {
-			ldi->next_datablock = allocate_new_datablock();
-			if (ldi->next_datablock == NULL)
-				return ZIP_INTERNALERROR;
-			ldi = ldi->next_datablock;
-			ll->last_block = ldi;
-		}
+        if (ldi->avail_in_this_block==0)
+        {
+            ldi->next_datablock = allocate_new_datablock();
+            if (ldi->next_datablock == NULL)
+                return ZIP_INTERNALERROR;
+            ldi = ldi->next_datablock ;
+            ll->last_block = ldi;
+        }
 
-		if (ldi->avail_in_this_block < len)
-			copy_this = (uInt)ldi->avail_in_this_block;
-		else
-			copy_this = (uInt)len;
+        if (ldi->avail_in_this_block < len)
+            copy_this = (uInt)ldi->avail_in_this_block;
+        else
+            copy_this = (uInt)len;
 
-		to_copy = &(ldi->data[ldi->filled_in_this_block]);
+        to_copy = &(ldi->data[ldi->filled_in_this_block]);
 
-		for (i = 0; i < copy_this; i++)
-			*(to_copy + i) = *(from_copy + i);
+        for (i=0;i<copy_this;i++)
+            *(to_copy+i)=*(from_copy+i);
 
-		ldi->filled_in_this_block += copy_this;
-		ldi->avail_in_this_block -= copy_this;
-		from_copy += copy_this;
-		len -= copy_this;
-	}
-	return ZIP_OK;
+        ldi->filled_in_this_block += copy_this;
+        ldi->avail_in_this_block -= copy_this;
+        from_copy += copy_this ;
+        len -= copy_this;
+    }
+    return ZIP_OK;
 }
 
 
@@ -274,46 +279,51 @@ local int add_data_in_datablock(linkedlist_data* ll, const void* buf, uLong len)
 
 #ifndef NO_ADDFILEINEXISTINGZIP
 /* ===========================================================================
-	Inputs a long in LSB order to the given file
-	nbByte == 1, 2 ,4 or 8 (byte, short or long, ZPOS64_T)
+   Inputs a long in LSB order to the given file
+   nbByte == 1, 2 ,4 or 8 (byte, short or long, ZPOS64_T)
 */
 
 local int zip64local_putValue OF((const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, ZPOS64_T x, int nbByte));
-local int zip64local_putValue(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, ZPOS64_T x, int nbByte)
+local int zip64local_putValue (const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, ZPOS64_T x, int nbByte)
 {
-	unsigned char buf[8];
-	int n;
-	for (n = 0; n < nbByte; n++) {
-		buf[n] = (unsigned char)(x & 0xff);
-		x >>= 8;
-	}
-	if (x != 0) {     /* data overflow - hack for ZIP64 (X Roche) */
-		for (n = 0; n < nbByte; n++) {
-			buf[n] = 0xff;
-		}
-	}
+    unsigned char buf[8];
+    int n;
+    for (n = 0; n < nbByte; n++)
+    {
+        buf[n] = (unsigned char)(x & 0xff);
+        x >>= 8;
+    }
+    if (x != 0)
+      {     /* data overflow - hack for ZIP64 (X Roche) */
+      for (n = 0; n < nbByte; n++)
+        {
+          buf[n] = 0xff;
+        }
+      }
 
-	if (ZWRITE64(*pzlib_filefunc_def, filestream, buf, nbByte) != (uLong)nbByte)
-		return ZIP_ERRNO;
-	else
-		return ZIP_OK;
+    if (ZWRITE64(*pzlib_filefunc_def,filestream,buf,nbByte)!=(uLong)nbByte)
+        return ZIP_ERRNO;
+    else
+        return ZIP_OK;
 }
 
 local void zip64local_putValue_inmemory OF((void* dest, ZPOS64_T x, int nbByte));
-local void zip64local_putValue_inmemory(void* dest, ZPOS64_T x, int nbByte)
+local void zip64local_putValue_inmemory (void* dest, ZPOS64_T x, int nbByte)
 {
-	unsigned char* buf = (unsigned char*)dest;
-	int n;
-	for (n = 0; n < nbByte; n++) {
-		buf[n] = (unsigned char)(x & 0xff);
-		x >>= 8;
-	}
+    unsigned char* buf=(unsigned char*)dest;
+    int n;
+    for (n = 0; n < nbByte; n++) {
+        buf[n] = (unsigned char)(x & 0xff);
+        x >>= 8;
+    }
 
-	if (x != 0) {     /* data overflow - hack for ZIP64 */
-		for (n = 0; n < nbByte; n++) {
-			buf[n] = 0xff;
-		}
-	}
+    if (x != 0)
+    {     /* data overflow - hack for ZIP64 */
+       for (n = 0; n < nbByte; n++)
+       {
+          buf[n] = 0xff;
+       }
+    }
 }
 
 /****************************************************************************/
@@ -321,14 +331,14 @@ local void zip64local_putValue_inmemory(void* dest, ZPOS64_T x, int nbByte)
 
 local uLong zip64local_TmzDateToDosDate(const tm_zip* ptm)
 {
-	uLong year = (uLong)ptm->tm_year;
-	if (year >= 1980)
-		year -= 1980;
-	else if (year >= 80)
-		year -= 80;
-	return
-		(uLong)(((ptm->tm_mday) + (32 * (ptm->tm_mon + 1)) + (512 * year)) << 16) |
-		((ptm->tm_sec / 2) + (32 * ptm->tm_min) + (2048 * (uLong)ptm->tm_hour));
+    uLong year = (uLong)ptm->tm_year;
+    if (year>=1980)
+        year-=1980;
+    else if (year>=80)
+        year-=80;
+    return
+      (uLong) (((ptm->tm_mday) + (32 * (ptm->tm_mon+1)) + (512 * year)) << 16) |
+        ((ptm->tm_sec/2) + (32* ptm->tm_min) + (2048 * (uLong)ptm->tm_hour));
 }
 
 
@@ -336,124 +346,126 @@ local uLong zip64local_TmzDateToDosDate(const tm_zip* ptm)
 
 local int zip64local_getByte OF((const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, int *pi));
 
-local int zip64local_getByte(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, int* pi)
+local int zip64local_getByte(const zlib_filefunc64_32_def* pzlib_filefunc_def,voidpf filestream,int* pi)
 {
-	unsigned char c;
-	int err = (int)ZREAD64(*pzlib_filefunc_def, filestream, &c, 1);
-	if (err == 1) {
-		*pi = (int)c;
-		return ZIP_OK;
-	}
-	else {
-		if (ZERROR64(*pzlib_filefunc_def, filestream))
-			return ZIP_ERRNO;
-		else
-			return ZIP_EOF;
-	}
+    unsigned char c;
+    int err = (int)ZREAD64(*pzlib_filefunc_def,filestream,&c,1);
+    if (err==1)
+    {
+        *pi = (int)c;
+        return ZIP_OK;
+    }
+    else
+    {
+        if (ZERROR64(*pzlib_filefunc_def,filestream))
+            return ZIP_ERRNO;
+        else
+            return ZIP_EOF;
+    }
 }
 
 
 /* ===========================================================================
-	Reads a long in LSB order from the given gz_stream. Sets
+   Reads a long in LSB order from the given gz_stream. Sets
 */
 local int zip64local_getShort OF((const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, uLong *pX));
 
-local int zip64local_getShort(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, uLong* pX)
+local int zip64local_getShort (const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, uLong* pX)
 {
-	uLong x;
-	int i = 0;
-	int err;
+    uLong x ;
+    int i = 0;
+    int err;
 
-	err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x = (uLong)i;
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((uLong)i) << 8;
+    if (err==ZIP_OK)
+        err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
 
-	if (err == ZIP_OK)
-		*pX = x;
-	else
-		*pX = 0;
-	return err;
+    if (err==ZIP_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
 }
 
 local int zip64local_getLong OF((const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, uLong *pX));
 
-local int zip64local_getLong(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, uLong* pX)
+local int zip64local_getLong (const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, uLong* pX)
 {
-	uLong x;
-	int i = 0;
-	int err;
+    uLong x ;
+    int i = 0;
+    int err;
 
-	err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x = (uLong)i;
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x = (uLong)i;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((uLong)i) << 8;
+    if (err==ZIP_OK)
+        err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<8;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((uLong)i) << 16;
+    if (err==ZIP_OK)
+        err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<16;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((uLong)i) << 24;
+    if (err==ZIP_OK)
+        err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+    x += ((uLong)i)<<24;
 
-	if (err == ZIP_OK)
-		*pX = x;
-	else
-		*pX = 0;
-	return err;
+    if (err==ZIP_OK)
+        *pX = x;
+    else
+        *pX = 0;
+    return err;
 }
 
 local int zip64local_getLong64 OF((const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, ZPOS64_T *pX));
 
 
-local int zip64local_getLong64(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, ZPOS64_T *pX)
+local int zip64local_getLong64 (const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream, ZPOS64_T *pX)
 {
-	ZPOS64_T x;
-	int i = 0;
-	int err;
+  ZPOS64_T x;
+  int i = 0;
+  int err;
 
-	err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x = (ZPOS64_T)i;
+  err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x = (ZPOS64_T)i;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((ZPOS64_T)i) << 8;
+  if (err==ZIP_OK)
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x += ((ZPOS64_T)i)<<8;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((ZPOS64_T)i) << 16;
+  if (err==ZIP_OK)
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x += ((ZPOS64_T)i)<<16;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((ZPOS64_T)i) << 24;
+  if (err==ZIP_OK)
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x += ((ZPOS64_T)i)<<24;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((ZPOS64_T)i) << 32;
+  if (err==ZIP_OK)
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x += ((ZPOS64_T)i)<<32;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((ZPOS64_T)i) << 40;
+  if (err==ZIP_OK)
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x += ((ZPOS64_T)i)<<40;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((ZPOS64_T)i) << 48;
+  if (err==ZIP_OK)
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x += ((ZPOS64_T)i)<<48;
 
-	if (err == ZIP_OK)
-		err = zip64local_getByte(pzlib_filefunc_def, filestream, &i);
-	x += ((ZPOS64_T)i) << 56;
+  if (err==ZIP_OK)
+    err = zip64local_getByte(pzlib_filefunc_def,filestream,&i);
+  x += ((ZPOS64_T)i)<<56;
 
-	if (err == ZIP_OK)
-		*pX = x;
-	else
-		*pX = 0;
+  if (err==ZIP_OK)
+    *pX = x;
+  else
+    *pX = 0;
 
-	return err;
+  return err;
 }
 
 #ifndef BUFREADCOMMENT
@@ -461,62 +473,64 @@ local int zip64local_getLong64(const zlib_filefunc64_32_def* pzlib_filefunc_def,
 #endif
 /*
   Locate the Central directory of a zipfile (at the end, just before
-	 the global comment)
+    the global comment)
 */
 local ZPOS64_T zip64local_SearchCentralDir OF((const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream));
 
 local ZPOS64_T zip64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream)
 {
-	unsigned char* buf;
-	ZPOS64_T uSizeFile;
-	ZPOS64_T uBackRead;
-	ZPOS64_T uMaxBack = 0xffff; /* maximum size of global comment */
-	ZPOS64_T uPosFound = 0;
+  unsigned char* buf;
+  ZPOS64_T uSizeFile;
+  ZPOS64_T uBackRead;
+  ZPOS64_T uMaxBack=0xffff; /* maximum size of global comment */
+  ZPOS64_T uPosFound=0;
 
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, 0, ZLIB_FILEFUNC_SEEK_END) != 0)
-		return 0;
+  if (ZSEEK64(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
+    return 0;
 
 
-	uSizeFile = ZTELL64(*pzlib_filefunc_def, filestream);
+  uSizeFile = ZTELL64(*pzlib_filefunc_def,filestream);
 
-	if (uMaxBack > uSizeFile)
-		uMaxBack = uSizeFile;
+  if (uMaxBack>uSizeFile)
+    uMaxBack = uSizeFile;
 
-	buf = (unsigned char*)ALLOC(BUFREADCOMMENT + 4);
-	if (buf == NULL)
-		return 0;
+  buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+  if (buf==NULL)
+    return 0;
 
-	uBackRead = 4;
-	while (uBackRead<uMaxBack) {
-		uLong uReadSize;
-		ZPOS64_T uReadPos;
-		int i;
-		if (uBackRead + BUFREADCOMMENT>uMaxBack)
-			uBackRead = uMaxBack;
-		else
-			uBackRead += BUFREADCOMMENT;
-		uReadPos = uSizeFile - uBackRead;
+  uBackRead = 4;
+  while (uBackRead<uMaxBack)
+  {
+    uLong uReadSize;
+    ZPOS64_T uReadPos ;
+    int i;
+    if (uBackRead+BUFREADCOMMENT>uMaxBack)
+      uBackRead = uMaxBack;
+    else
+      uBackRead+=BUFREADCOMMENT;
+    uReadPos = uSizeFile-uBackRead ;
 
-		uReadSize = ((BUFREADCOMMENT + 4) < (uSizeFile - uReadPos)) ?
-			(BUFREADCOMMENT + 4) : (uLong)(uSizeFile - uReadPos);
-		if (ZSEEK64(*pzlib_filefunc_def, filestream, uReadPos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			break;
+    uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
+      (BUFREADCOMMENT+4) : (uLong)(uSizeFile-uReadPos);
+    if (ZSEEK64(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+      break;
 
-		if (ZREAD64(*pzlib_filefunc_def, filestream, buf, uReadSize) != uReadSize)
-			break;
+    if (ZREAD64(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
+      break;
 
-		for (i = (int)uReadSize - 3; (i--) > 0;)
-			if (((*(buf + i)) == 0x50) && ((*(buf + i + 1)) == 0x4b) &&
-				((*(buf + i + 2)) == 0x05) && ((*(buf + i + 3)) == 0x06)) {
-				uPosFound = uReadPos + i;
-				break;
-			}
+    for (i=(int)uReadSize-3; (i--)>0;)
+      if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
+        ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
+      {
+        uPosFound = uReadPos+i;
+        break;
+      }
 
-		if (uPosFound != 0)
-			break;
-	}
-	TRYFREE(buf);
-	return uPosFound;
+      if (uPosFound!=0)
+        break;
+  }
+  TRYFREE(buf);
+  return uPosFound;
 }
 
 /*
@@ -527,293 +541,304 @@ local ZPOS64_T zip64local_SearchCentralDir64 OF((const zlib_filefunc64_32_def* p
 
 local ZPOS64_T zip64local_SearchCentralDir64(const zlib_filefunc64_32_def* pzlib_filefunc_def, voidpf filestream)
 {
-	unsigned char* buf;
-	ZPOS64_T uSizeFile;
-	ZPOS64_T uBackRead;
-	ZPOS64_T uMaxBack = 0xffff; /* maximum size of global comment */
-	ZPOS64_T uPosFound = 0;
-	uLong uL;
-	ZPOS64_T relativeOffset;
+  unsigned char* buf;
+  ZPOS64_T uSizeFile;
+  ZPOS64_T uBackRead;
+  ZPOS64_T uMaxBack=0xffff; /* maximum size of global comment */
+  ZPOS64_T uPosFound=0;
+  uLong uL;
+  ZPOS64_T relativeOffset;
 
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, 0, ZLIB_FILEFUNC_SEEK_END) != 0)
-		return 0;
+  if (ZSEEK64(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
+    return 0;
 
-	uSizeFile = ZTELL64(*pzlib_filefunc_def, filestream);
+  uSizeFile = ZTELL64(*pzlib_filefunc_def,filestream);
 
-	if (uMaxBack > uSizeFile)
-		uMaxBack = uSizeFile;
+  if (uMaxBack>uSizeFile)
+    uMaxBack = uSizeFile;
 
-	buf = (unsigned char*)ALLOC(BUFREADCOMMENT + 4);
-	if (buf == NULL)
-		return 0;
+  buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+  if (buf==NULL)
+    return 0;
 
-	uBackRead = 4;
-	while (uBackRead<uMaxBack) {
-		uLong uReadSize;
-		ZPOS64_T uReadPos;
-		int i;
-		if (uBackRead + BUFREADCOMMENT>uMaxBack)
-			uBackRead = uMaxBack;
-		else
-			uBackRead += BUFREADCOMMENT;
-		uReadPos = uSizeFile - uBackRead;
+  uBackRead = 4;
+  while (uBackRead<uMaxBack)
+  {
+    uLong uReadSize;
+    ZPOS64_T uReadPos;
+    int i;
+    if (uBackRead+BUFREADCOMMENT>uMaxBack)
+      uBackRead = uMaxBack;
+    else
+      uBackRead+=BUFREADCOMMENT;
+    uReadPos = uSizeFile-uBackRead ;
 
-		uReadSize = ((BUFREADCOMMENT + 4) < (uSizeFile - uReadPos)) ?
-			(BUFREADCOMMENT + 4) : (uLong)(uSizeFile - uReadPos);
-		if (ZSEEK64(*pzlib_filefunc_def, filestream, uReadPos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			break;
+    uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
+      (BUFREADCOMMENT+4) : (uLong)(uSizeFile-uReadPos);
+    if (ZSEEK64(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+      break;
 
-		if (ZREAD64(*pzlib_filefunc_def, filestream, buf, uReadSize) != uReadSize)
-			break;
+    if (ZREAD64(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
+      break;
 
-		for (i = (int)uReadSize - 3; (i--) > 0;) {
-			// Signature "0x07064b50" Zip64 end of central directory locater
-			if (((*(buf + i)) == 0x50) && ((*(buf + i + 1)) == 0x4b) && ((*(buf + i + 2)) == 0x06) && ((*(buf + i + 3)) == 0x07)) {
-				uPosFound = uReadPos + i;
-				break;
-			}
-		}
+    for (i=(int)uReadSize-3; (i--)>0;)
+    {
+      // Signature "0x07064b50" Zip64 end of central directory locater
+      if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) && ((*(buf+i+2))==0x06) && ((*(buf+i+3))==0x07))
+      {
+        uPosFound = uReadPos+i;
+        break;
+      }
+    }
 
-		if (uPosFound != 0)
-			break;
-	}
+      if (uPosFound!=0)
+        break;
+  }
 
-	TRYFREE(buf);
-	if (uPosFound == 0)
-		return 0;
+  TRYFREE(buf);
+  if (uPosFound == 0)
+    return 0;
 
-	/* Zip64 end of central directory locator */
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, uPosFound, ZLIB_FILEFUNC_SEEK_SET) != 0)
-		return 0;
+  /* Zip64 end of central directory locator */
+  if (ZSEEK64(*pzlib_filefunc_def,filestream, uPosFound,ZLIB_FILEFUNC_SEEK_SET)!=0)
+    return 0;
 
-	/* the signature, already checked */
-	if (zip64local_getLong(pzlib_filefunc_def, filestream, &uL) != ZIP_OK)
-		return 0;
+  /* the signature, already checked */
+  if (zip64local_getLong(pzlib_filefunc_def,filestream,&uL)!=ZIP_OK)
+    return 0;
 
-	/* number of the disk with the start of the zip64 end of  central directory */
-	if (zip64local_getLong(pzlib_filefunc_def, filestream, &uL) != ZIP_OK)
-		return 0;
-	if (uL != 0)
-		return 0;
+  /* number of the disk with the start of the zip64 end of  central directory */
+  if (zip64local_getLong(pzlib_filefunc_def,filestream,&uL)!=ZIP_OK)
+    return 0;
+  if (uL != 0)
+    return 0;
 
-	/* relative offset of the zip64 end of central directory record */
-	if (zip64local_getLong64(pzlib_filefunc_def, filestream, &relativeOffset) != ZIP_OK)
-		return 0;
+  /* relative offset of the zip64 end of central directory record */
+  if (zip64local_getLong64(pzlib_filefunc_def,filestream,&relativeOffset)!=ZIP_OK)
+    return 0;
 
-	/* total number of disks */
-	if (zip64local_getLong(pzlib_filefunc_def, filestream, &uL) != ZIP_OK)
-		return 0;
-	if (uL != 1)
-		return 0;
+  /* total number of disks */
+  if (zip64local_getLong(pzlib_filefunc_def,filestream,&uL)!=ZIP_OK)
+    return 0;
+  if (uL != 1)
+    return 0;
 
-	/* Goto Zip64 end of central directory record */
-	if (ZSEEK64(*pzlib_filefunc_def, filestream, relativeOffset, ZLIB_FILEFUNC_SEEK_SET) != 0)
-		return 0;
+  /* Goto Zip64 end of central directory record */
+  if (ZSEEK64(*pzlib_filefunc_def,filestream, relativeOffset,ZLIB_FILEFUNC_SEEK_SET)!=0)
+    return 0;
 
-	/* the signature */
-	if (zip64local_getLong(pzlib_filefunc_def, filestream, &uL) != ZIP_OK)
-		return 0;
+  /* the signature */
+  if (zip64local_getLong(pzlib_filefunc_def,filestream,&uL)!=ZIP_OK)
+    return 0;
 
-	if (uL != 0x06064b50) // signature of 'Zip64 end of central directory'
-		return 0;
+  if (uL != 0x06064b50) // signature of 'Zip64 end of central directory'
+    return 0;
 
-	return relativeOffset;
+  return relativeOffset;
 }
 
 int LoadCentralDirectoryRecord(zip64_internal* pziinit)
 {
-	int err = ZIP_OK;
-	ZPOS64_T byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
+  int err=ZIP_OK;
+  ZPOS64_T byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
 
-	ZPOS64_T size_central_dir;     /* size of the central directory  */
-	ZPOS64_T offset_central_dir;   /* offset of start of central directory */
-	ZPOS64_T central_pos;
-	uLong uL;
+  ZPOS64_T size_central_dir;     /* size of the central directory  */
+  ZPOS64_T offset_central_dir;   /* offset of start of central directory */
+  ZPOS64_T central_pos;
+  uLong uL;
 
-	uLong number_disk;          /* number of the current dist, used for
-										 spaning ZIP, unsupported, always 0*/
-	uLong number_disk_with_CD;  /* number the the disk with central dir, used
-										 for spaning ZIP, unsupported, always 0*/
-	ZPOS64_T number_entry;
-	ZPOS64_T number_entry_CD;      /* total number of entries in
-											the central dir
-											(same than number_entry on nospan) */
-	uLong VersionMadeBy;
-	uLong VersionNeeded;
-	uLong size_comment;
+  uLong number_disk;          /* number of the current dist, used for
+                              spaning ZIP, unsupported, always 0*/
+  uLong number_disk_with_CD;  /* number the the disk with central dir, used
+                              for spaning ZIP, unsupported, always 0*/
+  ZPOS64_T number_entry;
+  ZPOS64_T number_entry_CD;      /* total number of entries in
+                                the central dir
+                                (same than number_entry on nospan) */
+  uLong VersionMadeBy;
+  uLong VersionNeeded;
+  uLong size_comment;
 
-	int hasZIP64Record = 0;
+  int hasZIP64Record = 0;
 
-	// check first if we find a ZIP64 record
-	central_pos = zip64local_SearchCentralDir64(&pziinit->z_filefunc, pziinit->filestream);
-	if (central_pos > 0) {
-		hasZIP64Record = 1;
-	}
-	else if (central_pos == 0) {
-		central_pos = zip64local_SearchCentralDir(&pziinit->z_filefunc, pziinit->filestream);
-	}
+  // check first if we find a ZIP64 record
+  central_pos = zip64local_SearchCentralDir64(&pziinit->z_filefunc,pziinit->filestream);
+  if(central_pos > 0)
+  {
+    hasZIP64Record = 1;
+  }
+  else if(central_pos == 0)
+  {
+    central_pos = zip64local_SearchCentralDir(&pziinit->z_filefunc,pziinit->filestream);
+  }
 
-	/* disable to allow appending to empty ZIP archive
-			  if (central_pos==0)
-					err=ZIP_ERRNO;
-	*/
+/* disable to allow appending to empty ZIP archive
+        if (central_pos==0)
+            err=ZIP_ERRNO;
+*/
 
-	if (hasZIP64Record) {
-		ZPOS64_T sizeEndOfCentralDirectory;
-		if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			err = ZIP_ERRNO;
+  if(hasZIP64Record)
+  {
+    ZPOS64_T sizeEndOfCentralDirectory;
+    if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
+      err=ZIP_ERRNO;
 
-		/* the signature, already checked */
-		if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &uL) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* the signature, already checked */
+    if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream,&uL)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* size of zip64 end of central directory record */
-		if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream, &sizeEndOfCentralDirectory) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* size of zip64 end of central directory record */
+    if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream, &sizeEndOfCentralDirectory)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* version made by */
-		if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &VersionMadeBy) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* version made by */
+    if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &VersionMadeBy)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* version needed to extract */
-		if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &VersionNeeded) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* version needed to extract */
+    if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &VersionNeeded)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* number of this disk */
-		if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &number_disk) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* number of this disk */
+    if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream,&number_disk)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* number of the disk with the start of the central directory */
-		if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &number_disk_with_CD) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* number of the disk with the start of the central directory */
+    if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream,&number_disk_with_CD)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* total number of entries in the central directory on this disk */
-		if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream, &number_entry) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* total number of entries in the central directory on this disk */
+    if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream, &number_entry)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* total number of entries in the central directory */
-		if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream, &number_entry_CD) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* total number of entries in the central directory */
+    if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream,&number_entry_CD)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		if ((number_entry_CD != number_entry) || (number_disk_with_CD != 0) || (number_disk != 0))
-			err = ZIP_BADZIPFILE;
+    if ((number_entry_CD!=number_entry) || (number_disk_with_CD!=0) || (number_disk!=0))
+      err=ZIP_BADZIPFILE;
 
-		/* size of the central directory */
-		if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream, &size_central_dir) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* size of the central directory */
+    if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream,&size_central_dir)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* offset of start of central directory with respect to the
-		starting disk number */
-		if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream, &offset_central_dir) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* offset of start of central directory with respect to the
+    starting disk number */
+    if (zip64local_getLong64(&pziinit->z_filefunc, pziinit->filestream,&offset_central_dir)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		// TODO..
-		// read the comment from the standard central header.
-		size_comment = 0;
-	}
-	else {
-		// Read End of central Directory info
-		if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			err = ZIP_ERRNO;
+    // TODO..
+    // read the comment from the standard central header.
+    size_comment = 0;
+  }
+  else
+  {
+    // Read End of central Directory info
+    if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+      err=ZIP_ERRNO;
 
-		/* the signature, already checked */
-		if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &uL) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* the signature, already checked */
+    if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream,&uL)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* number of this disk */
-		if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &number_disk) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* number of this disk */
+    if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream,&number_disk)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* number of the disk with the start of the central directory */
-		if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &number_disk_with_CD) != ZIP_OK)
-			err = ZIP_ERRNO;
+    /* number of the disk with the start of the central directory */
+    if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream,&number_disk_with_CD)!=ZIP_OK)
+      err=ZIP_ERRNO;
 
-		/* total number of entries in the central dir on this disk */
-		number_entry = 0;
-		if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &uL) != ZIP_OK)
-			err = ZIP_ERRNO;
-		else
-			number_entry = uL;
+    /* total number of entries in the central dir on this disk */
+    number_entry = 0;
+    if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &uL)!=ZIP_OK)
+      err=ZIP_ERRNO;
+    else
+      number_entry = uL;
 
-		/* total number of entries in the central dir */
-		number_entry_CD = 0;
-		if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &uL) != ZIP_OK)
-			err = ZIP_ERRNO;
-		else
-			number_entry_CD = uL;
+    /* total number of entries in the central dir */
+    number_entry_CD = 0;
+    if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &uL)!=ZIP_OK)
+      err=ZIP_ERRNO;
+    else
+      number_entry_CD = uL;
 
-		if ((number_entry_CD != number_entry) || (number_disk_with_CD != 0) || (number_disk != 0))
-			err = ZIP_BADZIPFILE;
+    if ((number_entry_CD!=number_entry) || (number_disk_with_CD!=0) || (number_disk!=0))
+      err=ZIP_BADZIPFILE;
 
-		/* size of the central directory */
-		size_central_dir = 0;
-		if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &uL) != ZIP_OK)
-			err = ZIP_ERRNO;
-		else
-			size_central_dir = uL;
+    /* size of the central directory */
+    size_central_dir = 0;
+    if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &uL)!=ZIP_OK)
+      err=ZIP_ERRNO;
+    else
+      size_central_dir = uL;
 
-		/* offset of start of central directory with respect to the starting disk number */
-		offset_central_dir = 0;
-		if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &uL) != ZIP_OK)
-			err = ZIP_ERRNO;
-		else
-			offset_central_dir = uL;
+    /* offset of start of central directory with respect to the starting disk number */
+    offset_central_dir = 0;
+    if (zip64local_getLong(&pziinit->z_filefunc, pziinit->filestream, &uL)!=ZIP_OK)
+      err=ZIP_ERRNO;
+    else
+      offset_central_dir = uL;
 
 
-		/* zipfile global comment length */
-		if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &size_comment) != ZIP_OK)
-			err = ZIP_ERRNO;
-	}
+    /* zipfile global comment length */
+    if (zip64local_getShort(&pziinit->z_filefunc, pziinit->filestream, &size_comment)!=ZIP_OK)
+      err=ZIP_ERRNO;
+  }
 
-	if ((central_pos < offset_central_dir + size_central_dir) &&
-		(err == ZIP_OK))
-		err = ZIP_BADZIPFILE;
+  if ((central_pos<offset_central_dir+size_central_dir) &&
+    (err==ZIP_OK))
+    err=ZIP_BADZIPFILE;
 
-	if (err != ZIP_OK) {
-		ZCLOSE64(pziinit->z_filefunc, pziinit->filestream);
-		return ZIP_ERRNO;
-	}
+  if (err!=ZIP_OK)
+  {
+    ZCLOSE64(pziinit->z_filefunc, pziinit->filestream);
+    return ZIP_ERRNO;
+  }
 
-	if (size_comment > 0) {
-		pziinit->globalcomment = (char*)ALLOC(size_comment + 1);
-		if (pziinit->globalcomment) {
-			size_comment = ZREAD64(pziinit->z_filefunc, pziinit->filestream, pziinit->globalcomment, size_comment);
-			pziinit->globalcomment[size_comment] = 0;
-		}
-	}
+  if (size_comment>0)
+  {
+    pziinit->globalcomment = (char*)ALLOC(size_comment+1);
+    if (pziinit->globalcomment)
+    {
+      size_comment = ZREAD64(pziinit->z_filefunc, pziinit->filestream, pziinit->globalcomment,size_comment);
+      pziinit->globalcomment[size_comment]=0;
+    }
+  }
 
-	byte_before_the_zipfile = central_pos - (offset_central_dir + size_central_dir);
-	pziinit->add_position_when_writting_offset = byte_before_the_zipfile;
+  byte_before_the_zipfile = central_pos - (offset_central_dir+size_central_dir);
+  pziinit->add_position_when_writing_offset = byte_before_the_zipfile;
 
-	{
-		ZPOS64_T size_central_dir_to_read = size_central_dir;
-		size_t buf_size = SIZEDATA_INDATABLOCK;
-		void* buf_read = (void*)ALLOC(buf_size);
-		if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, offset_central_dir + byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			err = ZIP_ERRNO;
+  {
+    ZPOS64_T size_central_dir_to_read = size_central_dir;
+    size_t buf_size = SIZEDATA_INDATABLOCK;
+    void* buf_read = (void*)ALLOC(buf_size);
+    if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, offset_central_dir + byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
+      err=ZIP_ERRNO;
 
-		while ((size_central_dir_to_read > 0) && (err == ZIP_OK)) {
-			ZPOS64_T read_this = SIZEDATA_INDATABLOCK;
-			if (read_this > size_central_dir_to_read)
-				read_this = size_central_dir_to_read;
+    while ((size_central_dir_to_read>0) && (err==ZIP_OK))
+    {
+      ZPOS64_T read_this = SIZEDATA_INDATABLOCK;
+      if (read_this > size_central_dir_to_read)
+        read_this = size_central_dir_to_read;
 
-			if (ZREAD64(pziinit->z_filefunc, pziinit->filestream, buf_read, (uLong)read_this) != read_this)
-				err = ZIP_ERRNO;
+      if (ZREAD64(pziinit->z_filefunc, pziinit->filestream,buf_read,(uLong)read_this) != read_this)
+        err=ZIP_ERRNO;
 
-			if (err == ZIP_OK)
-				err = add_data_in_datablock(&pziinit->central_dir, buf_read, (uLong)read_this);
+      if (err==ZIP_OK)
+        err = add_data_in_datablock(&pziinit->central_dir,buf_read, (uLong)read_this);
 
-			size_central_dir_to_read -= read_this;
-		}
-		TRYFREE(buf_read);
-	}
-	pziinit->begin_pos = byte_before_the_zipfile;
-	pziinit->number_entry = number_entry_CD;
+      size_central_dir_to_read-=read_this;
+    }
+    TRYFREE(buf_read);
+  }
+  pziinit->begin_pos = byte_before_the_zipfile;
+  pziinit->number_entry = number_entry_CD;
 
-	if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, offset_central_dir + byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
-		err = ZIP_ERRNO;
+  if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, offset_central_dir+byte_before_the_zipfile,ZLIB_FILEFUNC_SEEK_SET) != 0)
+    err=ZIP_ERRNO;
 
-	return err;
+  return err;
 }
 
 
@@ -821,188 +846,202 @@ int LoadCentralDirectoryRecord(zip64_internal* pziinit)
 
 
 /************************************************************/
-extern zipFile ZEXPORT zipOpen3(const void *pathname, int append, zipcharpc* globalcomment, zlib_filefunc64_32_def* pzlib_filefunc64_32_def)
+extern zipFile ZEXPORT zipOpen3 (const void *pathname, int append, zipcharpc* globalcomment, zlib_filefunc64_32_def* pzlib_filefunc64_32_def)
 {
-	zip64_internal ziinit;
-	zip64_internal* zi;
-	int err = ZIP_OK;
+    zip64_internal ziinit;
+    zip64_internal* zi;
+    int err=ZIP_OK;
 
-	ziinit.z_filefunc.zseek32_file = NULL;
-	ziinit.z_filefunc.ztell32_file = NULL;
-	if (pzlib_filefunc64_32_def == NULL)
-		fill_fopen64_filefunc(&ziinit.z_filefunc.zfile_func64);
-	else
-		ziinit.z_filefunc = *pzlib_filefunc64_32_def;
+    ziinit.z_filefunc.zseek32_file = NULL;
+    ziinit.z_filefunc.ztell32_file = NULL;
+    if (pzlib_filefunc64_32_def==NULL)
+        fill_fopen64_filefunc(&ziinit.z_filefunc.zfile_func64);
+    else
+        ziinit.z_filefunc = *pzlib_filefunc64_32_def;
 
-	ziinit.filestream = ZOPEN64(ziinit.z_filefunc,
-		pathname,
-		(append == APPEND_STATUS_CREATE) ?
-		(ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_CREATE) :
-		(ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_EXISTING));
+    ziinit.filestream = ZOPEN64(ziinit.z_filefunc,
+                  pathname,
+                  (append == APPEND_STATUS_CREATE) ?
+                  (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_CREATE) :
+                    (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_EXISTING));
 
-	if (ziinit.filestream == NULL)
-		return NULL;
+    if (ziinit.filestream == NULL)
+        return NULL;
 
-	if (append == APPEND_STATUS_CREATEAFTER)
-		ZSEEK64(ziinit.z_filefunc, ziinit.filestream, 0, SEEK_END);
+    if (append == APPEND_STATUS_CREATEAFTER)
+        ZSEEK64(ziinit.z_filefunc,ziinit.filestream,0,SEEK_END);
 
-	ziinit.begin_pos = ZTELL64(ziinit.z_filefunc, ziinit.filestream);
-	ziinit.in_opened_file_inzip = 0;
-	ziinit.ci.stream_initialised = 0;
-	ziinit.number_entry = 0;
-	ziinit.add_position_when_writting_offset = 0;
-	init_linkedlist(&(ziinit.central_dir));
+    ziinit.begin_pos = ZTELL64(ziinit.z_filefunc,ziinit.filestream);
+    ziinit.in_opened_file_inzip = 0;
+    ziinit.ci.stream_initialised = 0;
+    ziinit.number_entry = 0;
+    ziinit.add_position_when_writing_offset = 0;
+    init_linkedlist(&(ziinit.central_dir));
 
 
 
-	zi = (zip64_internal*)ALLOC(sizeof(zip64_internal));
-	if (zi == NULL) {
-		ZCLOSE64(ziinit.z_filefunc, ziinit.filestream);
-		return NULL;
-	}
+    zi = (zip64_internal*)ALLOC(sizeof(zip64_internal));
+    if (zi==NULL)
+    {
+        ZCLOSE64(ziinit.z_filefunc,ziinit.filestream);
+        return NULL;
+    }
 
-	/* now we add file in a zipfile */
-	#    ifndef NO_ADDFILEINEXISTINGZIP
-	ziinit.globalcomment = NULL;
-	if (append == APPEND_STATUS_ADDINZIP) {
-		// Read and Cache Central Directory Records
-		err = LoadCentralDirectoryRecord(&ziinit);
-	}
+    /* now we add file in a zipfile */
+#    ifndef NO_ADDFILEINEXISTINGZIP
+    ziinit.globalcomment = NULL;
+    if (append == APPEND_STATUS_ADDINZIP)
+    {
+      // Read and Cache Central Directory Records
+      err = LoadCentralDirectoryRecord(&ziinit);
+    }
 
-	if (globalcomment) {
-		*globalcomment = ziinit.globalcomment;
-	}
-	#    endif /* !NO_ADDFILEINEXISTINGZIP*/
+    if (globalcomment)
+    {
+      *globalcomment = ziinit.globalcomment;
+    }
+#    endif /* !NO_ADDFILEINEXISTINGZIP*/
 
-	if (err != ZIP_OK) {
-		#    ifndef NO_ADDFILEINEXISTINGZIP
-		TRYFREE(ziinit.globalcomment);
-		#    endif /* !NO_ADDFILEINEXISTINGZIP*/
-		TRYFREE(zi);
-		return NULL;
-	}
-	else {
-		*zi = ziinit;
-		return (zipFile)zi;
-	}
+    if (err != ZIP_OK)
+    {
+#    ifndef NO_ADDFILEINEXISTINGZIP
+        TRYFREE(ziinit.globalcomment);
+#    endif /* !NO_ADDFILEINEXISTINGZIP*/
+        TRYFREE(zi);
+        return NULL;
+    }
+    else
+    {
+        *zi = ziinit;
+        return (zipFile)zi;
+    }
 }
 
-extern zipFile ZEXPORT zipOpen2(const char *pathname, int append, zipcharpc* globalcomment, zlib_filefunc_def* pzlib_filefunc32_def)
+extern zipFile ZEXPORT zipOpen2 (const char *pathname, int append, zipcharpc* globalcomment, zlib_filefunc_def* pzlib_filefunc32_def)
 {
-	if (pzlib_filefunc32_def != NULL) {
-		zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
-		fill_zlib_filefunc64_32_def_from_filefunc32(&zlib_filefunc64_32_def_fill, pzlib_filefunc32_def);
-		return zipOpen3(pathname, append, globalcomment, &zlib_filefunc64_32_def_fill);
-	}
-	else
-		return zipOpen3(pathname, append, globalcomment, NULL);
+    if (pzlib_filefunc32_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        fill_zlib_filefunc64_32_def_from_filefunc32(&zlib_filefunc64_32_def_fill,pzlib_filefunc32_def);
+        return zipOpen3(pathname, append, globalcomment, &zlib_filefunc64_32_def_fill);
+    }
+    else
+        return zipOpen3(pathname, append, globalcomment, NULL);
 }
 
-extern zipFile ZEXPORT zipOpen2_64(const void *pathname, int append, zipcharpc* globalcomment, zlib_filefunc64_def* pzlib_filefunc_def)
+extern zipFile ZEXPORT zipOpen2_64 (const void *pathname, int append, zipcharpc* globalcomment, zlib_filefunc64_def* pzlib_filefunc_def)
 {
-	if (pzlib_filefunc_def != NULL) {
-		zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
-		zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
-		zlib_filefunc64_32_def_fill.ztell32_file = NULL;
-		zlib_filefunc64_32_def_fill.zseek32_file = NULL;
-		return zipOpen3(pathname, append, globalcomment, &zlib_filefunc64_32_def_fill);
-	}
-	else
-		return zipOpen3(pathname, append, globalcomment, NULL);
+    if (pzlib_filefunc_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
+        zlib_filefunc64_32_def_fill.ztell32_file = NULL;
+        zlib_filefunc64_32_def_fill.zseek32_file = NULL;
+        return zipOpen3(pathname, append, globalcomment, &zlib_filefunc64_32_def_fill);
+    }
+    else
+        return zipOpen3(pathname, append, globalcomment, NULL);
 }
 
 
 
-extern zipFile ZEXPORT zipOpen(const char* pathname, int append)
+extern zipFile ZEXPORT zipOpen (const char* pathname, int append)
 {
-	return zipOpen3((const void*)pathname, append, NULL, NULL);
+    return zipOpen3((const void*)pathname,append,NULL,NULL);
 }
 
-extern zipFile ZEXPORT zipOpen64(const void* pathname, int append)
+extern zipFile ZEXPORT zipOpen64 (const void* pathname, int append)
 {
-	return zipOpen3(pathname, append, NULL, NULL);
+    return zipOpen3(pathname,append,NULL,NULL);
 }
 
 int Write_LocalFileHeader(zip64_internal* zi, const char* filename, uInt size_extrafield_local, const void* extrafield_local)
 {
-	/* write the local header */
-	int err;
-	uInt size_filename = (uInt)strlen(filename);
-	uInt size_extrafield = size_extrafield_local;
+  /* write the local header */
+  int err;
+  uInt size_filename = (uInt)strlen(filename);
+  uInt size_extrafield = size_extrafield_local;
 
-	err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)LOCALHEADERMAGIC, 4);
+  err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)LOCALHEADERMAGIC, 4);
 
-	if (err == ZIP_OK) {
-		if (zi->ci.zip64)
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)45, 2);/* version needed to extract */
-		else
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)20, 2);/* version needed to extract */
-	}
+  if (err==ZIP_OK)
+  {
+    if(zi->ci.zip64)
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)45,2);/* version needed to extract */
+    else
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)20,2);/* version needed to extract */
+  }
 
-	if (err == ZIP_OK)
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)zi->ci.flag, 2);
+  if (err==ZIP_OK)
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->ci.flag,2);
 
-	if (err == ZIP_OK)
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)zi->ci.method, 2);
+  if (err==ZIP_OK)
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->ci.method,2);
 
-	if (err == ZIP_OK)
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)zi->ci.dosDate, 4);
+  if (err==ZIP_OK)
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->ci.dosDate,4);
 
-	// CRC / Compressed size / Uncompressed size will be filled in later and rewritten later
-	if (err == ZIP_OK)
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 4); /* crc 32, unknown */
-	if (err == ZIP_OK) {
-		if (zi->ci.zip64)
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0xFFFFFFFF, 4); /* compressed size, unknown */
-		else
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 4); /* compressed size, unknown */
-	}
-	if (err == ZIP_OK) {
-		if (zi->ci.zip64)
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0xFFFFFFFF, 4); /* uncompressed size, unknown */
-		else
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 4); /* uncompressed size, unknown */
-	}
+  // CRC / Compressed size / Uncompressed size will be filled in later and rewritten later
+  if (err==ZIP_OK)
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4); /* crc 32, unknown */
+  if (err==ZIP_OK)
+  {
+    if(zi->ci.zip64)
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0xFFFFFFFF,4); /* compressed size, unknown */
+    else
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4); /* compressed size, unknown */
+  }
+  if (err==ZIP_OK)
+  {
+    if(zi->ci.zip64)
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0xFFFFFFFF,4); /* uncompressed size, unknown */
+    else
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4); /* uncompressed size, unknown */
+  }
 
-	if (err == ZIP_OK)
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)size_filename, 2);
+  if (err==ZIP_OK)
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_filename,2);
 
-	if (zi->ci.zip64) {
-		size_extrafield += 20;
-	}
+  if(zi->ci.zip64)
+  {
+    size_extrafield += 20;
+  }
 
-	if (err == ZIP_OK)
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)size_extrafield, 2);
+  if (err==ZIP_OK)
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_extrafield,2);
 
-	if ((err == ZIP_OK) && (size_filename > 0)) {
-		if (ZWRITE64(zi->z_filefunc, zi->filestream, filename, size_filename) != size_filename)
-			err = ZIP_ERRNO;
-	}
+  if ((err==ZIP_OK) && (size_filename > 0))
+  {
+    if (ZWRITE64(zi->z_filefunc,zi->filestream,filename,size_filename)!=size_filename)
+      err = ZIP_ERRNO;
+  }
 
-	if ((err == ZIP_OK) && (size_extrafield_local > 0)) {
-		if (ZWRITE64(zi->z_filefunc, zi->filestream, extrafield_local, size_extrafield_local) != size_extrafield_local)
-			err = ZIP_ERRNO;
-	}
+  if ((err==ZIP_OK) && (size_extrafield_local > 0))
+  {
+    if (ZWRITE64(zi->z_filefunc, zi->filestream, extrafield_local, size_extrafield_local) != size_extrafield_local)
+      err = ZIP_ERRNO;
+  }
 
 
-	if ((err == ZIP_OK) && (zi->ci.zip64)) {
-		// write the Zip64 extended info
-		short HeaderID = 1;
-		short DataSize = 16;
-		ZPOS64_T CompressedSize = 0;
-		ZPOS64_T UncompressedSize = 0;
+  if ((err==ZIP_OK) && (zi->ci.zip64))
+  {
+      // write the Zip64 extended info
+      short HeaderID = 1;
+      short DataSize = 16;
+      ZPOS64_T CompressedSize = 0;
+      ZPOS64_T UncompressedSize = 0;
 
-		// Remember position of Zip64 extended info for the local file header. (needed when we update size after done with file)
-		zi->ci.pos_zip64extrainfo = ZTELL64(zi->z_filefunc, zi->filestream);
+      // Remember position of Zip64 extended info for the local file header. (needed when we update size after done with file)
+      zi->ci.pos_zip64extrainfo = ZTELL64(zi->z_filefunc,zi->filestream);
 
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)HeaderID, 2);
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)DataSize, 2);
+      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)HeaderID,2);
+      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (short)DataSize,2);
 
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)UncompressedSize, 8);
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)CompressedSize, 8);
-	}
+      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)UncompressedSize,8);
+      err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)CompressedSize,8);
+  }
 
-	return err;
+  return err;
 }
 
 /*
@@ -1013,910 +1052,956 @@ int Write_LocalFileHeader(zip64_internal* zi, const char* filename, uInt size_ex
  It is not done here because then we need to realloc a new buffer since parameters are 'const' and I want to minimize
  unnecessary allocations.
  */
-extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void* extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level, int raw,
-	int windowBits, int memLevel, int strategy,
-	const char* password, uLong crcForCrypting,
-	uLong versionMadeBy, uLong flagBase, int zip64)
+extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, const zip_fileinfo* zipfi,
+                                         const void* extrafield_local, uInt size_extrafield_local,
+                                         const void* extrafield_global, uInt size_extrafield_global,
+                                         const char* comment, int method, int level, int raw,
+                                         int windowBits,int memLevel, int strategy,
+                                         const char* password, uLong crcForCrypting,
+                                         uLong versionMadeBy, uLong flagBase, int zip64)
 {
-	zip64_internal* zi;
-	uInt size_filename;
-	uInt size_comment;
-	uInt i;
-	int err = ZIP_OK;
+    zip64_internal* zi;
+    uInt size_filename;
+    uInt size_comment;
+    uInt i;
+    int err = ZIP_OK;
 
-	#    ifdef NOCRYPT
-	(crcForCrypting);
-	if (password != NULL)
-		return ZIP_PARAMERROR;
-	#    endif
+#    ifdef NOCRYPT
+    (crcForCrypting);
+    if (password != NULL)
+        return ZIP_PARAMERROR;
+#    endif
 
-	if (file == NULL)
-		return ZIP_PARAMERROR;
+    if (file == NULL)
+        return ZIP_PARAMERROR;
 
-	#ifdef HAVE_BZIP2
-	if ((method != 0) && (method != Z_DEFLATED) && (method != Z_BZIP2ED))
-		return ZIP_PARAMERROR;
-	#else
-	if ((method != 0) && (method != Z_DEFLATED))
-		return ZIP_PARAMERROR;
-	#endif
+#ifdef HAVE_BZIP2
+    if ((method!=0) && (method!=Z_DEFLATED) && (method!=Z_BZIP2ED))
+      return ZIP_PARAMERROR;
+#else
+    if ((method!=0) && (method!=Z_DEFLATED))
+      return ZIP_PARAMERROR;
+#endif
 
-	zi = (zip64_internal*)file;
+    zi = (zip64_internal*)file;
 
-	if (zi->in_opened_file_inzip == 1) {
-		err = zipCloseFileInZip(file);
-		if (err != ZIP_OK)
-			return err;
-	}
+    if (zi->in_opened_file_inzip == 1)
+    {
+        err = zipCloseFileInZip (file);
+        if (err != ZIP_OK)
+            return err;
+    }
 
-	if (filename == NULL)
-		filename = "-";
+    if (filename==NULL)
+        filename="-";
 
-	if (comment == NULL)
-		size_comment = 0;
-	else
-		size_comment = (uInt)strlen(comment);
+    if (comment==NULL)
+        size_comment = 0;
+    else
+        size_comment = (uInt)strlen(comment);
 
-	size_filename = (uInt)strlen(filename);
+    size_filename = (uInt)strlen(filename);
 
-	if (zipfi == NULL)
-		zi->ci.dosDate = 0;
-	else {
-		if (zipfi->dosDate != 0)
-			zi->ci.dosDate = zipfi->dosDate;
-		else
-			zi->ci.dosDate = zip64local_TmzDateToDosDate(&zipfi->tmz_date);
-	}
+    if (zipfi == NULL)
+        zi->ci.dosDate = 0;
+    else
+    {
+        if (zipfi->dosDate != 0)
+            zi->ci.dosDate = zipfi->dosDate;
+        else
+          zi->ci.dosDate = zip64local_TmzDateToDosDate(&zipfi->tmz_date);
+    }
 
-	zi->ci.flag = flagBase;
-	if ((level == 8) || (level == 9))
-		zi->ci.flag |= 2;
-	if (level == 2)
-		zi->ci.flag |= 4;
-	if (level == 1)
-		zi->ci.flag |= 6;
-	if (password != NULL)
-		zi->ci.flag |= 1;
+    zi->ci.flag = flagBase;
+    if ((level==8) || (level==9))
+      zi->ci.flag |= 2;
+    if (level==2)
+      zi->ci.flag |= 4;
+    if (level==1)
+      zi->ci.flag |= 6;
+    if (password != NULL)
+      zi->ci.flag |= 1;
 
-	zi->ci.crc32 = 0;
-	zi->ci.method = method;
-	zi->ci.encrypt = 0;
-	zi->ci.stream_initialised = 0;
-	zi->ci.pos_in_buffered_data = 0;
-	zi->ci.raw = raw;
-	zi->ci.pos_local_header = ZTELL64(zi->z_filefunc, zi->filestream);
+    zi->ci.crc32 = 0;
+    zi->ci.method = method;
+    zi->ci.encrypt = 0;
+    zi->ci.stream_initialised = 0;
+    zi->ci.pos_in_buffered_data = 0;
+    zi->ci.raw = raw;
+    zi->ci.pos_local_header = ZTELL64(zi->z_filefunc,zi->filestream);
 
-	zi->ci.size_centralheader = SIZECENTRALHEADER + size_filename + size_extrafield_global + size_comment;
-	zi->ci.size_centralExtraFree = 32; // Extra space we have reserved in case we need to add ZIP64 extra info data
+    zi->ci.size_centralheader = SIZECENTRALHEADER + size_filename + size_extrafield_global + size_comment;
+    zi->ci.size_centralExtraFree = 32; // Extra space we have reserved in case we need to add ZIP64 extra info data
 
-	zi->ci.central_header = (char*)ALLOC((uInt)zi->ci.size_centralheader + zi->ci.size_centralExtraFree);
+    zi->ci.central_header = (char*)ALLOC((uInt)zi->ci.size_centralheader + zi->ci.size_centralExtraFree);
 
-	zi->ci.size_centralExtra = size_extrafield_global;
-	zip64local_putValue_inmemory(zi->ci.central_header, (uLong)CENTRALHEADERMAGIC, 4);
-	/* version info */
-	zip64local_putValue_inmemory(zi->ci.central_header + 4, (uLong)versionMadeBy, 2);
-	zip64local_putValue_inmemory(zi->ci.central_header + 6, (uLong)20, 2);
-	zip64local_putValue_inmemory(zi->ci.central_header + 8, (uLong)zi->ci.flag, 2);
-	zip64local_putValue_inmemory(zi->ci.central_header + 10, (uLong)zi->ci.method, 2);
-	zip64local_putValue_inmemory(zi->ci.central_header + 12, (uLong)zi->ci.dosDate, 4);
-	zip64local_putValue_inmemory(zi->ci.central_header + 16, (uLong)0, 4); /*crc*/
-	zip64local_putValue_inmemory(zi->ci.central_header + 20, (uLong)0, 4); /*compr size*/
-	zip64local_putValue_inmemory(zi->ci.central_header + 24, (uLong)0, 4); /*uncompr size*/
-	zip64local_putValue_inmemory(zi->ci.central_header + 28, (uLong)size_filename, 2);
-	zip64local_putValue_inmemory(zi->ci.central_header + 30, (uLong)size_extrafield_global, 2);
-	zip64local_putValue_inmemory(zi->ci.central_header + 32, (uLong)size_comment, 2);
-	zip64local_putValue_inmemory(zi->ci.central_header + 34, (uLong)0, 2); /*disk nm start*/
+    zi->ci.size_centralExtra = size_extrafield_global;
+    zip64local_putValue_inmemory(zi->ci.central_header,(uLong)CENTRALHEADERMAGIC,4);
+    /* version info */
+    zip64local_putValue_inmemory(zi->ci.central_header+4,(uLong)versionMadeBy,2);
+    zip64local_putValue_inmemory(zi->ci.central_header+6,(uLong)20,2);
+    zip64local_putValue_inmemory(zi->ci.central_header+8,(uLong)zi->ci.flag,2);
+    zip64local_putValue_inmemory(zi->ci.central_header+10,(uLong)zi->ci.method,2);
+    zip64local_putValue_inmemory(zi->ci.central_header+12,(uLong)zi->ci.dosDate,4);
+    zip64local_putValue_inmemory(zi->ci.central_header+16,(uLong)0,4); /*crc*/
+    zip64local_putValue_inmemory(zi->ci.central_header+20,(uLong)0,4); /*compr size*/
+    zip64local_putValue_inmemory(zi->ci.central_header+24,(uLong)0,4); /*uncompr size*/
+    zip64local_putValue_inmemory(zi->ci.central_header+28,(uLong)size_filename,2);
+    zip64local_putValue_inmemory(zi->ci.central_header+30,(uLong)size_extrafield_global,2);
+    zip64local_putValue_inmemory(zi->ci.central_header+32,(uLong)size_comment,2);
+    zip64local_putValue_inmemory(zi->ci.central_header+34,(uLong)0,2); /*disk nm start*/
 
-	if (zipfi == NULL)
-		zip64local_putValue_inmemory(zi->ci.central_header + 36, (uLong)0, 2);
-	else
-		zip64local_putValue_inmemory(zi->ci.central_header + 36, (uLong)zipfi->internal_fa, 2);
+    if (zipfi==NULL)
+        zip64local_putValue_inmemory(zi->ci.central_header+36,(uLong)0,2);
+    else
+        zip64local_putValue_inmemory(zi->ci.central_header+36,(uLong)zipfi->internal_fa,2);
 
-	if (zipfi == NULL)
-		zip64local_putValue_inmemory(zi->ci.central_header + 38, (uLong)0, 4);
-	else
-		zip64local_putValue_inmemory(zi->ci.central_header + 38, (uLong)zipfi->external_fa, 4);
+    if (zipfi==NULL)
+        zip64local_putValue_inmemory(zi->ci.central_header+38,(uLong)0,4);
+    else
+        zip64local_putValue_inmemory(zi->ci.central_header+38,(uLong)zipfi->external_fa,4);
 
-	if (zi->ci.pos_local_header >= 0xffffffff)
-		zip64local_putValue_inmemory(zi->ci.central_header + 42, (uLong)0xffffffff, 4);
-	else
-		zip64local_putValue_inmemory(zi->ci.central_header + 42, (uLong)zi->ci.pos_local_header - zi->add_position_when_writting_offset, 4);
+    if(zi->ci.pos_local_header >= 0xffffffff)
+      zip64local_putValue_inmemory(zi->ci.central_header+42,(uLong)0xffffffff,4);
+    else
+      zip64local_putValue_inmemory(zi->ci.central_header+42,(uLong)zi->ci.pos_local_header - zi->add_position_when_writing_offset,4);
 
-	for (i = 0; i < size_filename; i++)
-		*(zi->ci.central_header + SIZECENTRALHEADER + i) = *(filename + i);
+    for (i=0;i<size_filename;i++)
+        *(zi->ci.central_header+SIZECENTRALHEADER+i) = *(filename+i);
 
-	for (i = 0; i < size_extrafield_global; i++)
-		*(zi->ci.central_header + SIZECENTRALHEADER + size_filename + i) =
-		*(((const char*)extrafield_global) + i);
+    for (i=0;i<size_extrafield_global;i++)
+        *(zi->ci.central_header+SIZECENTRALHEADER+size_filename+i) =
+              *(((const char*)extrafield_global)+i);
 
-	for (i = 0; i < size_comment; i++)
-		*(zi->ci.central_header + SIZECENTRALHEADER + size_filename +
-			size_extrafield_global + i) = *(comment + i);
-	if (zi->ci.central_header == NULL)
-		return ZIP_INTERNALERROR;
+    for (i=0;i<size_comment;i++)
+        *(zi->ci.central_header+SIZECENTRALHEADER+size_filename+
+              size_extrafield_global+i) = *(comment+i);
+    if (zi->ci.central_header == NULL)
+        return ZIP_INTERNALERROR;
 
-	zi->ci.zip64 = zip64;
-	zi->ci.totalCompressedData = 0;
-	zi->ci.totalUncompressedData = 0;
-	zi->ci.pos_zip64extrainfo = 0;
+    zi->ci.zip64 = zip64;
+    zi->ci.totalCompressedData = 0;
+    zi->ci.totalUncompressedData = 0;
+    zi->ci.pos_zip64extrainfo = 0;
 
-	err = Write_LocalFileHeader(zi, filename, size_extrafield_local, extrafield_local);
+    err = Write_LocalFileHeader(zi, filename, size_extrafield_local, extrafield_local);
 
-	#ifdef HAVE_BZIP2
-	zi->ci.bstream.avail_in = (uInt)0;
-	zi->ci.bstream.avail_out = (uInt)Z_BUFSIZE;
-	zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
-	zi->ci.bstream.total_in_hi32 = 0;
-	zi->ci.bstream.total_in_lo32 = 0;
-	zi->ci.bstream.total_out_hi32 = 0;
-	zi->ci.bstream.total_out_lo32 = 0;
-	#endif
+#ifdef HAVE_BZIP2
+    zi->ci.bstream.avail_in = (uInt)0;
+    zi->ci.bstream.avail_out = (uInt)Z_BUFSIZE;
+    zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
+    zi->ci.bstream.total_in_hi32 = 0;
+    zi->ci.bstream.total_in_lo32 = 0;
+    zi->ci.bstream.total_out_hi32 = 0;
+    zi->ci.bstream.total_out_lo32 = 0;
+#endif
 
-	zi->ci.stream.avail_in = (uInt)0;
-	zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
-	zi->ci.stream.next_out = zi->ci.buffered_data;
-	zi->ci.stream.total_in = 0;
-	zi->ci.stream.total_out = 0;
-	zi->ci.stream.data_type = Z_BINARY;
+    zi->ci.stream.avail_in = (uInt)0;
+    zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
+    zi->ci.stream.next_out = zi->ci.buffered_data;
+    zi->ci.stream.total_in = 0;
+    zi->ci.stream.total_out = 0;
+    zi->ci.stream.data_type = Z_BINARY;
 
-	#ifdef HAVE_BZIP2
-	if ((err == ZIP_OK) && (zi->ci.method == Z_DEFLATED || zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw))
-		#else
-	if ((err == ZIP_OK) && (zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
-		#endif
-	{
-		if (zi->ci.method == Z_DEFLATED) {
-			zi->ci.stream.zalloc = (alloc_func)0;
-			zi->ci.stream.zfree = (free_func)0;
-			zi->ci.stream.opaque = (voidpf)0;
+#ifdef HAVE_BZIP2
+    if ((err==ZIP_OK) && (zi->ci.method == Z_DEFLATED || zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw))
+#else
+    if ((err==ZIP_OK) && (zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+#endif
+    {
+        if(zi->ci.method == Z_DEFLATED)
+        {
+          zi->ci.stream.zalloc = (alloc_func)0;
+          zi->ci.stream.zfree = (free_func)0;
+          zi->ci.stream.opaque = (voidpf)0;
 
-			if (windowBits > 0)
-				windowBits = -windowBits;
+          if (windowBits>0)
+              windowBits = -windowBits;
 
-			err = deflateInit2(&zi->ci.stream, level, Z_DEFLATED, windowBits, memLevel, strategy);
+          err = deflateInit2(&zi->ci.stream, level, Z_DEFLATED, windowBits, memLevel, strategy);
 
-			if (err == Z_OK)
-				zi->ci.stream_initialised = Z_DEFLATED;
-		}
-		else if (zi->ci.method == Z_BZIP2ED) {
-			#ifdef HAVE_BZIP2
-			// Init BZip stuff here
-			zi->ci.bstream.bzalloc = 0;
-			zi->ci.bstream.bzfree = 0;
-			zi->ci.bstream.opaque = (voidpf)0;
+          if (err==Z_OK)
+              zi->ci.stream_initialised = Z_DEFLATED;
+        }
+        else if(zi->ci.method == Z_BZIP2ED)
+        {
+#ifdef HAVE_BZIP2
+            // Init BZip stuff here
+          zi->ci.bstream.bzalloc = 0;
+          zi->ci.bstream.bzfree = 0;
+          zi->ci.bstream.opaque = (voidpf)0;
 
-			err = BZ2_bzCompressInit(&zi->ci.bstream, level, 0, 35);
-			if (err == BZ_OK)
-				zi->ci.stream_initialised = Z_BZIP2ED;
-			#endif
-		}
+          err = BZ2_bzCompressInit(&zi->ci.bstream, level, 0,35);
+          if(err == BZ_OK)
+            zi->ci.stream_initialised = Z_BZIP2ED;
+#endif
+        }
 
-	}
+    }
 
-	#    ifndef NOCRYPT
-	zi->ci.crypt_header_size = 0;
-	if ((err == Z_OK) && (password != NULL)) {
-		unsigned char bufHead[RAND_HEAD_LEN];
-		unsigned int sizeHead;
-		zi->ci.encrypt = 1;
-		zi->ci.pcrc_32_tab = get_crc_table();
-		/*init_keys(password,zi->ci.keys,zi->ci.pcrc_32_tab);*/
+#    ifndef NOCRYPT
+    zi->ci.crypt_header_size = 0;
+    if ((err==Z_OK) && (password != NULL))
+    {
+        unsigned char bufHead[RAND_HEAD_LEN];
+        unsigned int sizeHead;
+        zi->ci.encrypt = 1;
+        zi->ci.pcrc_32_tab = get_crc_table();
+        /*init_keys(password,zi->ci.keys,zi->ci.pcrc_32_tab);*/
 
-		sizeHead = crypthead(password, bufHead, RAND_HEAD_LEN, zi->ci.keys, zi->ci.pcrc_32_tab, crcForCrypting);
-		zi->ci.crypt_header_size = sizeHead;
+        sizeHead=crypthead(password,bufHead,RAND_HEAD_LEN,zi->ci.keys,zi->ci.pcrc_32_tab,crcForCrypting);
+        zi->ci.crypt_header_size = sizeHead;
 
-		if (ZWRITE64(zi->z_filefunc, zi->filestream, bufHead, sizeHead) != sizeHead)
-			err = ZIP_ERRNO;
-	}
-	#    endif
+        if (ZWRITE64(zi->z_filefunc,zi->filestream,bufHead,sizeHead) != sizeHead)
+                err = ZIP_ERRNO;
+    }
+#    endif
 
-	if (err == Z_OK)
-		zi->in_opened_file_inzip = 1;
-	return err;
+    if (err==Z_OK)
+        zi->in_opened_file_inzip = 1;
+    return err;
 }
 
-extern int ZEXPORT zipOpenNewFileInZip4(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void* extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level, int raw,
-	int windowBits, int memLevel, int strategy,
-	const char* password, uLong crcForCrypting,
-	uLong versionMadeBy, uLong flagBase)
+extern int ZEXPORT zipOpenNewFileInZip4 (zipFile file, const char* filename, const zip_fileinfo* zipfi,
+                                         const void* extrafield_local, uInt size_extrafield_local,
+                                         const void* extrafield_global, uInt size_extrafield_global,
+                                         const char* comment, int method, int level, int raw,
+                                         int windowBits,int memLevel, int strategy,
+                                         const char* password, uLong crcForCrypting,
+                                         uLong versionMadeBy, uLong flagBase)
 {
-	return zipOpenNewFileInZip4_64(file, filename, zipfi,
-		extrafield_local, size_extrafield_local,
-		extrafield_global, size_extrafield_global,
-		comment, method, level, raw,
-		windowBits, memLevel, strategy,
-		password, crcForCrypting, versionMadeBy, flagBase, 0);
+    return zipOpenNewFileInZip4_64 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, raw,
+                                 windowBits, memLevel, strategy,
+                                 password, crcForCrypting, versionMadeBy, flagBase, 0);
 }
 
-extern int ZEXPORT zipOpenNewFileInZip3(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void* extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level, int raw,
-	int windowBits, int memLevel, int strategy,
-	const char* password, uLong crcForCrypting)
+extern int ZEXPORT zipOpenNewFileInZip3 (zipFile file, const char* filename, const zip_fileinfo* zipfi,
+                                         const void* extrafield_local, uInt size_extrafield_local,
+                                         const void* extrafield_global, uInt size_extrafield_global,
+                                         const char* comment, int method, int level, int raw,
+                                         int windowBits,int memLevel, int strategy,
+                                         const char* password, uLong crcForCrypting)
 {
-	return zipOpenNewFileInZip4_64(file, filename, zipfi,
-		extrafield_local, size_extrafield_local,
-		extrafield_global, size_extrafield_global,
-		comment, method, level, raw,
-		windowBits, memLevel, strategy,
-		password, crcForCrypting, VERSIONMADEBY, 0, 0);
+    return zipOpenNewFileInZip4_64 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, raw,
+                                 windowBits, memLevel, strategy,
+                                 password, crcForCrypting, VERSIONMADEBY, 0, 0);
 }
 
 extern int ZEXPORT zipOpenNewFileInZip3_64(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void* extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level, int raw,
-	int windowBits, int memLevel, int strategy,
-	const char* password, uLong crcForCrypting, int zip64)
+                                         const void* extrafield_local, uInt size_extrafield_local,
+                                         const void* extrafield_global, uInt size_extrafield_global,
+                                         const char* comment, int method, int level, int raw,
+                                         int windowBits,int memLevel, int strategy,
+                                         const char* password, uLong crcForCrypting, int zip64)
 {
-	return zipOpenNewFileInZip4_64(file, filename, zipfi,
-		extrafield_local, size_extrafield_local,
-		extrafield_global, size_extrafield_global,
-		comment, method, level, raw,
-		windowBits, memLevel, strategy,
-		password, crcForCrypting, VERSIONMADEBY, 0, zip64);
+    return zipOpenNewFileInZip4_64 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, raw,
+                                 windowBits, memLevel, strategy,
+                                 password, crcForCrypting, VERSIONMADEBY, 0, zip64);
 }
 
 extern int ZEXPORT zipOpenNewFileInZip2(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void* extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level, int raw)
+                                        const void* extrafield_local, uInt size_extrafield_local,
+                                        const void* extrafield_global, uInt size_extrafield_global,
+                                        const char* comment, int method, int level, int raw)
 {
-	return zipOpenNewFileInZip4_64(file, filename, zipfi,
-		extrafield_local, size_extrafield_local,
-		extrafield_global, size_extrafield_global,
-		comment, method, level, raw,
-		-MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-		NULL, 0, VERSIONMADEBY, 0, 0);
+    return zipOpenNewFileInZip4_64 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, raw,
+                                 -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                 NULL, 0, VERSIONMADEBY, 0, 0);
 }
 
 extern int ZEXPORT zipOpenNewFileInZip2_64(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void* extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level, int raw, int zip64)
+                                        const void* extrafield_local, uInt size_extrafield_local,
+                                        const void* extrafield_global, uInt size_extrafield_global,
+                                        const char* comment, int method, int level, int raw, int zip64)
 {
-	return zipOpenNewFileInZip4_64(file, filename, zipfi,
-		extrafield_local, size_extrafield_local,
-		extrafield_global, size_extrafield_global,
-		comment, method, level, raw,
-		-MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-		NULL, 0, VERSIONMADEBY, 0, zip64);
+    return zipOpenNewFileInZip4_64 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, raw,
+                                 -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                 NULL, 0, VERSIONMADEBY, 0, zip64);
 }
 
-extern int ZEXPORT zipOpenNewFileInZip64(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void*extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level, int zip64)
+extern int ZEXPORT zipOpenNewFileInZip64 (zipFile file, const char* filename, const zip_fileinfo* zipfi,
+                                        const void* extrafield_local, uInt size_extrafield_local,
+                                        const void*extrafield_global, uInt size_extrafield_global,
+                                        const char* comment, int method, int level, int zip64)
 {
-	return zipOpenNewFileInZip4_64(file, filename, zipfi,
-		extrafield_local, size_extrafield_local,
-		extrafield_global, size_extrafield_global,
-		comment, method, level, 0,
-		-MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-		NULL, 0, VERSIONMADEBY, 0, zip64);
+    return zipOpenNewFileInZip4_64 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, 0,
+                                 -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                 NULL, 0, VERSIONMADEBY, 0, zip64);
 }
 
-extern int ZEXPORT zipOpenNewFileInZip(zipFile file, const char* filename, const zip_fileinfo* zipfi,
-	const void* extrafield_local, uInt size_extrafield_local,
-	const void*extrafield_global, uInt size_extrafield_global,
-	const char* comment, int method, int level)
+extern int ZEXPORT zipOpenNewFileInZip (zipFile file, const char* filename, const zip_fileinfo* zipfi,
+                                        const void* extrafield_local, uInt size_extrafield_local,
+                                        const void*extrafield_global, uInt size_extrafield_global,
+                                        const char* comment, int method, int level)
 {
-	return zipOpenNewFileInZip4_64(file, filename, zipfi,
-		extrafield_local, size_extrafield_local,
-		extrafield_global, size_extrafield_global,
-		comment, method, level, 0,
-		-MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
-		NULL, 0, VERSIONMADEBY, 0, 0);
+    return zipOpenNewFileInZip4_64 (file, filename, zipfi,
+                                 extrafield_local, size_extrafield_local,
+                                 extrafield_global, size_extrafield_global,
+                                 comment, method, level, 0,
+                                 -MAX_WBITS, DEF_MEM_LEVEL, Z_DEFAULT_STRATEGY,
+                                 NULL, 0, VERSIONMADEBY, 0, 0);
 }
 
 local int zip64FlushWriteBuffer(zip64_internal* zi)
 {
-	int err = ZIP_OK;
+    int err=ZIP_OK;
 
-	if (zi->ci.encrypt != 0) {
-		#ifndef NOCRYPT
-		uInt i;
-		int t;
-		for (i = 0; i < zi->ci.pos_in_buffered_data; i++)
-			zi->ci.buffered_data[i] = zencode(zi->ci.keys, zi->ci.pcrc_32_tab, zi->ci.buffered_data[i], t);
-		#endif
-	}
+    if (zi->ci.encrypt != 0)
+    {
+#ifndef NOCRYPT
+        uInt i;
+        int t;
+        for (i=0;i<zi->ci.pos_in_buffered_data;i++)
+            zi->ci.buffered_data[i] = zencode(zi->ci.keys, zi->ci.pcrc_32_tab, zi->ci.buffered_data[i],t);
+#endif
+    }
 
-	if (ZWRITE64(zi->z_filefunc, zi->filestream, zi->ci.buffered_data, zi->ci.pos_in_buffered_data) != zi->ci.pos_in_buffered_data)
-		err = ZIP_ERRNO;
+    if (ZWRITE64(zi->z_filefunc,zi->filestream,zi->ci.buffered_data,zi->ci.pos_in_buffered_data) != zi->ci.pos_in_buffered_data)
+      err = ZIP_ERRNO;
 
-	zi->ci.totalCompressedData += zi->ci.pos_in_buffered_data;
+    zi->ci.totalCompressedData += zi->ci.pos_in_buffered_data;
 
-	#ifdef HAVE_BZIP2
-	if (zi->ci.method == Z_BZIP2ED) {
-		zi->ci.totalUncompressedData += zi->ci.bstream.total_in_lo32;
-		zi->ci.bstream.total_in_lo32 = 0;
-		zi->ci.bstream.total_in_hi32 = 0;
-	}
-	else
-		#endif
-	{
-		zi->ci.totalUncompressedData += zi->ci.stream.total_in;
-		zi->ci.stream.total_in = 0;
-	}
+#ifdef HAVE_BZIP2
+    if(zi->ci.method == Z_BZIP2ED)
+    {
+      zi->ci.totalUncompressedData += zi->ci.bstream.total_in_lo32;
+      zi->ci.bstream.total_in_lo32 = 0;
+      zi->ci.bstream.total_in_hi32 = 0;
+    }
+    else
+#endif
+    {
+      zi->ci.totalUncompressedData += zi->ci.stream.total_in;
+      zi->ci.stream.total_in = 0;
+    }
 
 
-	zi->ci.pos_in_buffered_data = 0;
+    zi->ci.pos_in_buffered_data = 0;
 
-	return err;
+    return err;
 }
 
-extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void* buf, unsigned int len)
+extern int ZEXPORT zipWriteInFileInZip (zipFile file,const void* buf,unsigned int len)
 {
-	zip64_internal* zi;
-	int err = ZIP_OK;
+    zip64_internal* zi;
+    int err=ZIP_OK;
 
-	if (file == NULL)
-		return ZIP_PARAMERROR;
-	zi = (zip64_internal*)file;
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip64_internal*)file;
 
-	if (zi->in_opened_file_inzip == 0)
-		return ZIP_PARAMERROR;
+    if (zi->in_opened_file_inzip == 0)
+        return ZIP_PARAMERROR;
 
-	zi->ci.crc32 = crc32(zi->ci.crc32, buf, (uInt)len);
+    zi->ci.crc32 = crc32(zi->ci.crc32,buf,(uInt)len);
 
-	#ifdef HAVE_BZIP2
-	if (zi->ci.method == Z_BZIP2ED && (!zi->ci.raw)) {
-		zi->ci.bstream.next_in = (void*)buf;
-		zi->ci.bstream.avail_in = len;
-		err = BZ_RUN_OK;
+#ifdef HAVE_BZIP2
+    if(zi->ci.method == Z_BZIP2ED && (!zi->ci.raw))
+    {
+      zi->ci.bstream.next_in = (void*)buf;
+      zi->ci.bstream.avail_in = len;
+      err = BZ_RUN_OK;
 
-		while ((err == BZ_RUN_OK) && (zi->ci.bstream.avail_in > 0)) {
-			if (zi->ci.bstream.avail_out == 0) {
-				if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
-					err = ZIP_ERRNO;
-				zi->ci.bstream.avail_out = (uInt)Z_BUFSIZE;
-				zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
-			}
-
-
-			if (err != BZ_RUN_OK)
-				break;
-
-			if ((zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw)) {
-				uLong uTotalOutBefore_lo = zi->ci.bstream.total_out_lo32;
-				//          uLong uTotalOutBefore_hi = zi->ci.bstream.total_out_hi32;
-				err = BZ2_bzCompress(&zi->ci.bstream, BZ_RUN);
-
-				zi->ci.pos_in_buffered_data += (uInt)(zi->ci.bstream.total_out_lo32 - uTotalOutBefore_lo);
-			}
-		}
-
-		if (err == BZ_RUN_OK)
-			err = ZIP_OK;
-	}
-	else
-		#endif
-	{
-		zi->ci.stream.next_in = (Bytef*)buf;
-		zi->ci.stream.avail_in = len;
-
-		while ((err == ZIP_OK) && (zi->ci.stream.avail_in > 0)) {
-			if (zi->ci.stream.avail_out == 0) {
-				if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
-					err = ZIP_ERRNO;
-				zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
-				zi->ci.stream.next_out = zi->ci.buffered_data;
-			}
+      while ((err==BZ_RUN_OK) && (zi->ci.bstream.avail_in>0))
+      {
+        if (zi->ci.bstream.avail_out == 0)
+        {
+          if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
+            err = ZIP_ERRNO;
+          zi->ci.bstream.avail_out = (uInt)Z_BUFSIZE;
+          zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
+        }
 
 
-			if (err != ZIP_OK)
-				break;
+        if(err != BZ_RUN_OK)
+          break;
 
-			if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw)) {
-				uLong uTotalOutBefore = zi->ci.stream.total_out;
-				err = deflate(&zi->ci.stream, Z_NO_FLUSH);
-				if (uTotalOutBefore > zi->ci.stream.total_out) {
-					int bBreak = 0;
-					bBreak++;
-				}
+        if ((zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw))
+        {
+          uLong uTotalOutBefore_lo = zi->ci.bstream.total_out_lo32;
+//          uLong uTotalOutBefore_hi = zi->ci.bstream.total_out_hi32;
+          err=BZ2_bzCompress(&zi->ci.bstream,  BZ_RUN);
 
-				zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - uTotalOutBefore);
-			}
-			else {
-				uInt copy_this, i;
-				if (zi->ci.stream.avail_in < zi->ci.stream.avail_out)
-					copy_this = zi->ci.stream.avail_in;
-				else
-					copy_this = zi->ci.stream.avail_out;
+          zi->ci.pos_in_buffered_data += (uInt)(zi->ci.bstream.total_out_lo32 - uTotalOutBefore_lo) ;
+        }
+      }
 
-				for (i = 0; i < copy_this; i++)
-					*(((char*)zi->ci.stream.next_out) + i) =
-					*(((const char*)zi->ci.stream.next_in) + i);
-				{
-					zi->ci.stream.avail_in -= copy_this;
-					zi->ci.stream.avail_out -= copy_this;
-					zi->ci.stream.next_in += copy_this;
-					zi->ci.stream.next_out += copy_this;
-					zi->ci.stream.total_in += copy_this;
-					zi->ci.stream.total_out += copy_this;
-					zi->ci.pos_in_buffered_data += copy_this;
-				}
-			}
-		}// while(...)
-	}
+      if(err == BZ_RUN_OK)
+        err = ZIP_OK;
+    }
+    else
+#endif
+    {
+      zi->ci.stream.next_in = (Bytef*)buf;
+      zi->ci.stream.avail_in = len;
 
-	return err;
+      while ((err==ZIP_OK) && (zi->ci.stream.avail_in>0))
+      {
+          if (zi->ci.stream.avail_out == 0)
+          {
+              if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
+                  err = ZIP_ERRNO;
+              zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
+              zi->ci.stream.next_out = zi->ci.buffered_data;
+          }
+
+
+          if(err != ZIP_OK)
+              break;
+
+          if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+          {
+              uLong uTotalOutBefore = zi->ci.stream.total_out;
+              err=deflate(&zi->ci.stream,  Z_NO_FLUSH);
+              if(uTotalOutBefore > zi->ci.stream.total_out)
+              {
+                int bBreak = 0;
+                bBreak++;
+              }
+
+              zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - uTotalOutBefore) ;
+          }
+          else
+          {
+              uInt copy_this,i;
+              if (zi->ci.stream.avail_in < zi->ci.stream.avail_out)
+                  copy_this = zi->ci.stream.avail_in;
+              else
+                  copy_this = zi->ci.stream.avail_out;
+
+              for (i = 0; i < copy_this; i++)
+                  *(((char*)zi->ci.stream.next_out)+i) =
+                      *(((const char*)zi->ci.stream.next_in)+i);
+              {
+                  zi->ci.stream.avail_in -= copy_this;
+                  zi->ci.stream.avail_out-= copy_this;
+                  zi->ci.stream.next_in+= copy_this;
+                  zi->ci.stream.next_out+= copy_this;
+                  zi->ci.stream.total_in+= copy_this;
+                  zi->ci.stream.total_out+= copy_this;
+                  zi->ci.pos_in_buffered_data += copy_this;
+              }
+          }
+      }// while(...)
+    }
+
+    return err;
 }
 
-extern int ZEXPORT zipCloseFileInZipRaw(zipFile file, uLong uncompressed_size, uLong crc32)
+extern int ZEXPORT zipCloseFileInZipRaw (zipFile file, uLong uncompressed_size, uLong crc32)
 {
-	return zipCloseFileInZipRaw64(file, uncompressed_size, crc32);
+    return zipCloseFileInZipRaw64 (file, uncompressed_size, crc32);
 }
 
-extern int ZEXPORT zipCloseFileInZipRaw64(zipFile file, ZPOS64_T uncompressed_size, uLong crc32)
+extern int ZEXPORT zipCloseFileInZipRaw64 (zipFile file, ZPOS64_T uncompressed_size, uLong crc32)
 {
-	zip64_internal* zi;
-	ZPOS64_T compressed_size;
-	uLong invalidValue = 0xffffffff;
-	short datasize = 0;
-	int err = ZIP_OK;
+    zip64_internal* zi;
+    ZPOS64_T compressed_size;
+    uLong invalidValue = 0xffffffff;
+    short datasize = 0;
+    int err=ZIP_OK;
 
-	if (file == NULL)
-		return ZIP_PARAMERROR;
-	zi = (zip64_internal*)file;
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip64_internal*)file;
 
-	if (zi->in_opened_file_inzip == 0)
-		return ZIP_PARAMERROR;
-	zi->ci.stream.avail_in = 0;
+    if (zi->in_opened_file_inzip == 0)
+        return ZIP_PARAMERROR;
+    zi->ci.stream.avail_in = 0;
 
-	if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw)) {
-		while (err == ZIP_OK) {
-			uLong uTotalOutBefore;
-			if (zi->ci.stream.avail_out == 0) {
-				if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
-					err = ZIP_ERRNO;
-				zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
-				zi->ci.stream.next_out = zi->ci.buffered_data;
-			}
-			uTotalOutBefore = zi->ci.stream.total_out;
-			err = deflate(&zi->ci.stream, Z_FINISH);
-			zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - uTotalOutBefore);
-		}
-	}
-	else if ((zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw)) {
-		#ifdef HAVE_BZIP2
-		err = BZ_FINISH_OK;
-		while (err == BZ_FINISH_OK) {
-			uLong uTotalOutBefore;
-			if (zi->ci.bstream.avail_out == 0) {
-				if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
-					err = ZIP_ERRNO;
-				zi->ci.bstream.avail_out = (uInt)Z_BUFSIZE;
-				zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
-			}
-			uTotalOutBefore = zi->ci.bstream.total_out_lo32;
-			err = BZ2_bzCompress(&zi->ci.bstream, BZ_FINISH);
-			if (err == BZ_STREAM_END)
-				err = Z_STREAM_END;
+    if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+                {
+                        while (err==ZIP_OK)
+                        {
+                                uLong uTotalOutBefore;
+                                if (zi->ci.stream.avail_out == 0)
+                                {
+                                        if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
+                                                err = ZIP_ERRNO;
+                                        zi->ci.stream.avail_out = (uInt)Z_BUFSIZE;
+                                        zi->ci.stream.next_out = zi->ci.buffered_data;
+                                }
+                                uTotalOutBefore = zi->ci.stream.total_out;
+                                err=deflate(&zi->ci.stream,  Z_FINISH);
+                                zi->ci.pos_in_buffered_data += (uInt)(zi->ci.stream.total_out - uTotalOutBefore) ;
+                        }
+                }
+    else if ((zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw))
+    {
+#ifdef HAVE_BZIP2
+      err = BZ_FINISH_OK;
+      while (err==BZ_FINISH_OK)
+      {
+        uLong uTotalOutBefore;
+        if (zi->ci.bstream.avail_out == 0)
+        {
+          if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
+            err = ZIP_ERRNO;
+          zi->ci.bstream.avail_out = (uInt)Z_BUFSIZE;
+          zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
+        }
+        uTotalOutBefore = zi->ci.bstream.total_out_lo32;
+        err=BZ2_bzCompress(&zi->ci.bstream,  BZ_FINISH);
+        if(err == BZ_STREAM_END)
+          err = Z_STREAM_END;
 
-			zi->ci.pos_in_buffered_data += (uInt)(zi->ci.bstream.total_out_lo32 - uTotalOutBefore);
-		}
+        zi->ci.pos_in_buffered_data += (uInt)(zi->ci.bstream.total_out_lo32 - uTotalOutBefore);
+      }
 
-		if (err == BZ_FINISH_OK)
-			err = ZIP_OK;
-		#endif
-	}
+      if(err == BZ_FINISH_OK)
+        err = ZIP_OK;
+#endif
+    }
 
-	if (err == Z_STREAM_END)
-		err = ZIP_OK; /* this is normal */
+    if (err==Z_STREAM_END)
+        err=ZIP_OK; /* this is normal */
 
-	if ((zi->ci.pos_in_buffered_data > 0) && (err == ZIP_OK)) {
-		if (zip64FlushWriteBuffer(zi) == ZIP_ERRNO)
-			err = ZIP_ERRNO;
-	}
+    if ((zi->ci.pos_in_buffered_data>0) && (err==ZIP_OK))
+                {
+        if (zip64FlushWriteBuffer(zi)==ZIP_ERRNO)
+            err = ZIP_ERRNO;
+                }
 
-	if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw)) {
-		int tmp_err = deflateEnd(&zi->ci.stream);
-		if (err == ZIP_OK)
-			err = tmp_err;
-		zi->ci.stream_initialised = 0;
-	}
-	#ifdef HAVE_BZIP2
-	else if ((zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw)) {
-		int tmperr = BZ2_bzCompressEnd(&zi->ci.bstream);
-		if (err == ZIP_OK)
-			err = tmperr;
-		zi->ci.stream_initialised = 0;
-	}
-	#endif
+    if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
+    {
+        int tmp_err = deflateEnd(&zi->ci.stream);
+        if (err == ZIP_OK)
+            err = tmp_err;
+        zi->ci.stream_initialised = 0;
+    }
+#ifdef HAVE_BZIP2
+    else if((zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw))
+    {
+      int tmperr = BZ2_bzCompressEnd(&zi->ci.bstream);
+                        if (err==ZIP_OK)
+                                err = tmperr;
+                        zi->ci.stream_initialised = 0;
+    }
+#endif
 
-	if (!zi->ci.raw) {
-		crc32 = (uLong)zi->ci.crc32;
-		uncompressed_size = zi->ci.totalUncompressedData;
-	}
-	compressed_size = zi->ci.totalCompressedData;
+    if (!zi->ci.raw)
+    {
+        crc32 = (uLong)zi->ci.crc32;
+        uncompressed_size = zi->ci.totalUncompressedData;
+    }
+    compressed_size = zi->ci.totalCompressedData;
 
-	#    ifndef NOCRYPT
-	compressed_size += zi->ci.crypt_header_size;
-	#    endif
+#    ifndef NOCRYPT
+    compressed_size += zi->ci.crypt_header_size;
+#    endif
 
-	// update Current Item crc and sizes,
-	if (compressed_size >= 0xffffffff || uncompressed_size >= 0xffffffff || zi->ci.pos_local_header >= 0xffffffff) {
-		/*version Made by*/
-		zip64local_putValue_inmemory(zi->ci.central_header + 4, (uLong)45, 2);
-		/*version needed*/
-		zip64local_putValue_inmemory(zi->ci.central_header + 6, (uLong)45, 2);
+    // update Current Item crc and sizes,
+    if(compressed_size >= 0xffffffff || uncompressed_size >= 0xffffffff || zi->ci.pos_local_header >= 0xffffffff)
+    {
+      /*version Made by*/
+      zip64local_putValue_inmemory(zi->ci.central_header+4,(uLong)45,2);
+      /*version needed*/
+      zip64local_putValue_inmemory(zi->ci.central_header+6,(uLong)45,2);
 
-	}
+    }
 
-	zip64local_putValue_inmemory(zi->ci.central_header + 16, crc32, 4); /*crc*/
+    zip64local_putValue_inmemory(zi->ci.central_header+16,crc32,4); /*crc*/
 
 
-	if (compressed_size >= 0xffffffff)
-		zip64local_putValue_inmemory(zi->ci.central_header + 20, invalidValue, 4); /*compr size*/
-	else
-		zip64local_putValue_inmemory(zi->ci.central_header + 20, compressed_size, 4); /*compr size*/
+    if(compressed_size >= 0xffffffff)
+      zip64local_putValue_inmemory(zi->ci.central_header+20, invalidValue,4); /*compr size*/
+    else
+      zip64local_putValue_inmemory(zi->ci.central_header+20, compressed_size,4); /*compr size*/
 
-	 /// set internal file attributes field
-	if (zi->ci.stream.data_type == Z_ASCII)
-		zip64local_putValue_inmemory(zi->ci.central_header + 36, (uLong)Z_ASCII, 2);
+    /// set internal file attributes field
+    if (zi->ci.stream.data_type == Z_ASCII)
+        zip64local_putValue_inmemory(zi->ci.central_header+36,(uLong)Z_ASCII,2);
 
-	if (uncompressed_size >= 0xffffffff)
-		zip64local_putValue_inmemory(zi->ci.central_header + 24, invalidValue, 4); /*uncompr size*/
-	else
-		zip64local_putValue_inmemory(zi->ci.central_header + 24, uncompressed_size, 4); /*uncompr size*/
+    if(uncompressed_size >= 0xffffffff)
+      zip64local_putValue_inmemory(zi->ci.central_header+24, invalidValue,4); /*uncompr size*/
+    else
+      zip64local_putValue_inmemory(zi->ci.central_header+24, uncompressed_size,4); /*uncompr size*/
 
-	 // Add ZIP64 extra info field for uncompressed size
-	if (uncompressed_size >= 0xffffffff)
-		datasize += 8;
+    // Add ZIP64 extra info field for uncompressed size
+    if(uncompressed_size >= 0xffffffff)
+      datasize += 8;
 
-	// Add ZIP64 extra info field for compressed size
-	if (compressed_size >= 0xffffffff)
-		datasize += 8;
+    // Add ZIP64 extra info field for compressed size
+    if(compressed_size >= 0xffffffff)
+      datasize += 8;
 
-	// Add ZIP64 extra info field for relative offset to local file header of current file
-	if (zi->ci.pos_local_header >= 0xffffffff)
-		datasize += 8;
+    // Add ZIP64 extra info field for relative offset to local file header of current file
+    if(zi->ci.pos_local_header >= 0xffffffff)
+      datasize += 8;
 
-	if (datasize > 0) {
-		char* p = NULL;
+    if(datasize > 0)
+    {
+      char* p = NULL;
 
-		if ((uLong)(datasize + 4) > zi->ci.size_centralExtraFree) {
-			// we can not write more data to the buffer that we have room for.
-			return ZIP_BADZIPFILE;
-		}
+      if((uLong)(datasize + 4) > zi->ci.size_centralExtraFree)
+      {
+        // we can not write more data to the buffer that we have room for.
+        return ZIP_BADZIPFILE;
+      }
 
-		p = zi->ci.central_header + zi->ci.size_centralheader;
+      p = zi->ci.central_header + zi->ci.size_centralheader;
 
-		// Add Extra Information Header for 'ZIP64 information'
-		zip64local_putValue_inmemory(p, 0x0001, 2); // HeaderID
-		p += 2;
-		zip64local_putValue_inmemory(p, datasize, 2); // DataSize
-		p += 2;
+      // Add Extra Information Header for 'ZIP64 information'
+      zip64local_putValue_inmemory(p, 0x0001, 2); // HeaderID
+      p += 2;
+      zip64local_putValue_inmemory(p, datasize, 2); // DataSize
+      p += 2;
 
-		if (uncompressed_size >= 0xffffffff) {
-			zip64local_putValue_inmemory(p, uncompressed_size, 8);
-			p += 8;
-		}
+      if(uncompressed_size >= 0xffffffff)
+      {
+        zip64local_putValue_inmemory(p, uncompressed_size, 8);
+        p += 8;
+      }
 
-		if (compressed_size >= 0xffffffff) {
-			zip64local_putValue_inmemory(p, compressed_size, 8);
-			p += 8;
-		}
+      if(compressed_size >= 0xffffffff)
+      {
+        zip64local_putValue_inmemory(p, compressed_size, 8);
+        p += 8;
+      }
 
-		if (zi->ci.pos_local_header >= 0xffffffff) {
-			zip64local_putValue_inmemory(p, zi->ci.pos_local_header, 8);
-			p += 8;
-		}
+      if(zi->ci.pos_local_header >= 0xffffffff)
+      {
+        zip64local_putValue_inmemory(p, zi->ci.pos_local_header, 8);
+        p += 8;
+      }
 
-		// Update how much extra free space we got in the memory buffer
-		// and increase the centralheader size so the new ZIP64 fields are included
-		// ( 4 below is the size of HeaderID and DataSize field )
-		zi->ci.size_centralExtraFree -= datasize + 4;
-		zi->ci.size_centralheader += datasize + 4;
+      // Update how much extra free space we got in the memory buffer
+      // and increase the centralheader size so the new ZIP64 fields are included
+      // ( 4 below is the size of HeaderID and DataSize field )
+      zi->ci.size_centralExtraFree -= datasize + 4;
+      zi->ci.size_centralheader += datasize + 4;
 
-		// Update the extra info size field
-		zi->ci.size_centralExtra += datasize + 4;
-		zip64local_putValue_inmemory(zi->ci.central_header + 30, (uLong)zi->ci.size_centralExtra, 2);
-	}
+      // Update the extra info size field
+      zi->ci.size_centralExtra += datasize + 4;
+      zip64local_putValue_inmemory(zi->ci.central_header+30,(uLong)zi->ci.size_centralExtra,2);
+    }
 
-	if (err == ZIP_OK)
-		err = add_data_in_datablock(&zi->central_dir, zi->ci.central_header, (uLong)zi->ci.size_centralheader);
+    if (err==ZIP_OK)
+        err = add_data_in_datablock(&zi->central_dir, zi->ci.central_header, (uLong)zi->ci.size_centralheader);
 
-	free(zi->ci.central_header);
+    free(zi->ci.central_header);
 
-	if (err == ZIP_OK) {
-		// Update the LocalFileHeader with the new values.
+    if (err==ZIP_OK)
+    {
+        // Update the LocalFileHeader with the new values.
 
-		ZPOS64_T cur_pos_inzip = ZTELL64(zi->z_filefunc, zi->filestream);
+        ZPOS64_T cur_pos_inzip = ZTELL64(zi->z_filefunc,zi->filestream);
 
-		if (ZSEEK64(zi->z_filefunc, zi->filestream, zi->ci.pos_local_header + 14, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			err = ZIP_ERRNO;
+        if (ZSEEK64(zi->z_filefunc,zi->filestream, zi->ci.pos_local_header + 14,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            err = ZIP_ERRNO;
 
-		if (err == ZIP_OK)
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, crc32, 4); /* crc 32, unknown */
+        if (err==ZIP_OK)
+            err = zip64local_putValue(&zi->z_filefunc,zi->filestream,crc32,4); /* crc 32, unknown */
 
-		if (uncompressed_size >= 0xffffffff || compressed_size >= 0xffffffff) {
-			if (zi->ci.pos_zip64extrainfo > 0) {
-				// Update the size in the ZIP64 extended field.
-				if (ZSEEK64(zi->z_filefunc, zi->filestream, zi->ci.pos_zip64extrainfo + 4, ZLIB_FILEFUNC_SEEK_SET) != 0)
-					err = ZIP_ERRNO;
+        if(uncompressed_size >= 0xffffffff || compressed_size >= 0xffffffff )
+        {
+          if(zi->ci.pos_zip64extrainfo > 0)
+          {
+            // Update the size in the ZIP64 extended field.
+            if (ZSEEK64(zi->z_filefunc,zi->filestream, zi->ci.pos_zip64extrainfo + 4,ZLIB_FILEFUNC_SEEK_SET)!=0)
+              err = ZIP_ERRNO;
 
-				if (err == ZIP_OK) /* compressed size, unknown */
-					err = zip64local_putValue(&zi->z_filefunc, zi->filestream, uncompressed_size, 8);
+            if (err==ZIP_OK) /* compressed size, unknown */
+              err = zip64local_putValue(&zi->z_filefunc, zi->filestream, uncompressed_size, 8);
 
-				if (err == ZIP_OK) /* uncompressed size, unknown */
-					err = zip64local_putValue(&zi->z_filefunc, zi->filestream, compressed_size, 8);
-			}
-			else
-				err = ZIP_BADZIPFILE; // Caller passed zip64 = 0, so no room for zip64 info -> fatal
-		}
-		else {
-			if (err == ZIP_OK) /* compressed size, unknown */
-				err = zip64local_putValue(&zi->z_filefunc, zi->filestream, compressed_size, 4);
+            if (err==ZIP_OK) /* uncompressed size, unknown */
+              err = zip64local_putValue(&zi->z_filefunc, zi->filestream, compressed_size, 8);
+          }
+          else
+              err = ZIP_BADZIPFILE; // Caller passed zip64 = 0, so no room for zip64 info -> fatal
+        }
+        else
+        {
+          if (err==ZIP_OK) /* compressed size, unknown */
+              err = zip64local_putValue(&zi->z_filefunc,zi->filestream,compressed_size,4);
 
-			if (err == ZIP_OK) /* uncompressed size, unknown */
-				err = zip64local_putValue(&zi->z_filefunc, zi->filestream, uncompressed_size, 4);
-		}
+          if (err==ZIP_OK) /* uncompressed size, unknown */
+              err = zip64local_putValue(&zi->z_filefunc,zi->filestream,uncompressed_size,4);
+        }
 
-		if (ZSEEK64(zi->z_filefunc, zi->filestream, cur_pos_inzip, ZLIB_FILEFUNC_SEEK_SET) != 0)
-			err = ZIP_ERRNO;
-	}
+        if (ZSEEK64(zi->z_filefunc,zi->filestream, cur_pos_inzip,ZLIB_FILEFUNC_SEEK_SET)!=0)
+            err = ZIP_ERRNO;
+    }
 
-	zi->number_entry++;
-	zi->in_opened_file_inzip = 0;
+    zi->number_entry ++;
+    zi->in_opened_file_inzip = 0;
 
-	return err;
+    return err;
 }
 
-extern int ZEXPORT zipCloseFileInZip(zipFile file)
+extern int ZEXPORT zipCloseFileInZip (zipFile file)
 {
-	return zipCloseFileInZipRaw(file, 0, 0);
+    return zipCloseFileInZipRaw (file,0,0);
 }
 
 int Write_Zip64EndOfCentralDirectoryLocator(zip64_internal* zi, ZPOS64_T zip64eocd_pos_inzip)
 {
-	int err = ZIP_OK;
-	ZPOS64_T pos = zip64eocd_pos_inzip - zi->add_position_when_writting_offset;
+  int err = ZIP_OK;
+  ZPOS64_T pos = zip64eocd_pos_inzip - zi->add_position_when_writing_offset;
 
-	err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)ZIP64ENDLOCHEADERMAGIC, 4);
+  err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)ZIP64ENDLOCHEADERMAGIC,4);
 
-	/*num disks*/
-	if (err == ZIP_OK) /* number of the disk with the start of the central directory */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 4);
+  /*num disks*/
+    if (err==ZIP_OK) /* number of the disk with the start of the central directory */
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4);
 
-	/*relative offset*/
-	if (err == ZIP_OK) /* Relative offset to the Zip64EndOfCentralDirectory */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, pos, 8);
+  /*relative offset*/
+    if (err==ZIP_OK) /* Relative offset to the Zip64EndOfCentralDirectory */
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream, pos,8);
 
-	/*total disks*/ /* Do not support spawning of disk so always say 1 here*/
-	if (err == ZIP_OK) /* number of the disk with the start of the central directory */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)1, 4);
+  /*total disks*/ /* Do not support spawning of disk so always say 1 here*/
+    if (err==ZIP_OK) /* number of the disk with the start of the central directory */
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)1,4);
 
-	return err;
+    return err;
 }
 
 int Write_Zip64EndOfCentralDirectoryRecord(zip64_internal* zi, uLong size_centraldir, ZPOS64_T centraldir_pos_inzip)
 {
-	int err = ZIP_OK;
+  int err = ZIP_OK;
 
-	uLong Zip64DataSize = 44;
+  uLong Zip64DataSize = 44;
 
-	err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)ZIP64ENDHEADERMAGIC, 4);
+  err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)ZIP64ENDHEADERMAGIC,4);
 
-	if (err == ZIP_OK) /* size of this 'zip64 end of central directory' */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)Zip64DataSize, 8); // why ZPOS64_T of this ?
+  if (err==ZIP_OK) /* size of this 'zip64 end of central directory' */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(ZPOS64_T)Zip64DataSize,8); // why ZPOS64_T of this ?
 
-	if (err == ZIP_OK) /* version made by */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)45, 2);
+  if (err==ZIP_OK) /* version made by */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)45,2);
 
-	if (err == ZIP_OK) /* version needed */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)45, 2);
+  if (err==ZIP_OK) /* version needed */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)45,2);
 
-	if (err == ZIP_OK) /* number of this disk */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 4);
+  if (err==ZIP_OK) /* number of this disk */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4);
 
-	if (err == ZIP_OK) /* number of the disk with the start of the central directory */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 4);
+  if (err==ZIP_OK) /* number of the disk with the start of the central directory */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,4);
 
-	if (err == ZIP_OK) /* total number of entries in the central dir on this disk */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, zi->number_entry, 8);
+  if (err==ZIP_OK) /* total number of entries in the central dir on this disk */
+    err = zip64local_putValue(&zi->z_filefunc, zi->filestream, zi->number_entry, 8);
 
-	if (err == ZIP_OK) /* total number of entries in the central dir */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, zi->number_entry, 8);
+  if (err==ZIP_OK) /* total number of entries in the central dir */
+    err = zip64local_putValue(&zi->z_filefunc, zi->filestream, zi->number_entry, 8);
 
-	if (err == ZIP_OK) /* size of the central directory */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)size_centraldir, 8);
+  if (err==ZIP_OK) /* size of the central directory */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(ZPOS64_T)size_centraldir,8);
 
-	if (err == ZIP_OK) /* offset of start of central directory with respect to the starting disk number */
-	{
-		ZPOS64_T pos = centraldir_pos_inzip - zi->add_position_when_writting_offset;
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (ZPOS64_T)pos, 8);
-	}
-	return err;
+  if (err==ZIP_OK) /* offset of start of central directory with respect to the starting disk number */
+  {
+    ZPOS64_T pos = centraldir_pos_inzip - zi->add_position_when_writing_offset;
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream, (ZPOS64_T)pos,8);
+  }
+  return err;
 }
 int Write_EndOfCentralDirectoryRecord(zip64_internal* zi, uLong size_centraldir, ZPOS64_T centraldir_pos_inzip)
 {
-	int err = ZIP_OK;
+  int err = ZIP_OK;
 
-	/*signature*/
-	err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)ENDHEADERMAGIC, 4);
+  /*signature*/
+  err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)ENDHEADERMAGIC,4);
 
-	if (err == ZIP_OK) /* number of this disk */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 2);
+  if (err==ZIP_OK) /* number of this disk */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,2);
 
-	if (err == ZIP_OK) /* number of the disk with the start of the central directory */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0, 2);
+  if (err==ZIP_OK) /* number of the disk with the start of the central directory */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0,2);
 
-	if (err == ZIP_OK) /* total number of entries in the central dir on this disk */
-	{
-		{
-			if (zi->number_entry >= 0xFFFF)
-				err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0xffff, 2); // use value in ZIP64 record
-			else
-				err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)zi->number_entry, 2);
-		}
-	}
+  if (err==ZIP_OK) /* total number of entries in the central dir on this disk */
+  {
+    {
+      if(zi->number_entry >= 0xFFFF)
+        err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0xffff,2); // use value in ZIP64 record
+      else
+        err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->number_entry,2);
+    }
+  }
 
-	if (err == ZIP_OK) /* total number of entries in the central dir */
-	{
-		if (zi->number_entry >= 0xFFFF)
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0xffff, 2); // use value in ZIP64 record
-		else
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)zi->number_entry, 2);
-	}
+  if (err==ZIP_OK) /* total number of entries in the central dir */
+  {
+    if(zi->number_entry >= 0xFFFF)
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)0xffff,2); // use value in ZIP64 record
+    else
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)zi->number_entry,2);
+  }
 
-	if (err == ZIP_OK) /* size of the central directory */
-		err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)size_centraldir, 4);
+  if (err==ZIP_OK) /* size of the central directory */
+    err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_centraldir,4);
 
-	if (err == ZIP_OK) /* offset of start of central directory with respect to the starting disk number */
-	{
-		ZPOS64_T pos = centraldir_pos_inzip - zi->add_position_when_writting_offset;
-		if (pos >= 0xffffffff) {
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)0xffffffff, 4);
-		}
-		else
-			err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)(centraldir_pos_inzip - zi->add_position_when_writting_offset), 4);
-	}
+  if (err==ZIP_OK) /* offset of start of central directory with respect to the starting disk number */
+  {
+    ZPOS64_T pos = centraldir_pos_inzip - zi->add_position_when_writing_offset;
+    if(pos >= 0xffffffff)
+    {
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream, (uLong)0xffffffff,4);
+    }
+    else
+      err = zip64local_putValue(&zi->z_filefunc,zi->filestream, (uLong)(centraldir_pos_inzip - zi->add_position_when_writing_offset),4);
+  }
 
-	return err;
+   return err;
 }
 
 int Write_GlobalComment(zip64_internal* zi, const char* global_comment)
 {
-	int err = ZIP_OK;
-	uInt size_global_comment = 0;
+  int err = ZIP_OK;
+  uInt size_global_comment = 0;
 
-	if (global_comment != NULL)
-		size_global_comment = (uInt)strlen(global_comment);
+  if(global_comment != NULL)
+    size_global_comment = (uInt)strlen(global_comment);
 
-	err = zip64local_putValue(&zi->z_filefunc, zi->filestream, (uLong)size_global_comment, 2);
+  err = zip64local_putValue(&zi->z_filefunc,zi->filestream,(uLong)size_global_comment,2);
 
-	if (err == ZIP_OK && size_global_comment > 0) {
-		if (ZWRITE64(zi->z_filefunc, zi->filestream, global_comment, size_global_comment) != size_global_comment)
-			err = ZIP_ERRNO;
-	}
-	return err;
+  if (err == ZIP_OK && size_global_comment > 0)
+  {
+    if (ZWRITE64(zi->z_filefunc,zi->filestream, global_comment, size_global_comment) != size_global_comment)
+      err = ZIP_ERRNO;
+  }
+  return err;
 }
 
-extern int ZEXPORT zipClose(zipFile file, const char* global_comment)
+extern int ZEXPORT zipClose (zipFile file, const char* global_comment)
 {
-	zip64_internal* zi;
-	int err = 0;
-	uLong size_centraldir = 0;
-	ZPOS64_T centraldir_pos_inzip;
-	ZPOS64_T pos;
+    zip64_internal* zi;
+    int err = 0;
+    uLong size_centraldir = 0;
+    ZPOS64_T centraldir_pos_inzip;
+    ZPOS64_T pos;
 
-	if (file == NULL)
-		return ZIP_PARAMERROR;
+    if (file == NULL)
+        return ZIP_PARAMERROR;
 
-	zi = (zip64_internal*)file;
+    zi = (zip64_internal*)file;
 
-	if (zi->in_opened_file_inzip == 1) {
-		err = zipCloseFileInZip(file);
-	}
+    if (zi->in_opened_file_inzip == 1)
+    {
+        err = zipCloseFileInZip (file);
+    }
 
-	#ifndef NO_ADDFILEINEXISTINGZIP
-	if (global_comment == NULL)
-		global_comment = zi->globalcomment;
-	#endif
+#ifndef NO_ADDFILEINEXISTINGZIP
+    if (global_comment==NULL)
+        global_comment = zi->globalcomment;
+#endif
 
-	centraldir_pos_inzip = ZTELL64(zi->z_filefunc, zi->filestream);
+    centraldir_pos_inzip = ZTELL64(zi->z_filefunc,zi->filestream);
 
-	if (err == ZIP_OK) {
-		linkedlist_datablock_internal* ldi = zi->central_dir.first_block;
-		while (ldi != NULL) {
-			if ((err == ZIP_OK) && (ldi->filled_in_this_block > 0)) {
-				if (ZWRITE64(zi->z_filefunc, zi->filestream, ldi->data, ldi->filled_in_this_block) != ldi->filled_in_this_block)
-					err = ZIP_ERRNO;
-			}
+    if (err==ZIP_OK)
+    {
+        linkedlist_datablock_internal* ldi = zi->central_dir.first_block;
+        while (ldi!=NULL)
+        {
+            if ((err==ZIP_OK) && (ldi->filled_in_this_block>0))
+            {
+                if (ZWRITE64(zi->z_filefunc,zi->filestream, ldi->data, ldi->filled_in_this_block) != ldi->filled_in_this_block)
+                    err = ZIP_ERRNO;
+            }
 
-			size_centraldir += ldi->filled_in_this_block;
-			ldi = ldi->next_datablock;
-		}
-	}
-	free_linkedlist(&(zi->central_dir));
+            size_centraldir += ldi->filled_in_this_block;
+            ldi = ldi->next_datablock;
+        }
+    }
+    free_linkedlist(&(zi->central_dir));
 
-	pos = centraldir_pos_inzip - zi->add_position_when_writting_offset;
-	if (pos >= 0xffffffff || zi->number_entry > 0xFFFF) {
-		ZPOS64_T Zip64EOCDpos = ZTELL64(zi->z_filefunc, zi->filestream);
-		Write_Zip64EndOfCentralDirectoryRecord(zi, size_centraldir, centraldir_pos_inzip);
+    pos = centraldir_pos_inzip - zi->add_position_when_writing_offset;
+    if(pos >= 0xffffffff || zi->number_entry > 0xFFFF)
+    {
+      ZPOS64_T Zip64EOCDpos = ZTELL64(zi->z_filefunc,zi->filestream);
+      Write_Zip64EndOfCentralDirectoryRecord(zi, size_centraldir, centraldir_pos_inzip);
 
-		Write_Zip64EndOfCentralDirectoryLocator(zi, Zip64EOCDpos);
-	}
+      Write_Zip64EndOfCentralDirectoryLocator(zi, Zip64EOCDpos);
+    }
 
-	if (err == ZIP_OK)
-		err = Write_EndOfCentralDirectoryRecord(zi, size_centraldir, centraldir_pos_inzip);
+    if (err==ZIP_OK)
+      err = Write_EndOfCentralDirectoryRecord(zi, size_centraldir, centraldir_pos_inzip);
 
-	if (err == ZIP_OK)
-		err = Write_GlobalComment(zi, global_comment);
+    if(err == ZIP_OK)
+      err = Write_GlobalComment(zi, global_comment);
 
-	if (ZCLOSE64(zi->z_filefunc, zi->filestream) != 0)
-		if (err == ZIP_OK)
-			err = ZIP_ERRNO;
+    if (ZCLOSE64(zi->z_filefunc,zi->filestream) != 0)
+        if (err == ZIP_OK)
+            err = ZIP_ERRNO;
 
-	#ifndef NO_ADDFILEINEXISTINGZIP
-	TRYFREE(zi->globalcomment);
-	#endif
-	TRYFREE(zi);
+#ifndef NO_ADDFILEINEXISTINGZIP
+    TRYFREE(zi->globalcomment);
+#endif
+    TRYFREE(zi);
 
-	return err;
+    return err;
 }
 
-extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHeader)
+extern int ZEXPORT zipRemoveExtraInfoBlock (char* pData, int* dataLen, short sHeader)
 {
-	char* p = pData;
-	int size = 0;
-	char* pNewHeader;
-	char* pTmp;
-	short header;
-	short dataSize;
+  char* p = pData;
+  int size = 0;
+  char* pNewHeader;
+  char* pTmp;
+  short header;
+  short dataSize;
 
-	int retVal = ZIP_OK;
+  int retVal = ZIP_OK;
 
-	if (pData == NULL || *dataLen < 4)
-		return ZIP_PARAMERROR;
+  if(pData == NULL || *dataLen < 4)
+    return ZIP_PARAMERROR;
 
-	pNewHeader = (char*)ALLOC(*dataLen);
-	pTmp = pNewHeader;
+  pNewHeader = (char*)ALLOC(*dataLen);
+  pTmp = pNewHeader;
 
-	while (p < (pData + *dataLen)) {
-		header = *(short*)p;
-		dataSize = *(((short*)p) + 1);
+  while(p < (pData + *dataLen))
+  {
+    header = *(short*)p;
+    dataSize = *(((short*)p)+1);
 
-		if (header == sHeader) // Header found.
-		{
-			p += dataSize + 4; // skip it. do not copy to temp buffer
-		}
-		else {
-			// Extra Info block should not be removed, So copy it to the temp buffer.
-			memcpy(pTmp, p, dataSize + 4);
-			p += dataSize + 4;
-			size += dataSize + 4;
-		}
+    if( header == sHeader ) // Header found.
+    {
+      p += dataSize + 4; // skip it. do not copy to temp buffer
+    }
+    else
+    {
+      // Extra Info block should not be removed, So copy it to the temp buffer.
+      memcpy(pTmp, p, dataSize + 4);
+      p += dataSize + 4;
+      size += dataSize + 4;
+    }
 
-	}
+  }
 
-	if (size < *dataLen) {
-		// clean old extra info block.
-		memset(pData, 0, *dataLen);
+  if(size < *dataLen)
+  {
+    // clean old extra info block.
+    memset(pData,0, *dataLen);
 
-		// copy the new extra info block over the old
-		if (size > 0)
-			memcpy(pData, pNewHeader, size);
+    // copy the new extra info block over the old
+    if(size > 0)
+      memcpy(pData, pNewHeader, size);
 
-		// set the new extra info size
-		*dataLen = size;
+    // set the new extra info size
+    *dataLen = size;
 
-		retVal = ZIP_OK;
-	}
-	else
-		retVal = ZIP_ERRNO;
+    retVal = ZIP_OK;
+  }
+  else
+    retVal = ZIP_ERRNO;
 
-	TRYFREE(pNewHeader);
+  TRYFREE(pNewHeader);
 
-	return retVal;
+  return retVal;
 }

--- a/libs/zlib/src/zlib.def
+++ b/libs/zlib/src/zlib.def
@@ -1,5 +1,4 @@
 ; zlib data compression library
-LIBRARY zlib.mir
 EXPORTS
 ; basic functions
     zlibVersion
@@ -9,6 +8,7 @@ EXPORTS
     inflateEnd
 ; advanced functions
     deflateSetDictionary
+    deflateGetDictionary
     deflateCopy
     deflateReset
     deflateParams
@@ -34,12 +34,15 @@ EXPORTS
     compress2
     compressBound
     uncompress
+    uncompress2
     gzopen
     gzdopen
     gzbuffer
     gzsetparams
     gzread
+    gzfread
     gzwrite
+    gzfwrite
     gzprintf
     gzvprintf
     gzputs
@@ -68,7 +71,9 @@ EXPORTS
     crc32_combine64
 ; checksum functions
     adler32
+    adler32_z
     crc32
+    crc32_z
     adler32_combine
     crc32_combine
 ; various hacks, don't look :)
@@ -82,26 +87,8 @@ EXPORTS
     inflateSyncPoint
     get_crc_table
     inflateUndermine
+    inflateValidate
+    inflateCodesUsed
     inflateResetKeep
     deflateResetKeep
     gzopen_w
-; minizip functions
-    zipOpen2
-    zipOpenNewFileInZip4_64
-    zipWriteInFileInZip
-    zipCloseFileInZip
-    zipClose
-    unzOpen2
-    unzClose
-    unzGoToNextFile
-    unzGetCurrentFileInfo
-    unzOpenCurrentFilePassword
-    unzCloseCurrentFile
-    unzReadCurrentFile
-    fill_win32_filefunc
-    unzGetCurrentFileInfo64
-    unzOpenCurrentFile
-    fill_fopen64_filefunc
-    unzOpen2_64
-    zipOpen2_64
-    zipOpenNewFileInZip

--- a/libs/zlib/src/zlib.def
+++ b/libs/zlib/src/zlib.def
@@ -1,4 +1,5 @@
 ; zlib data compression library
+LIBRARY zlib.mir
 EXPORTS
 ; basic functions
     zlibVersion
@@ -92,3 +93,23 @@ EXPORTS
     inflateResetKeep
     deflateResetKeep
     gzopen_w
+; minizip functions
+    zipOpen2
+    zipOpenNewFileInZip4_64
+    zipWriteInFileInZip
+    zipCloseFileInZip
+    zipClose
+    unzOpen2
+    unzClose
+    unzGoToNextFile
+    unzGetCurrentFileInfo
+    unzOpenCurrentFilePassword
+    unzCloseCurrentFile
+    unzReadCurrentFile
+    fill_win32_filefunc
+    unzGetCurrentFileInfo64
+    unzOpenCurrentFile
+    fill_fopen64_filefunc
+    unzOpen2_64
+    zipOpen2_64
+    zipOpenNewFileInZip

--- a/libs/zlib/src/zlib.h
+++ b/libs/zlib/src/zlib.h
@@ -1,7 +1,7 @@
 /* zlib.h -- interface of the 'zlib' general purpose compression library
-  version 1.2.8, April 28th, 2013
+  version 1.2.11, January 15th, 2017
 
-  Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
+  Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -37,11 +37,11 @@
 extern "C" {
 #endif
 
-#define ZLIB_VERSION "1.2.8"
-#define ZLIB_VERNUM 0x1280
+#define ZLIB_VERSION "1.2.11"
+#define ZLIB_VERNUM 0x12b0
 #define ZLIB_VER_MAJOR 1
 #define ZLIB_VER_MINOR 2
-#define ZLIB_VER_REVISION 8
+#define ZLIB_VER_REVISION 11
 #define ZLIB_VER_SUBREVISION 0
 
 /*
@@ -65,7 +65,8 @@ extern "C" {
   with "gz".  The gzip format is different from the zlib format.  gzip is a
   gzip wrapper, documented in RFC 1952, wrapped around a deflate stream.
 
-    This library can optionally read and write gzip streams in memory as well.
+    This library can optionally read and write gzip and raw deflate streams in
+  memory as well.
 
     The zlib format was designed to be compact and fast for use in memory
   and on communications channels.  The gzip format was designed for single-
@@ -74,7 +75,7 @@ extern "C" {
 
     The library does not install any signal handler.  The decoder checks
   the consistency of the compressed data, so the library should never crash
-  even in case of corrupted input.
+  even in the case of corrupted input.
 */
 
 typedef voidpf (*alloc_func) OF((voidpf opaque, uInt items, uInt size));
@@ -87,7 +88,7 @@ typedef struct z_stream_s {
     uInt     avail_in;  /* number of bytes available at next_in */
     uLong    total_in;  /* total number of input bytes read so far */
 
-    Bytef    *next_out; /* next output byte should be put there */
+    Bytef    *next_out; /* next output byte will go here */
     uInt     avail_out; /* remaining free space at next_out */
     uLong    total_out; /* total number of bytes output so far */
 
@@ -98,8 +99,9 @@ typedef struct z_stream_s {
     free_func  zfree;   /* used to free the internal state */
     voidpf     opaque;  /* private data object passed to zalloc and zfree */
 
-    int     data_type;  /* best guess about the data type: binary or text */
-    uLong   adler;      /* adler32 value of the uncompressed data */
+    int     data_type;  /* best guess about the data type: binary or text
+                           for deflate, or the decoding state for inflate */
+    uLong   adler;      /* Adler-32 or CRC-32 value of the uncompressed data */
     uLong   reserved;   /* reserved for future use */
 } z_stream;
 
@@ -142,7 +144,9 @@ typedef gz_header FAR *gz_headerp;
 
      zalloc must return Z_NULL if there is not enough memory for the object.
    If zlib is used in a multi-threaded application, zalloc and zfree must be
-   thread safe.
+   thread safe.  In that case, zlib is thread-safe.  When zalloc and zfree are
+   Z_NULL on entry to the initialization function, they are set to internal
+   routines that use the standard library functions malloc() and free().
 
      On 16-bit systems, the functions zalloc and zfree must be able to allocate
    exactly 65536 bytes, but will not be required to allocate more than this if
@@ -155,7 +159,7 @@ typedef gz_header FAR *gz_headerp;
 
      The fields total_in and total_out can be used for statistics or progress
    reports.  After compression, total_in holds the total size of the
-   uncompressed data and may be saved for use in the decompressor (particularly
+   uncompressed data and may be saved for use by the decompressor (particularly
    if the decompressor wants to decompress everything in a single step).
 */
 
@@ -200,7 +204,7 @@ typedef gz_header FAR *gz_headerp;
 #define Z_TEXT     1
 #define Z_ASCII    Z_TEXT   /* for compatibility with 1.2.2 and earlier */
 #define Z_UNKNOWN  2
-/* Possible values of the data_type field (though see inflate()) */
+/* Possible values of the data_type field for deflate() */
 
 #define Z_DEFLATED   8
 /* The deflate compression method (the only one supported in this version) */
@@ -258,11 +262,11 @@ ZEXTERN int ZEXPORT deflate OF((z_streamp strm, int flush));
     enough room in the output buffer), next_in and avail_in are updated and
     processing will resume at this point for the next call of deflate().
 
-  - Provide more output starting at next_out and update next_out and avail_out
+  - Generate more output starting at next_out and update next_out and avail_out
     accordingly.  This action is forced if the parameter flush is non zero.
     Forcing flush frequently degrades the compression ratio, so this parameter
-    should be set only when necessary (in interactive applications).  Some
-    output may be provided even if flush is not set.
+    should be set only when necessary.  Some output may be provided even if
+    flush is zero.
 
     Before the call of deflate(), the application should ensure that at least
   one of the actions is possible, by providing more input and/or consuming more
@@ -271,7 +275,9 @@ ZEXTERN int ZEXPORT deflate OF((z_streamp strm, int flush));
   output when it wants, for example when the output buffer is full (avail_out
   == 0), or after each call of deflate().  If deflate returns Z_OK and with
   zero avail_out, it must be called again after making room in the output
-  buffer because there might be more output pending.
+  buffer because there might be more output pending. See deflatePending(),
+  which can be used if desired to determine whether or not there is more ouput
+  in that case.
 
     Normally the parameter flush is set to Z_NO_FLUSH, which allows deflate to
   decide how much data to accumulate before producing output, in order to
@@ -292,8 +298,8 @@ ZEXTERN int ZEXPORT deflate OF((z_streamp strm, int flush));
   input data so far will be available to the decompressor, as for Z_SYNC_FLUSH.
   This completes the current deflate block and follows it with an empty fixed
   codes block that is 10 bits long.  This assures that enough bytes are output
-  in order for the decompressor to finish the block before the empty fixed code
-  block.
+  in order for the decompressor to finish the block before the empty fixed
+  codes block.
 
     If flush is set to Z_BLOCK, a deflate block is completed and emitted, as
   for Z_SYNC_FLUSH, but the output is not aligned on a byte boundary, and up to
@@ -319,34 +325,38 @@ ZEXTERN int ZEXPORT deflate OF((z_streamp strm, int flush));
 
     If the parameter flush is set to Z_FINISH, pending input is processed,
   pending output is flushed and deflate returns with Z_STREAM_END if there was
-  enough output space; if deflate returns with Z_OK, this function must be
-  called again with Z_FINISH and more output space (updated avail_out) but no
-  more input data, until it returns with Z_STREAM_END or an error.  After
-  deflate has returned Z_STREAM_END, the only possible operations on the stream
-  are deflateReset or deflateEnd.
+  enough output space.  If deflate returns with Z_OK or Z_BUF_ERROR, this
+  function must be called again with Z_FINISH and more output space (updated
+  avail_out) but no more input data, until it returns with Z_STREAM_END or an
+  error.  After deflate has returned Z_STREAM_END, the only possible operations
+  on the stream are deflateReset or deflateEnd.
 
-    Z_FINISH can be used immediately after deflateInit if all the compression
-  is to be done in a single step.  In this case, avail_out must be at least the
-  value returned by deflateBound (see below).  Then deflate is guaranteed to
-  return Z_STREAM_END.  If not enough output space is provided, deflate will
-  not return Z_STREAM_END, and it must be called again as described above.
+    Z_FINISH can be used in the first deflate call after deflateInit if all the
+  compression is to be done in a single step.  In order to complete in one
+  call, avail_out must be at least the value returned by deflateBound (see
+  below).  Then deflate is guaranteed to return Z_STREAM_END.  If not enough
+  output space is provided, deflate will not return Z_STREAM_END, and it must
+  be called again as described above.
 
-    deflate() sets strm->adler to the adler32 checksum of all input read
-  so far (that is, total_in bytes).
+    deflate() sets strm->adler to the Adler-32 checksum of all input read
+  so far (that is, total_in bytes).  If a gzip stream is being generated, then
+  strm->adler will be the CRC-32 checksum of the input read so far.  (See
+  deflateInit2 below.)
 
     deflate() may update strm->data_type if it can make a good guess about
-  the input data type (Z_BINARY or Z_TEXT).  In doubt, the data is considered
-  binary.  This field is only for information purposes and does not affect the
-  compression algorithm in any manner.
+  the input data type (Z_BINARY or Z_TEXT).  If in doubt, the data is
+  considered binary.  This field is only for information purposes and does not
+  affect the compression algorithm in any manner.
 
     deflate() returns Z_OK if some progress has been made (more input
   processed or more output produced), Z_STREAM_END if all input has been
   consumed and all output has been produced (only when flush is set to
   Z_FINISH), Z_STREAM_ERROR if the stream state was inconsistent (for example
-  if next_in or next_out was Z_NULL), Z_BUF_ERROR if no progress is possible
-  (for example avail_in or avail_out was zero).  Note that Z_BUF_ERROR is not
-  fatal, and deflate() can be called again with more input and more output
-  space to continue compressing.
+  if next_in or next_out was Z_NULL or the state was inadvertently written over
+  by the application), or Z_BUF_ERROR if no progress is possible (for example
+  avail_in or avail_out was zero).  Note that Z_BUF_ERROR is not fatal, and
+  deflate() can be called again with more input and more output space to
+  continue compressing.
 */
 
 
@@ -369,23 +379,21 @@ ZEXTERN int ZEXPORT inflateInit OF((z_streamp strm));
 
      Initializes the internal stream state for decompression.  The fields
    next_in, avail_in, zalloc, zfree and opaque must be initialized before by
-   the caller.  If next_in is not Z_NULL and avail_in is large enough (the
-   exact value depends on the compression method), inflateInit determines the
-   compression method from the zlib header and allocates all data structures
-   accordingly; otherwise the allocation will be deferred to the first call of
-   inflate.  If zalloc and zfree are set to Z_NULL, inflateInit updates them to
-   use default allocation functions.
+   the caller.  In the current version of inflate, the provided input is not
+   read or consumed.  The allocation of a sliding window will be deferred to
+   the first call of inflate (if the decompression does not complete on the
+   first call).  If zalloc and zfree are set to Z_NULL, inflateInit updates
+   them to use default allocation functions.
 
      inflateInit returns Z_OK if success, Z_MEM_ERROR if there was not enough
    memory, Z_VERSION_ERROR if the zlib library version is incompatible with the
    version assumed by the caller, or Z_STREAM_ERROR if the parameters are
    invalid, such as a null pointer to the structure.  msg is set to null if
-   there is no error message.  inflateInit does not perform any decompression
-   apart from possibly reading the zlib header if present: actual decompression
-   will be done by inflate().  (So next_in and avail_in may be modified, but
-   next_out and avail_out are unused and unchanged.) The current implementation
-   of inflateInit() does not process any header information -- that is deferred
-   until inflate() is called.
+   there is no error message.  inflateInit does not perform any decompression.
+   Actual decompression will be done by inflate().  So next_in, and avail_in,
+   next_out, and avail_out are unused and unchanged.  The current
+   implementation of inflateInit() does not process any header information --
+   that is deferred until inflate() is called.
 */
 
 
@@ -401,17 +409,20 @@ ZEXTERN int ZEXPORT inflate OF((z_streamp strm, int flush));
 
   - Decompress more input starting at next_in and update next_in and avail_in
     accordingly.  If not all input can be processed (because there is not
-    enough room in the output buffer), next_in is updated and processing will
-    resume at this point for the next call of inflate().
+    enough room in the output buffer), then next_in and avail_in are updated
+    accordingly, and processing will resume at this point for the next call of
+    inflate().
 
-  - Provide more output starting at next_out and update next_out and avail_out
+  - Generate more output starting at next_out and update next_out and avail_out
     accordingly.  inflate() provides as much output as possible, until there is
     no more input data or no more space in the output buffer (see below about
     the flush parameter).
 
     Before the call of inflate(), the application should ensure that at least
   one of the actions is possible, by providing more input and/or consuming more
-  output, and updating the next_* and avail_* values accordingly.  The
+  output, and updating the next_* and avail_* values accordingly.  If the
+  caller of inflate() does not provide both available input and available
+  output space, it is possible that there will be no progress made.  The
   application can consume the uncompressed output when it wants, for example
   when the output buffer is full (avail_out == 0), or after each call of
   inflate().  If inflate returns Z_OK and with zero avail_out, it must be
@@ -428,7 +439,7 @@ ZEXTERN int ZEXPORT inflate OF((z_streamp strm, int flush));
   gets to the end of that block, or when it runs out of data.
 
     The Z_BLOCK option assists in appending to or combining deflate streams.
-  Also to assist in this, on return inflate() will set strm->data_type to the
+  To assist in this, on return inflate() always sets strm->data_type to the
   number of unused bits in the last byte taken from strm->next_in, plus 64 if
   inflate() is currently decoding the last block in the deflate stream, plus
   128 if inflate() returned immediately after decoding an end-of-block code or
@@ -454,7 +465,7 @@ ZEXTERN int ZEXPORT inflate OF((z_streamp strm, int flush));
   this case all pending input is processed and all pending output is flushed;
   avail_out must be large enough to hold all of the uncompressed data for the
   operation to complete.  (The size of the uncompressed data may have been
-  saved by the compressor for this purpose.) The use of Z_FINISH is not
+  saved by the compressor for this purpose.)  The use of Z_FINISH is not
   required to perform an inflation in one step.  However it may be used to
   inform inflate that a faster approach can be used for the single inflate()
   call.  Z_FINISH also informs inflate to not maintain a sliding window if the
@@ -476,32 +487,33 @@ ZEXTERN int ZEXPORT inflate OF((z_streamp strm, int flush));
   chosen by the compressor and returns Z_NEED_DICT; otherwise it sets
   strm->adler to the Adler-32 checksum of all output produced so far (that is,
   total_out bytes) and returns Z_OK, Z_STREAM_END or an error code as described
-  below.  At the end of the stream, inflate() checks that its computed adler32
+  below.  At the end of the stream, inflate() checks that its computed Adler-32
   checksum is equal to that saved by the compressor and returns Z_STREAM_END
   only if the checksum is correct.
 
     inflate() can decompress and check either zlib-wrapped or gzip-wrapped
   deflate data.  The header type is detected automatically, if requested when
   initializing with inflateInit2().  Any information contained in the gzip
-  header is not retained, so applications that need that information should
-  instead use raw inflate, see inflateInit2() below, or inflateBack() and
-  perform their own processing of the gzip header and trailer.  When processing
+  header is not retained unless inflateGetHeader() is used.  When processing
   gzip-wrapped deflate data, strm->adler32 is set to the CRC-32 of the output
-  producted so far.  The CRC-32 is checked against the gzip trailer.
+  produced so far.  The CRC-32 is checked against the gzip trailer, as is the
+  uncompressed length, modulo 2^32.
 
     inflate() returns Z_OK if some progress has been made (more input processed
   or more output produced), Z_STREAM_END if the end of the compressed data has
   been reached and all uncompressed output has been produced, Z_NEED_DICT if a
   preset dictionary is needed at this point, Z_DATA_ERROR if the input data was
   corrupted (input stream not conforming to the zlib format or incorrect check
-  value), Z_STREAM_ERROR if the stream structure was inconsistent (for example
-  next_in or next_out was Z_NULL), Z_MEM_ERROR if there was not enough memory,
-  Z_BUF_ERROR if no progress is possible or if there was not enough room in the
-  output buffer when Z_FINISH is used.  Note that Z_BUF_ERROR is not fatal, and
+  value, in which case strm->msg points to a string with a more specific
+  error), Z_STREAM_ERROR if the stream structure was inconsistent (for example
+  next_in or next_out was Z_NULL, or the state was inadvertently written over
+  by the application), Z_MEM_ERROR if there was not enough memory, Z_BUF_ERROR
+  if no progress was possible or if there was not enough room in the output
+  buffer when Z_FINISH is used.  Note that Z_BUF_ERROR is not fatal, and
   inflate() can be called again with more input and more output space to
   continue decompressing.  If Z_DATA_ERROR is returned, the application may
   then call inflateSync() to look for a good compression block if a partial
-  recovery of the data is desired.
+  recovery of the data is to be attempted.
 */
 
 
@@ -511,9 +523,8 @@ ZEXTERN int ZEXPORT inflateEnd OF((z_streamp strm));
    This function discards any unprocessed input and does not flush any pending
    output.
 
-     inflateEnd returns Z_OK if success, Z_STREAM_ERROR if the stream state
-   was inconsistent.  In the error case, msg may be set but then points to a
-   static string (which must not be deallocated).
+     inflateEnd returns Z_OK if success, or Z_STREAM_ERROR if the stream state
+   was inconsistent.
 */
 
 
@@ -544,16 +555,29 @@ ZEXTERN int ZEXPORT deflateInit2 OF((z_streamp strm,
    compression at the expense of memory usage.  The default value is 15 if
    deflateInit is used instead.
 
+     For the current implementation of deflate(), a windowBits value of 8 (a
+   window size of 256 bytes) is not supported.  As a result, a request for 8
+   will result in 9 (a 512-byte window).  In that case, providing 8 to
+   inflateInit2() will result in an error when the zlib header with 9 is
+   checked against the initialization of inflate().  The remedy is to not use 8
+   with deflateInit2() with this initialization, or at least in that case use 9
+   with inflateInit2().
+
      windowBits can also be -8..-15 for raw deflate.  In this case, -windowBits
    determines the window size.  deflate() will then generate raw deflate data
-   with no zlib header or trailer, and will not compute an adler32 check value.
+   with no zlib header or trailer, and will not compute a check value.
 
      windowBits can also be greater than 15 for optional gzip encoding.  Add
    16 to windowBits to write a simple gzip header and trailer around the
    compressed data instead of a zlib wrapper.  The gzip header will have no
    file name, no extra data, no comment, no modification time (set to zero), no
-   header crc, and the operating system will be set to 255 (unknown).  If a
-   gzip stream is being written, strm->adler is a crc32 instead of an adler32.
+   header crc, and the operating system will be set to the appropriate value,
+   if the operating system was determined at compile time.  If a gzip stream is
+   being written, strm->adler is a CRC-32 instead of an Adler-32.
+
+     For raw deflate or gzip encoding, a request for a 256-byte window is
+   rejected as invalid, since only the zlib header provides a means of
+   transmitting the window size to the decompressor.
 
      The memLevel parameter specifies how much memory should be allocated
    for the internal compression state.  memLevel=1 uses minimum memory but is
@@ -614,18 +638,40 @@ ZEXTERN int ZEXPORT deflateSetDictionary OF((z_streamp strm,
    addition, the current implementation of deflate will use at most the window
    size minus 262 bytes of the provided dictionary.
 
-     Upon return of this function, strm->adler is set to the adler32 value
+     Upon return of this function, strm->adler is set to the Adler-32 value
    of the dictionary; the decompressor may later use this value to determine
-   which dictionary has been used by the compressor.  (The adler32 value
+   which dictionary has been used by the compressor.  (The Adler-32 value
    applies to the whole dictionary even if only a subset of the dictionary is
    actually used by the compressor.) If a raw deflate was requested, then the
-   adler32 value is not computed and strm->adler is not set.
+   Adler-32 value is not computed and strm->adler is not set.
 
      deflateSetDictionary returns Z_OK if success, or Z_STREAM_ERROR if a
    parameter is invalid (e.g.  dictionary being Z_NULL) or the stream state is
    inconsistent (for example if deflate has already been called for this stream
    or if not at a block boundary for raw deflate).  deflateSetDictionary does
    not perform any compression: this will be done by deflate().
+*/
+
+ZEXTERN int ZEXPORT deflateGetDictionary OF((z_streamp strm,
+                                             Bytef *dictionary,
+                                             uInt  *dictLength));
+/*
+     Returns the sliding dictionary being maintained by deflate.  dictLength is
+   set to the number of bytes in the dictionary, and that many bytes are copied
+   to dictionary.  dictionary must have enough space, where 32768 bytes is
+   always enough.  If deflateGetDictionary() is called with dictionary equal to
+   Z_NULL, then only the dictionary length is returned, and nothing is copied.
+   Similary, if dictLength is Z_NULL, then it is not set.
+
+     deflateGetDictionary() may return a length less than the window size, even
+   when more than the window size in input has been provided. It may return up
+   to 258 bytes less in that case, due to how zlib's implementation of deflate
+   manages the sliding window and lookahead for matches, where matches can be
+   up to 258 bytes long. If the application needs the last window-size bytes of
+   input, then that would need to be saved by the application outside of zlib.
+
+     deflateGetDictionary returns Z_OK on success, or Z_STREAM_ERROR if the
+   stream state is inconsistent.
 */
 
 ZEXTERN int ZEXPORT deflateCopy OF((z_streamp dest,
@@ -648,10 +694,10 @@ ZEXTERN int ZEXPORT deflateCopy OF((z_streamp dest,
 
 ZEXTERN int ZEXPORT deflateReset OF((z_streamp strm));
 /*
-     This function is equivalent to deflateEnd followed by deflateInit,
-   but does not free and reallocate all the internal compression state.  The
-   stream will keep the same compression level and any other attributes that
-   may have been set by deflateInit2.
+     This function is equivalent to deflateEnd followed by deflateInit, but
+   does not free and reallocate the internal compression state.  The stream
+   will leave the compression level and any other attributes that may have been
+   set unchanged.
 
      deflateReset returns Z_OK if success, or Z_STREAM_ERROR if the source
    stream state was inconsistent (such as zalloc or state being Z_NULL).
@@ -662,20 +708,36 @@ ZEXTERN int ZEXPORT deflateParams OF((z_streamp strm,
                                       int strategy));
 /*
      Dynamically update the compression level and compression strategy.  The
-   interpretation of level and strategy is as in deflateInit2.  This can be
+   interpretation of level and strategy is as in deflateInit2().  This can be
    used to switch between compression and straight copy of the input data, or
    to switch to a different kind of input data requiring a different strategy.
-   If the compression level is changed, the input available so far is
-   compressed with the old level (and may be flushed); the new level will take
-   effect only at the next call of deflate().
+   If the compression approach (which is a function of the level) or the
+   strategy is changed, and if any input has been consumed in a previous
+   deflate() call, then the input available so far is compressed with the old
+   level and strategy using deflate(strm, Z_BLOCK).  There are three approaches
+   for the compression levels 0, 1..3, and 4..9 respectively.  The new level
+   and strategy will take effect at the next call of deflate().
 
-     Before the call of deflateParams, the stream state must be set as for
-   a call of deflate(), since the currently available input may have to be
-   compressed and flushed.  In particular, strm->avail_out must be non-zero.
+     If a deflate(strm, Z_BLOCK) is performed by deflateParams(), and it does
+   not have enough output space to complete, then the parameter change will not
+   take effect.  In this case, deflateParams() can be called again with the
+   same parameters and more output space to try again.
 
-     deflateParams returns Z_OK if success, Z_STREAM_ERROR if the source
-   stream state was inconsistent or if a parameter was invalid, Z_BUF_ERROR if
-   strm->avail_out was zero.
+     In order to assure a change in the parameters on the first try, the
+   deflate stream should be flushed using deflate() with Z_BLOCK or other flush
+   request until strm.avail_out is not zero, before calling deflateParams().
+   Then no more input data should be provided before the deflateParams() call.
+   If this is done, the old level and strategy will be applied to the data
+   compressed before deflateParams(), and the new level and strategy will be
+   applied to the the data compressed after deflateParams().
+
+     deflateParams returns Z_OK on success, Z_STREAM_ERROR if the source stream
+   state was inconsistent or if a parameter was invalid, or Z_BUF_ERROR if
+   there was not enough output space to complete the compression of the
+   available input data before a change in the strategy or approach.  Note that
+   in the case of a Z_BUF_ERROR, the parameters are not changed.  A return
+   value of Z_BUF_ERROR is not fatal, in which case deflateParams() can be
+   retried with more output space.
 */
 
 ZEXTERN int ZEXPORT deflateTune OF((z_streamp strm,
@@ -793,7 +855,7 @@ ZEXTERN int ZEXPORT inflateInit2 OF((z_streamp strm,
    is for use with other formats that use the deflate compressed data format
    such as zip.  Those formats provide their own check values.  If a custom
    format is developed using the raw deflate format for compressed data, it is
-   recommended that a check value such as an adler32 or a crc32 be applied to
+   recommended that a check value such as an Adler-32 or a CRC-32 be applied to
    the uncompressed data as is done in the zlib, gzip, and zip formats.  For
    most applications, the zlib format should be used as is.  Note that comments
    above on the use in deflateInit2() applies to the magnitude of windowBits.
@@ -802,7 +864,10 @@ ZEXTERN int ZEXPORT inflateInit2 OF((z_streamp strm,
    32 to windowBits to enable zlib and gzip decoding with automatic header
    detection, or add 16 to decode only the gzip format (the zlib format will
    return a Z_DATA_ERROR).  If a gzip stream is being decoded, strm->adler is a
-   crc32 instead of an adler32.
+   CRC-32 instead of an Adler-32.  Unlike the gunzip utility and gzread() (see
+   below), inflate() will not automatically decode concatenated gzip streams.
+   inflate() will return Z_STREAM_END at the end of the gzip stream.  The state
+   would need to be reset to continue decoding a subsequent gzip stream.
 
      inflateInit2 returns Z_OK if success, Z_MEM_ERROR if there was not enough
    memory, Z_VERSION_ERROR if the zlib library version is incompatible with the
@@ -823,7 +888,7 @@ ZEXTERN int ZEXPORT inflateSetDictionary OF((z_streamp strm,
      Initializes the decompression dictionary from the given uncompressed byte
    sequence.  This function must be called immediately after a call of inflate,
    if that call returned Z_NEED_DICT.  The dictionary chosen by the compressor
-   can be determined from the adler32 value returned by that call of inflate.
+   can be determined from the Adler-32 value returned by that call of inflate.
    The compressor and decompressor must use exactly the same dictionary (see
    deflateSetDictionary).  For raw inflate, this function can be called at any
    time to set the dictionary.  If the provided dictionary is smaller than the
@@ -834,7 +899,7 @@ ZEXTERN int ZEXPORT inflateSetDictionary OF((z_streamp strm,
      inflateSetDictionary returns Z_OK if success, Z_STREAM_ERROR if a
    parameter is invalid (e.g.  dictionary being Z_NULL) or the stream state is
    inconsistent, Z_DATA_ERROR if the given dictionary doesn't match the
-   expected one (incorrect adler32 value).  inflateSetDictionary does not
+   expected one (incorrect Adler-32 value).  inflateSetDictionary does not
    perform any decompression: this will be done by subsequent calls of
    inflate().
 */
@@ -892,7 +957,7 @@ ZEXTERN int ZEXPORT inflateCopy OF((z_streamp dest,
 ZEXTERN int ZEXPORT inflateReset OF((z_streamp strm));
 /*
      This function is equivalent to inflateEnd followed by inflateInit,
-   but does not free and reallocate all the internal decompression state.  The
+   but does not free and reallocate the internal decompression state.  The
    stream will keep attributes that may have been set by inflateInit2.
 
      inflateReset returns Z_OK if success, or Z_STREAM_ERROR if the source
@@ -904,7 +969,9 @@ ZEXTERN int ZEXPORT inflateReset2 OF((z_streamp strm,
 /*
      This function is the same as inflateReset, but it also permits changing
    the wrap and window size requests.  The windowBits parameter is interpreted
-   the same as it is for inflateInit2.
+   the same as it is for inflateInit2.  If the window size is changed, then the
+   memory allocated for the window is freed, and the window will be reallocated
+   by inflate() if needed.
 
      inflateReset2 returns Z_OK if success, or Z_STREAM_ERROR if the source
    stream state was inconsistent (such as zalloc or state being Z_NULL), or if
@@ -956,7 +1023,7 @@ ZEXTERN long ZEXPORT inflateMark OF((z_streamp strm));
    location in the input stream can be determined from avail_in and data_type
    as noted in the description for the Z_BLOCK flush parameter for inflate.
 
-     inflateMark returns the value noted above or -1 << 16 if the provided
+     inflateMark returns the value noted above, or -65536 if the provided
    source stream state was inconsistent.
 */
 
@@ -1048,9 +1115,9 @@ ZEXTERN int ZEXPORT inflateBack OF((z_streamp strm,
    This routine would normally be used in a utility that reads zip or gzip
    files and writes out uncompressed files.  The utility would decode the
    header and process the trailer on its own, hence this routine expects only
-   the raw deflate stream to decompress.  This is different from the normal
-   behavior of inflate(), which expects either a zlib or gzip header and
-   trailer around the deflate stream.
+   the raw deflate stream to decompress.  This is different from the default
+   behavior of inflate(), which expects a zlib header and trailer around the
+   deflate stream.
 
      inflateBack() uses two subroutines supplied by the caller that are then
    called by inflateBack() for input and output.  inflateBack() calls those
@@ -1059,12 +1126,12 @@ ZEXTERN int ZEXPORT inflateBack OF((z_streamp strm,
    parameters and return types are defined above in the in_func and out_func
    typedefs.  inflateBack() will call in(in_desc, &buf) which should return the
    number of bytes of provided input, and a pointer to that input in buf.  If
-   there is no input available, in() must return zero--buf is ignored in that
-   case--and inflateBack() will return a buffer error.  inflateBack() will call
-   out(out_desc, buf, len) to write the uncompressed data buf[0..len-1].  out()
-   should return zero on success, or non-zero on failure.  If out() returns
-   non-zero, inflateBack() will return with an error.  Neither in() nor out()
-   are permitted to change the contents of the window provided to
+   there is no input available, in() must return zero -- buf is ignored in that
+   case -- and inflateBack() will return a buffer error.  inflateBack() will
+   call out(out_desc, buf, len) to write the uncompressed data buf[0..len-1].
+   out() should return zero on success, or non-zero on failure.  If out()
+   returns non-zero, inflateBack() will return with an error.  Neither in() nor
+   out() are permitted to change the contents of the window provided to
    inflateBackInit(), which is also the buffer that out() uses to write from.
    The length written by out() will be at most the window size.  Any non-zero
    amount of input may be provided by in().
@@ -1092,7 +1159,7 @@ ZEXTERN int ZEXPORT inflateBack OF((z_streamp strm,
    using strm->next_in which will be Z_NULL only if in() returned an error.  If
    strm->next_in is not Z_NULL, then the Z_BUF_ERROR was due to out() returning
    non-zero.  (in() will always be called before out(), so strm->next_in is
-   assured to be defined if out() returns non-zero.) Note that inflateBack()
+   assured to be defined if out() returns non-zero.)  Note that inflateBack()
    cannot return Z_OK.
 */
 
@@ -1114,7 +1181,7 @@ ZEXTERN uLong ZEXPORT zlibCompileFlags OF((void));
      7.6: size of z_off_t
 
     Compiler, assembler, and debug options:
-     8: DEBUG
+     8: ZLIB_DEBUG
      9: ASMV or ASMINF -- use ASM code
      10: ZLIB_WINAPI -- exported functions use the WINAPI calling convention
      11: 0 (reserved)
@@ -1164,7 +1231,8 @@ ZEXTERN int ZEXPORT compress OF((Bytef *dest,   uLongf *destLen,
    the byte length of the source buffer.  Upon entry, destLen is the total size
    of the destination buffer, which must be at least the value returned by
    compressBound(sourceLen).  Upon exit, destLen is the actual size of the
-   compressed buffer.
+   compressed data.  compress() is equivalent to compress2() with a level
+   parameter of Z_DEFAULT_COMPRESSION.
 
      compress returns Z_OK if success, Z_MEM_ERROR if there was not
    enough memory, Z_BUF_ERROR if there was not enough room in the output
@@ -1180,7 +1248,7 @@ ZEXTERN int ZEXPORT compress2 OF((Bytef *dest,   uLongf *destLen,
    length of the source buffer.  Upon entry, destLen is the total size of the
    destination buffer, which must be at least the value returned by
    compressBound(sourceLen).  Upon exit, destLen is the actual size of the
-   compressed buffer.
+   compressed data.
 
      compress2 returns Z_OK if success, Z_MEM_ERROR if there was not enough
    memory, Z_BUF_ERROR if there was not enough room in the output buffer,
@@ -1203,13 +1271,21 @@ ZEXTERN int ZEXPORT uncompress OF((Bytef *dest,   uLongf *destLen,
    uncompressed data.  (The size of the uncompressed data must have been saved
    previously by the compressor and transmitted to the decompressor by some
    mechanism outside the scope of this compression library.) Upon exit, destLen
-   is the actual size of the uncompressed buffer.
+   is the actual size of the uncompressed data.
 
      uncompress returns Z_OK if success, Z_MEM_ERROR if there was not
    enough memory, Z_BUF_ERROR if there was not enough room in the output
    buffer, or Z_DATA_ERROR if the input data was corrupted or incomplete.  In
    the case where there is not enough room, uncompress() will fill the output
    buffer with the uncompressed data up to that point.
+*/
+
+ZEXTERN int ZEXPORT uncompress2 OF((Bytef *dest,   uLongf *destLen,
+                                    const Bytef *source, uLong *sourceLen));
+/*
+     Same as uncompress, except that sourceLen is a pointer, where the
+   length of the source is *sourceLen.  On return, *sourceLen is the number of
+   source bytes consumed.
 */
 
                         /* gzip file access functions */
@@ -1290,10 +1366,9 @@ ZEXTERN int ZEXPORT gzbuffer OF((gzFile file, unsigned size));
    default buffer size is 8192 bytes.  This function must be called after
    gzopen() or gzdopen(), and before any other calls that read or write the
    file.  The buffer memory allocation is always deferred to the first read or
-   write.  Two buffers are allocated, either both of the specified size when
-   writing, or one of the specified size and the other twice that size when
-   reading.  A larger buffer size of, for example, 64K or 128K bytes will
-   noticeably increase the speed of decompression (reading).
+   write.  Three times that size in buffer space is allocated.  A larger buffer
+   size of, for example, 64K or 128K bytes will noticeably increase the speed
+   of decompression (reading).
 
      The new buffer size also affects the maximum length for gzprintf().
 
@@ -1304,10 +1379,12 @@ ZEXTERN int ZEXPORT gzbuffer OF((gzFile file, unsigned size));
 ZEXTERN int ZEXPORT gzsetparams OF((gzFile file, int level, int strategy));
 /*
      Dynamically update the compression level or strategy.  See the description
-   of deflateInit2 for the meaning of these parameters.
+   of deflateInit2 for the meaning of these parameters.  Previously provided
+   data is flushed before the parameter change.
 
-     gzsetparams returns Z_OK if success, or Z_STREAM_ERROR if the file was not
-   opened for writing.
+     gzsetparams returns Z_OK if success, Z_STREAM_ERROR if the file was not
+   opened for writing, Z_ERRNO if there is an error writing the flushed data,
+   or Z_MEM_ERROR if there is a memory allocation error.
 */
 
 ZEXTERN int ZEXPORT gzread OF((gzFile file, voidp buf, unsigned len));
@@ -1335,7 +1412,35 @@ ZEXTERN int ZEXPORT gzread OF((gzFile file, voidp buf, unsigned len));
    case.
 
      gzread returns the number of uncompressed bytes actually read, less than
-   len for end of file, or -1 for error.
+   len for end of file, or -1 for error.  If len is too large to fit in an int,
+   then nothing is read, -1 is returned, and the error state is set to
+   Z_STREAM_ERROR.
+*/
+
+ZEXTERN z_size_t ZEXPORT gzfread OF((voidp buf, z_size_t size, z_size_t nitems,
+                                     gzFile file));
+/*
+     Read up to nitems items of size size from file to buf, otherwise operating
+   as gzread() does.  This duplicates the interface of stdio's fread(), with
+   size_t request and return types.  If the library defines size_t, then
+   z_size_t is identical to size_t.  If not, then z_size_t is an unsigned
+   integer type that can contain a pointer.
+
+     gzfread() returns the number of full items read of size size, or zero if
+   the end of the file was reached and a full item could not be read, or if
+   there was an error.  gzerror() must be consulted if zero is returned in
+   order to determine if there was an error.  If the multiplication of size and
+   nitems overflows, i.e. the product does not fit in a z_size_t, then nothing
+   is read, zero is returned, and the error state is set to Z_STREAM_ERROR.
+
+     In the event that the end of file is reached and only a partial item is
+   available at the end, i.e. the remaining uncompressed data length is not a
+   multiple of size, then the final partial item is nevetheless read into buf
+   and the end-of-file flag is set.  The length of the partial item read is not
+   provided, but could be inferred from the result of gztell().  This behavior
+   is the same as the behavior of fread() implementations in common libraries,
+   but it prevents the direct use of gzfread() to read a concurrently written
+   file, reseting and retrying on end-of-file, when size is not 1.
 */
 
 ZEXTERN int ZEXPORT gzwrite OF((gzFile file,
@@ -1346,19 +1451,33 @@ ZEXTERN int ZEXPORT gzwrite OF((gzFile file,
    error.
 */
 
+ZEXTERN z_size_t ZEXPORT gzfwrite OF((voidpc buf, z_size_t size,
+                                      z_size_t nitems, gzFile file));
+/*
+     gzfwrite() writes nitems items of size size from buf to file, duplicating
+   the interface of stdio's fwrite(), with size_t request and return types.  If
+   the library defines size_t, then z_size_t is identical to size_t.  If not,
+   then z_size_t is an unsigned integer type that can contain a pointer.
+
+     gzfwrite() returns the number of full items written of size size, or zero
+   if there was an error.  If the multiplication of size and nitems overflows,
+   i.e. the product does not fit in a z_size_t, then nothing is written, zero
+   is returned, and the error state is set to Z_STREAM_ERROR.
+*/
+
 ZEXTERN int ZEXPORTVA gzprintf Z_ARG((gzFile file, const char *format, ...));
 /*
      Converts, formats, and writes the arguments to the compressed file under
    control of the format string, as in fprintf.  gzprintf returns the number of
-   uncompressed bytes actually written, or 0 in case of error.  The number of
-   uncompressed bytes written is limited to 8191, or one less than the buffer
-   size given to gzbuffer().  The caller should assure that this limit is not
-   exceeded.  If it is exceeded, then gzprintf() will return an error (0) with
-   nothing written.  In this case, there may also be a buffer overflow with
-   unpredictable consequences, which is possible only if zlib was compiled with
-   the insecure functions sprintf() or vsprintf() because the secure snprintf()
-   or vsnprintf() functions were not available.  This can be determined using
-   zlibCompileFlags().
+   uncompressed bytes actually written, or a negative zlib error code in case
+   of error.  The number of uncompressed bytes written is limited to 8191, or
+   one less than the buffer size given to gzbuffer().  The caller should assure
+   that this limit is not exceeded.  If it is exceeded, then gzprintf() will
+   return an error (0) with nothing written.  In this case, there may also be a
+   buffer overflow with unpredictable consequences, which is possible only if
+   zlib was compiled with the insecure functions sprintf() or vsprintf()
+   because the secure snprintf() or vsnprintf() functions were not available.
+   This can be determined using zlibCompileFlags().
 */
 
 ZEXTERN int ZEXPORT gzputs OF((gzFile file, const char *s));
@@ -1418,7 +1537,7 @@ ZEXTERN int ZEXPORT gzflush OF((gzFile file, int flush));
      If the flush parameter is Z_FINISH, the remaining data is written and the
    gzip stream is completed in the output.  If gzwrite() is called again, a new
    gzip stream will be started in the output.  gzread() is able to read such
-   concatented gzip streams.
+   concatenated gzip streams.
 
      gzflush should be called only when strictly necessary because it will
    degrade compression if called too often.
@@ -1572,7 +1691,7 @@ ZEXTERN uLong ZEXPORT adler32 OF((uLong adler, const Bytef *buf, uInt len));
    return the updated checksum.  If buf is Z_NULL, this function returns the
    required initial value for the checksum.
 
-     An Adler-32 checksum is almost as reliable as a CRC32 but can be computed
+     An Adler-32 checksum is almost as reliable as a CRC-32 but can be computed
    much faster.
 
    Usage example:
@@ -1583,6 +1702,12 @@ ZEXTERN uLong ZEXPORT adler32 OF((uLong adler, const Bytef *buf, uInt len));
        adler = adler32(adler, buffer, length);
      }
      if (adler != original_adler) error();
+*/
+
+ZEXTERN uLong ZEXPORT adler32_z OF((uLong adler, const Bytef *buf,
+                                    z_size_t len));
+/*
+     Same as adler32(), but with a size_t length.
 */
 
 /*
@@ -1612,6 +1737,12 @@ ZEXTERN uLong ZEXPORT crc32   OF((uLong crc, const Bytef *buf, uInt len));
        crc = crc32(crc, buffer, length);
      }
      if (crc != original_crc) error();
+*/
+
+ZEXTERN uLong ZEXPORT crc32_z OF((uLong adler, const Bytef *buf,
+                                  z_size_t len));
+/*
+     Same as crc32(), but with a size_t length.
 */
 
 /*
@@ -1644,19 +1775,35 @@ ZEXTERN int ZEXPORT inflateBackInit_ OF((z_streamp strm, int windowBits,
                                          unsigned char FAR *window,
                                          const char *version,
                                          int stream_size));
-#define deflateInit(strm, level) \
-        deflateInit_((strm), (level), ZLIB_VERSION, sizeof(z_stream))
-#define inflateInit(strm) \
-        inflateInit_((strm), ZLIB_VERSION, sizeof(z_stream))
-#define deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
-        deflateInit2_((strm),(level),(method),(windowBits),(memLevel),\
-                      (strategy), ZLIB_VERSION, sizeof(z_stream))
-#define inflateInit2(strm, windowBits) \
-        inflateInit2_((strm), (windowBits), ZLIB_VERSION, \
-                      sizeof(z_stream))
-#define inflateBackInit(strm, windowBits, window) \
-        inflateBackInit_((strm), (windowBits), (window), \
-                      ZLIB_VERSION, sizeof(z_stream))
+#ifdef Z_PREFIX_SET
+#  define z_deflateInit(strm, level) \
+          deflateInit_((strm), (level), ZLIB_VERSION, (int)sizeof(z_stream))
+#  define z_inflateInit(strm) \
+          inflateInit_((strm), ZLIB_VERSION, (int)sizeof(z_stream))
+#  define z_deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
+          deflateInit2_((strm),(level),(method),(windowBits),(memLevel),\
+                        (strategy), ZLIB_VERSION, (int)sizeof(z_stream))
+#  define z_inflateInit2(strm, windowBits) \
+          inflateInit2_((strm), (windowBits), ZLIB_VERSION, \
+                        (int)sizeof(z_stream))
+#  define z_inflateBackInit(strm, windowBits, window) \
+          inflateBackInit_((strm), (windowBits), (window), \
+                           ZLIB_VERSION, (int)sizeof(z_stream))
+#else
+#  define deflateInit(strm, level) \
+          deflateInit_((strm), (level), ZLIB_VERSION, (int)sizeof(z_stream))
+#  define inflateInit(strm) \
+          inflateInit_((strm), ZLIB_VERSION, (int)sizeof(z_stream))
+#  define deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
+          deflateInit2_((strm),(level),(method),(windowBits),(memLevel),\
+                        (strategy), ZLIB_VERSION, (int)sizeof(z_stream))
+#  define inflateInit2(strm, windowBits) \
+          inflateInit2_((strm), (windowBits), ZLIB_VERSION, \
+                        (int)sizeof(z_stream))
+#  define inflateBackInit(strm, windowBits, window) \
+          inflateBackInit_((strm), (windowBits), (window), \
+                           ZLIB_VERSION, (int)sizeof(z_stream))
+#endif
 
 #ifndef Z_SOLO
 
@@ -1676,10 +1823,10 @@ ZEXTERN int ZEXPORT gzgetc_ OF((gzFile file));  /* backward compatibility */
 #ifdef Z_PREFIX_SET
 #  undef z_gzgetc
 #  define z_gzgetc(g) \
-          ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : gzgetc(g))
+          ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : (gzgetc)(g))
 #else
 #  define gzgetc(g) \
-          ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : gzgetc(g))
+          ((g)->have ? ((g)->have--, (g)->pos++, *((g)->next)++) : (gzgetc)(g))
 #endif
 
 /* provide 64-bit offset functions if _LARGEFILE64_SOURCE defined, and/or
@@ -1737,19 +1884,16 @@ ZEXTERN int ZEXPORT gzgetc_ OF((gzFile file));  /* backward compatibility */
 
 #endif /* !Z_SOLO */
 
-/* hack for buggy compilers */
-#if !defined(ZUTIL_H) && !defined(NO_DUMMY_DECL)
-    struct internal_state {int dummy;};
-#endif
-
 /* undocumented functions */
 ZEXTERN const char   * ZEXPORT zError           OF((int));
 ZEXTERN int            ZEXPORT inflateSyncPoint OF((z_streamp));
 ZEXTERN const z_crc_t FAR * ZEXPORT get_crc_table    OF((void));
 ZEXTERN int            ZEXPORT inflateUndermine OF((z_streamp, int));
+ZEXTERN int            ZEXPORT inflateValidate OF((z_streamp, int));
+ZEXTERN unsigned long  ZEXPORT inflateCodesUsed OF ((z_streamp));
 ZEXTERN int            ZEXPORT inflateResetKeep OF((z_streamp));
 ZEXTERN int            ZEXPORT deflateResetKeep OF((z_streamp));
-#if defined(_WIN32) && !defined(Z_SOLO)
+#if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(Z_SOLO)
 ZEXTERN gzFile         ZEXPORT gzopen_w OF((const wchar_t *path,
                                             const char *mode));
 #endif

--- a/libs/zlib/src/zlib.h
+++ b/libs/zlib/src/zlib.h
@@ -1791,18 +1791,18 @@ ZEXTERN int ZEXPORT inflateBackInit_ OF((z_streamp strm, int windowBits,
                            ZLIB_VERSION, (int)sizeof(z_stream))
 #else
 #  define deflateInit(strm, level) \
-          deflateInit_((strm), (level), ZLIB_VERSION, (int)sizeof(z_stream))
+          deflateInit_((strm), (level), ZLIB_VERSION, sizeof(z_stream))
 #  define inflateInit(strm) \
-          inflateInit_((strm), ZLIB_VERSION, (int)sizeof(z_stream))
+          inflateInit_((strm), ZLIB_VERSION, sizeof(z_stream))
 #  define deflateInit2(strm, level, method, windowBits, memLevel, strategy) \
           deflateInit2_((strm),(level),(method),(windowBits),(memLevel),\
-                        (strategy), ZLIB_VERSION, (int)sizeof(z_stream))
+                        (strategy), ZLIB_VERSION, sizeof(z_stream))
 #  define inflateInit2(strm, windowBits) \
           inflateInit2_((strm), (windowBits), ZLIB_VERSION, \
-                        (int)sizeof(z_stream))
+                        sizeof(z_stream))
 #  define inflateBackInit(strm, windowBits, window) \
           inflateBackInit_((strm), (windowBits), (window), \
-                           ZLIB_VERSION, (int)sizeof(z_stream))
+                           ZLIB_VERSION, sizeof(z_stream))
 #endif
 
 #ifndef Z_SOLO

--- a/libs/zlib/src/zutil.c
+++ b/libs/zlib/src/zutil.c
@@ -34,25 +34,25 @@ uLong ZEXPORT zlibCompileFlags()
     uLong flags;
 
     flags = 0;
-    switch ((int)(sizeof(uInt))) {
+    switch (sizeof(uInt)) {
     case 2:     break;
     case 4:     flags += 1;     break;
     case 8:     flags += 2;     break;
     default:    flags += 3;
     }
-    switch ((int)(sizeof(uLong))) {
+    switch (sizeof(uLong)) {
     case 2:     break;
     case 4:     flags += 1 << 2;        break;
     case 8:     flags += 2 << 2;        break;
     default:    flags += 3 << 2;
     }
-    switch ((int)(sizeof(voidpf))) {
+    switch (sizeof(voidpf)) {
     case 2:     break;
     case 4:     flags += 1 << 4;        break;
     case 8:     flags += 2 << 4;        break;
     default:    flags += 3 << 4;
     }
-    switch ((int)(sizeof(z_off_t))) {
+    switch (sizeof(z_off_t)) {
     case 2:     break;
     case 4:     flags += 1 << 6;        break;
     case 8:     flags += 2 << 6;        break;

--- a/libs/zlib/src/zutil.c
+++ b/libs/zlib/src/zutil.c
@@ -1,5 +1,5 @@
 /* zutil.c -- target dependent utility functions for the compression library
- * Copyright (C) 1995-2005, 2010, 2011, 2012 Jean-loup Gailly.
+ * Copyright (C) 1995-2017 Jean-loup Gailly
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -10,124 +10,120 @@
 #  include "gzguts.h"
 #endif
 
-#ifndef NO_DUMMY_DECL
-struct internal_state      {int dummy;}; /* for buggy compilers */
-#endif
-
-z_const char * const z_errmsg[10] =
-{
-	"need dictionary",     /* Z_NEED_DICT       2  */
-	"stream end",          /* Z_STREAM_END      1  */
-	"",                    /* Z_OK              0  */
-	"file error",          /* Z_ERRNO         (-1) */
-	"stream error",        /* Z_STREAM_ERROR  (-2) */
-	"data error",          /* Z_DATA_ERROR    (-3) */
-	"insufficient memory", /* Z_MEM_ERROR     (-4) */
-	"buffer error",        /* Z_BUF_ERROR     (-5) */
-	"incompatible version",/* Z_VERSION_ERROR (-6) */
-	""
+z_const char * const z_errmsg[10] = {
+    (z_const char *)"need dictionary",     /* Z_NEED_DICT       2  */
+    (z_const char *)"stream end",          /* Z_STREAM_END      1  */
+    (z_const char *)"",                    /* Z_OK              0  */
+    (z_const char *)"file error",          /* Z_ERRNO         (-1) */
+    (z_const char *)"stream error",        /* Z_STREAM_ERROR  (-2) */
+    (z_const char *)"data error",          /* Z_DATA_ERROR    (-3) */
+    (z_const char *)"insufficient memory", /* Z_MEM_ERROR     (-4) */
+    (z_const char *)"buffer error",        /* Z_BUF_ERROR     (-5) */
+    (z_const char *)"incompatible version",/* Z_VERSION_ERROR (-6) */
+    (z_const char *)""
 };
+
 
 const char * ZEXPORT zlibVersion()
 {
-	return ZLIB_VERSION;
+    return ZLIB_VERSION;
 }
 
 uLong ZEXPORT zlibCompileFlags()
 {
-	uLong flags;
+    uLong flags;
 
-	flags = 0;
-	switch (sizeof(uInt)) {
-	case 2:     break;
-	case 4:     flags += 1;     break;
-	case 8:     flags += 2;     break;
-	default:    flags += 3;
-	}
-	switch (sizeof(uLong)) {
-	case 2:     break;
-	case 4:     flags += 1 << 2;        break;
-	case 8:     flags += 2 << 2;        break;
-	default:    flags += 3 << 2;
-	}
-	switch (sizeof(voidpf)) {
-	case 2:     break;
-	case 4:     flags += 1 << 4;        break;
-	case 8:     flags += 2 << 4;        break;
-	default:    flags += 3 << 4;
-	}
-	switch (sizeof(z_off_t)) {
-	case 2:     break;
-	case 4:     flags += 1 << 6;        break;
-	case 8:     flags += 2 << 6;        break;
-	default:    flags += 3 << 6;
-	}
-	#ifdef DEBUG
-	flags += 1 << 8;
-	#endif
-	#if defined(ASMV) || defined(ASMINF)
-	flags += 1 << 9;
-	#endif
-	#ifdef ZLIB_WINAPI
-	flags += 1 << 10;
-	#endif
-	#ifdef BUILDFIXED
-	flags += 1 << 12;
-	#endif
-	#ifdef DYNAMIC_CRC_TABLE
-	flags += 1 << 13;
-	#endif
-	#ifdef NO_GZCOMPRESS
-	flags += 1L << 16;
-	#endif
-	#ifdef NO_GZIP
-	flags += 1L << 17;
-	#endif
-	#ifdef PKZIP_BUG_WORKAROUND
-	flags += 1L << 20;
-	#endif
-	#ifdef FASTEST
-	flags += 1L << 21;
-	#endif
-	#if defined(STDC) || defined(Z_HAVE_STDARG_H)
-	#  ifdef NO_vsnprintf
-	flags += 1L << 25;
-	#    ifdef HAS_vsprintf_void
-	flags += 1L << 26;
-	#    endif
-	#  else
-	#    ifdef HAS_vsnprintf_void
-	flags += 1L << 26;
-	#    endif
-	#  endif
-	#else
-	flags += 1L << 24;
-	#  ifdef NO_snprintf
-	flags += 1L << 25;
-	#    ifdef HAS_sprintf_void
-	flags += 1L << 26;
-	#    endif
-	#  else
-	#    ifdef HAS_snprintf_void
-	flags += 1L << 26;
-	#    endif
-	#  endif
-	#endif
-	return flags;
+    flags = 0;
+    switch ((int)(sizeof(uInt))) {
+    case 2:     break;
+    case 4:     flags += 1;     break;
+    case 8:     flags += 2;     break;
+    default:    flags += 3;
+    }
+    switch ((int)(sizeof(uLong))) {
+    case 2:     break;
+    case 4:     flags += 1 << 2;        break;
+    case 8:     flags += 2 << 2;        break;
+    default:    flags += 3 << 2;
+    }
+    switch ((int)(sizeof(voidpf))) {
+    case 2:     break;
+    case 4:     flags += 1 << 4;        break;
+    case 8:     flags += 2 << 4;        break;
+    default:    flags += 3 << 4;
+    }
+    switch ((int)(sizeof(z_off_t))) {
+    case 2:     break;
+    case 4:     flags += 1 << 6;        break;
+    case 8:     flags += 2 << 6;        break;
+    default:    flags += 3 << 6;
+    }
+#ifdef ZLIB_DEBUG
+    flags += 1 << 8;
+#endif
+#if defined(ASMV) || defined(ASMINF)
+    flags += 1 << 9;
+#endif
+#ifdef ZLIB_WINAPI
+    flags += 1 << 10;
+#endif
+#ifdef BUILDFIXED
+    flags += 1 << 12;
+#endif
+#ifdef DYNAMIC_CRC_TABLE
+    flags += 1 << 13;
+#endif
+#ifdef NO_GZCOMPRESS
+    flags += 1L << 16;
+#endif
+#ifdef NO_GZIP
+    flags += 1L << 17;
+#endif
+#ifdef PKZIP_BUG_WORKAROUND
+    flags += 1L << 20;
+#endif
+#ifdef FASTEST
+    flags += 1L << 21;
+#endif
+#if defined(STDC) || defined(Z_HAVE_STDARG_H)
+#  ifdef NO_vsnprintf
+    flags += 1L << 25;
+#    ifdef HAS_vsprintf_void
+    flags += 1L << 26;
+#    endif
+#  else
+#    ifdef HAS_vsnprintf_void
+    flags += 1L << 26;
+#    endif
+#  endif
+#else
+    flags += 1L << 24;
+#  ifdef NO_snprintf
+    flags += 1L << 25;
+#    ifdef HAS_sprintf_void
+    flags += 1L << 26;
+#    endif
+#  else
+#    ifdef HAS_snprintf_void
+    flags += 1L << 26;
+#    endif
+#  endif
+#endif
+    return flags;
 }
 
-#ifdef DEBUG
-
+#ifdef ZLIB_DEBUG
+#include <stdlib.h>
 #  ifndef verbose
 #    define verbose 0
 #  endif
 int ZLIB_INTERNAL z_verbose = verbose;
 
-void ZLIB_INTERNAL z_error(m)
-char *m;
+void ZLIB_INTERNAL z_error (m)
+    char *m;
 {
-	fprintf(stderr, "%s\n", m);
-	exit(1);
+    fprintf(stderr, "%s\n", m);
+    exit(1);
 }
 #endif
 
@@ -135,53 +131,53 @@ char *m;
  * uncompress()
  */
 const char * ZEXPORT zError(err)
-int err;
+    int err;
 {
-	return ERR_MSG(err);
+    return ERR_MSG(err);
 }
 
 #if defined(_WIN32_WCE)
-/* The Microsoft C Run-Time Library for Windows CE doesn't have
- * errno.  We define it as a global variable to simplify porting.
- * Its value is always 0 and should not be used.
- */
-int errno = 0;
+    /* The Microsoft C Run-Time Library for Windows CE doesn't have
+     * errno.  We define it as a global variable to simplify porting.
+     * Its value is always 0 and should not be used.
+     */
+    int errno = 0;
 #endif
 
 #ifndef HAVE_MEMCPY
 
 void ZLIB_INTERNAL zmemcpy(dest, source, len)
-Bytef* dest;
-const Bytef* source;
-uInt  len;
+    Bytef* dest;
+    const Bytef* source;
+    uInt  len;
 {
-	if (len == 0) return;
-	do {
-		*dest++ = *source++; /* ??? to be unrolled */
-	} while (--len != 0);
+    if (len == 0) return;
+    do {
+        *dest++ = *source++; /* ??? to be unrolled */
+    } while (--len != 0);
 }
 
 int ZLIB_INTERNAL zmemcmp(s1, s2, len)
-const Bytef* s1;
-const Bytef* s2;
-uInt  len;
+    const Bytef* s1;
+    const Bytef* s2;
+    uInt  len;
 {
-	uInt j;
+    uInt j;
 
-	for (j = 0; j < len; j++) {
-		if (s1[j] != s2[j]) return 2 * (s1[j] > s2[j]) - 1;
-	}
-	return 0;
+    for (j = 0; j < len; j++) {
+        if (s1[j] != s2[j]) return 2*(s1[j] > s2[j])-1;
+    }
+    return 0;
 }
 
 void ZLIB_INTERNAL zmemzero(dest, len)
-Bytef* dest;
-uInt  len;
+    Bytef* dest;
+    uInt  len;
 {
-	if (len == 0) return;
-	do {
-		*dest++ = 0;  /* ??? to be unrolled */
-	} while (--len != 0);
+    if (len == 0) return;
+    do {
+        *dest++ = 0;  /* ??? to be unrolled */
+    } while (--len != 0);
 }
 #endif
 
@@ -201,14 +197,13 @@ uInt  len;
  */
 
 #define MAX_PTR 10
- /* 10*64K = 640K */
+/* 10*64K = 640K */
 
 local int next_ptr = 0;
 
-typedef struct ptr_table_s
-{
-	voidpf org_ptr;
-	voidpf new_ptr;
+typedef struct ptr_table_s {
+    voidpf org_ptr;
+    voidpf new_ptr;
 } ptr_table;
 
 local ptr_table table[MAX_PTR];
@@ -219,51 +214,54 @@ local ptr_table table[MAX_PTR];
  * a protected system like OS/2. Use Microsoft C instead.
  */
 
-voidpf ZLIB_INTERNAL zcalloc(voidpf opaque, unsigned items, unsigned size)
+voidpf ZLIB_INTERNAL zcalloc (voidpf opaque, unsigned items, unsigned size)
 {
-	voidpf buf = opaque; /* just to make some compilers happy */
-	ulg bsize = (ulg)items*size;
+    voidpf buf;
+    ulg bsize = (ulg)items*size;
 
-	/* If we allocate less than 65520 bytes, we assume that farmalloc
-	 * will return a usable pointer which doesn't have to be normalized.
-	 */
-	if (bsize < 65520L) {
-		buf = farmalloc(bsize);
-		if (*(ush*)&buf != 0) return buf;
-	}
-	else {
-		buf = farmalloc(bsize + 16L);
-	}
-	if (buf == NULL || next_ptr >= MAX_PTR) return NULL;
-	table[next_ptr].org_ptr = buf;
+    (void)opaque;
 
-	/* Normalize the pointer to seg:0 */
-	*((ush*)&buf + 1) += ((ush)((uch*)buf - 0) + 15) >> 4;
-	*(ush*)&buf = 0;
-	table[next_ptr++].new_ptr = buf;
-	return buf;
+    /* If we allocate less than 65520 bytes, we assume that farmalloc
+     * will return a usable pointer which doesn't have to be normalized.
+     */
+    if (bsize < 65520L) {
+        buf = farmalloc(bsize);
+        if (*(ush*)&buf != 0) return buf;
+    } else {
+        buf = farmalloc(bsize + 16L);
+    }
+    if (buf == NULL || next_ptr >= MAX_PTR) return NULL;
+    table[next_ptr].org_ptr = buf;
+
+    /* Normalize the pointer to seg:0 */
+    *((ush*)&buf+1) += ((ush)((uch*)buf-0) + 15) >> 4;
+    *(ush*)&buf = 0;
+    table[next_ptr++].new_ptr = buf;
+    return buf;
 }
 
-void ZLIB_INTERNAL zcfree(voidpf opaque, voidpf ptr)
+void ZLIB_INTERNAL zcfree (voidpf opaque, voidpf ptr)
 {
-	int n;
-	if (*(ush*)&ptr != 0) { /* object < 64K */
-		farfree(ptr);
-		return;
-	}
-	/* Find the original pointer */
-	for (n = 0; n < next_ptr; n++) {
-		if (ptr != table[n].new_ptr) continue;
+    int n;
 
-		farfree(table[n].org_ptr);
-		while (++n < next_ptr) {
-			table[n - 1] = table[n];
-		}
-		next_ptr--;
-		return;
-	}
-	ptr = opaque; /* just to make some compilers happy */
-	Assert(0, "zcfree: ptr not found");
+    (void)opaque;
+
+    if (*(ush*)&ptr != 0) { /* object < 64K */
+        farfree(ptr);
+        return;
+    }
+    /* Find the original pointer */
+    for (n = 0; n < next_ptr; n++) {
+        if (ptr != table[n].new_ptr) continue;
+
+        farfree(table[n].org_ptr);
+        while (++n < next_ptr) {
+            table[n-1] = table[n];
+        }
+        next_ptr--;
+        return;
+    }
+    Assert(0, "zcfree: ptr not found");
 }
 
 #endif /* __TURBOC__ */
@@ -279,16 +277,16 @@ void ZLIB_INTERNAL zcfree(voidpf opaque, voidpf ptr)
 #  define _hfree   hfree
 #endif
 
-voidpf ZLIB_INTERNAL zcalloc(voidpf opaque, uInt items, uInt size)
+voidpf ZLIB_INTERNAL zcalloc (voidpf opaque, uInt items, uInt size)
 {
-	if (opaque) opaque = 0; /* to make compiler happy */
-	return _halloc((long)items, size);
+    (void)opaque;
+    return _halloc((long)items, size);
 }
 
-void ZLIB_INTERNAL zcfree(voidpf opaque, voidpf ptr)
+void ZLIB_INTERNAL zcfree (voidpf opaque, voidpf ptr)
 {
-	if (opaque) opaque = 0; /* to make compiler happy */
-	_hfree(ptr);
+    (void)opaque;
+    _hfree(ptr);
 }
 
 #endif /* M_I86 */
@@ -304,22 +302,22 @@ extern voidp  calloc OF((uInt items, uInt size));
 extern void   free   OF((voidpf ptr));
 #endif
 
-voidpf ZLIB_INTERNAL zcalloc(opaque, items, size)
-voidpf opaque;
-unsigned items;
-unsigned size;
+voidpf ZLIB_INTERNAL zcalloc (opaque, items, size)
+    voidpf opaque;
+    unsigned items;
+    unsigned size;
 {
-	if (opaque) items += size - size; /* make compiler happy */
-	return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
-		(voidpf)calloc(items, size);
+    (void)opaque;
+    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
+                              (voidpf)calloc(items, size);
 }
 
-void ZLIB_INTERNAL zcfree(opaque, ptr)
-voidpf opaque;
-voidpf ptr;
+void ZLIB_INTERNAL zcfree (opaque, ptr)
+    voidpf opaque;
+    voidpf ptr;
 {
-	free(ptr);
-	if (opaque) return; /* make compiler happy */
+    (void)opaque;
+    free(ptr);
 }
 
 #endif /* MY_ZCALLOC */

--- a/libs/zlib/src/zutil.h
+++ b/libs/zlib/src/zutil.h
@@ -1,5 +1,5 @@
 /* zutil.h -- internal interface and configuration of the compression library
- * Copyright (C) 1995-2013 Jean-loup Gailly.
+ * Copyright (C) 1995-2016 Jean-loup Gailly, Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
@@ -36,7 +36,9 @@
 #ifndef local
 #  define local static
 #endif
-/* compile with -Dlocal if your debugger can't find static symbols */
+/* since "static" is used to mean two completely different things in C, we
+   define "local" for the non-static meaning of "static", for readability
+   (compile with -Dlocal if your debugger can't find static symbols) */
 
 typedef unsigned char  uch;
 typedef uch FAR uchf;
@@ -98,28 +100,38 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #endif
 
 #ifdef AMIGA
-#  define OS_CODE  0x01
+#  define OS_CODE  1
 #endif
 
 #if defined(VAXC) || defined(VMS)
-#  define OS_CODE  0x02
+#  define OS_CODE  2
 #  define F_OPEN(name, mode) \
      fopen((name), (mode), "mbc=60", "ctx=stm", "rfm=fix", "mrs=512")
 #endif
 
+#ifdef __370__
+#  if __TARGET_LIB__ < 0x20000000
+#    define OS_CODE 4
+#  elif __TARGET_LIB__ < 0x40000000
+#    define OS_CODE 11
+#  else
+#    define OS_CODE 8
+#  endif
+#endif
+
 #if defined(ATARI) || defined(atarist)
-#  define OS_CODE  0x05
+#  define OS_CODE  5
 #endif
 
 #ifdef OS2
-#  define OS_CODE  0x06
+#  define OS_CODE  6
 #  if defined(M_I86) && !defined(Z_SOLO)
 #    include <malloc.h>
 #  endif
 #endif
 
 #if defined(MACOS) || defined(TARGET_OS_MAC)
-#  define OS_CODE  0x07
+#  define OS_CODE  7
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #      include <unix.h> /* for fdopen */
@@ -131,18 +143,24 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#ifdef TOPS20
-#  define OS_CODE  0x0a
+#ifdef __acorn
+#  define OS_CODE 13
 #endif
 
-#ifdef WIN32
-#  ifndef __CYGWIN__  /* Cygwin is Unix, not Win32 */
-#    define OS_CODE  0x0b
-#  endif
+#if defined(WIN32) && !defined(__CYGWIN__)
+#  define OS_CODE  10
 #endif
 
-#ifdef __50SERIES /* Prime/PRIMOS */
-#  define OS_CODE  0x0f
+#ifdef _BEOS_
+#  define OS_CODE  16
+#endif
+
+#ifdef __TOS_OS400__
+#  define OS_CODE 18
+#endif
+
+#ifdef __APPLE__
+#  define OS_CODE 19
 #endif
 
 #if defined(_BEOS_) || defined(RISCOS)
@@ -177,7 +195,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
         /* common defaults */
 
 #ifndef OS_CODE
-#  define OS_CODE  0x03  /* assume Unix */
+#  define OS_CODE  3     /* assume Unix */
 #endif
 
 #ifndef F_OPEN
@@ -216,7 +234,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #endif
 
 /* Diagnostic functions */
-#ifdef DEBUG
+#ifdef ZLIB_DEBUG
 #  include <stdio.h>
    extern int ZLIB_INTERNAL z_verbose;
    extern void ZLIB_INTERNAL z_error OF((char *m));


### PR DESCRIPTION
Difference from https://github.com/miranda-ng/miranda-ng/pull/815:

- using \zlib-1.2.11\win32\zlib1.rc instead of \zlib-1.2.11\contrib\vstudio\vc10\zlib.rc (because \win32\zlib1.rc is identical with current [zlib.rc](https://github.com/miranda-ng/miranda-ng/blob/master/libs/zlib/res/zlib.rc))
- using \zlib-1.2.11\win32\zlib.def instead of \zlib-1.2.11\contrib\vstudio\vc10\zlibvc.def (because \win32\zlib.def is almost identical with current [zlib.def](https://github.com/miranda-ng/miranda-ng/blob/master/libs/zlib/src/zlib.def))
- contains Miranda-specific fixes made by @georgehazan  in the interval between zlib 1.2.8 and the current moment
- it works :D