### PR TITLE
Fix filters preventing projects from opening

### DIFF
--- a/build/vc.common/common.filters
+++ b/build/vc.common/common.filters
@@ -14,22 +14,4 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
     </Filter>
   </ItemGroup>
-
-  <ItemGroup>
-    <ClCompile Include="*\*.cpp;*\*.c;*\*.cxx;*\*.c++">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClInclude Include="*\*.h;*\*.hpp;*\*.hxx">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ResourceCompile Include="*\*.rc">
-      <Filter>Resource Files</Filter>
-    </ResourceCompile>
-    <None Include="*\*.def">
-      <Filter>Source Files</Filter>
-    </None>
-    <None Include="*\*.ico;*\*.bmp;*\*.cur">
-      <Filter>Resource Files</Filter>
-    </None>	 
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Problem
Single project files that imports build/vc.common/common.filters in the *.vcxproj.filters aren't able to be opened. Shows error "Cannot modify an evaluated object originating in an imported file common.filters". From solution level you aren't able to run debugger and to see properties of those projects.
Tested with VS2017 and VS2013

## Cause
Wildcards used in common.filters

## Explanation
I guess (from the little info I found on net) that VS does not fully support wildcards and it looks like it doesn't support them at all in .filter files. They work in *.vcxproj but not in filters. I tried a bunch of combinations from within imported file or in the .filter file itself. None of it seems to apply any filter at all.  And they probably never worked. Some of the combinations result in the mentioned problems. We just have non-destructive combination till now - luckily.
The whole filtering comes only from entries
```
    <Filter Include="...">
      <Extensions>...</Extensions>
    </Filter>
```
that are applied on files loaded through common.props entries or individual one. The rest is obsolete.