### PR TITLE
Fix filtering for Visual Studio 2017

### DIFF
--- a/build/vc.common/common.filters
+++ b/build/vc.common/common.filters
@@ -16,16 +16,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ClCompile Include="*.cpp">
+    <ClCompile Include="**\*.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClInclude Include="*.h;*.hpp">
+    <ClInclude Include="**\*.h;**\*.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ResourceCompile Include="*.rc">
+    <ResourceCompile Include="**\*.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
-    <None Include="*.def">
+    <None Include="**\*.def">
       <Filter>Source Files</Filter>
     </None>
   </ItemGroup>


### PR DESCRIPTION
A pattern like `*.cpp` will only match files in the same directory as the project file. Adding a [recursive wildcard](https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-select-the-files-to-build) allows it to match in the `src` subdirectories as well.