### PR TITLE
Facebook: initial changes to support loading of unread chat messages

### DIFF
--- a/protocols/FacebookRM/src/client.h
+++ b/protocols/FacebookRM/src/client.h
@@ -225,6 +225,7 @@ public:
 	// history.cpp
 	HttpRequest* threadInfoRequest(bool isChat, const char *id, const char* timestamp = nullptr, int limit = -1);
 	HttpRequest* threadInfoRequest(const LIST<char> &ids, int offset, int limit);
+	HttpRequest* threadInfoRequest(const char *id);
 	HttpRequest* unreadThreadsRequest();
 
 	// login.cpp

--- a/protocols/FacebookRM/src/history.cpp
+++ b/protocols/FacebookRM/src/history.cpp
@@ -96,6 +96,42 @@ HttpRequest* facebook_client::threadInfoRequest(const LIST<char> &ids, int offse
 	return p;
 }
 
+// Request both thread info and messages for given thread
+HttpRequest* facebook_client::threadInfoRequest(const char *id)
+{
+	HttpRequest *p = new HttpRequest(REQUEST_POST, FACEBOOK_SERVER_REGULAR "/api/graphqlbatch/");
+
+	p->Body
+		<< CHAR_PARAM("batch_name", "MessengerGraphQLThreadFetcherRe")
+		<< CHAR_PARAM("__user", self_.user_id.c_str())
+		<< INT_PARAM("__a", 1)
+		<< CHAR_PARAM("__dyn", __dyn())
+		<< CHAR_PARAM("__req", __req())
+		<< INT_PARAM("__be", 1)
+		<< CHAR_PARAM("__pc", "PHASED:DEFAULT")
+		<< CHAR_PARAM("__rev", __rev())
+		<< CHAR_PARAM("fb_dtsg", dtsg_.c_str());
+
+	JSONNode root, o0, query_params;
+	query_params
+		<< CHAR_PARAM("id", id)
+		<< INT_PARAM("message_limit", 21/*(limit == -1) ? 50 : limit*/)
+		<< INT_PARAM("load_messages", 1)
+		<< BOOL_PARAM("load_read_receipts", false);
+
+	/*if (timestamp != nullptr)
+		query_params << CHAR_PARAM("before", timestamp);
+	else*/
+		query_params << NULL_PARAM("before");
+
+	o0 << CHAR_PARAM("doc_id", "1508526735892416") << JSON_PARAM("query_params", query_params);
+	root << JSON_PARAM("o0", o0);
+
+	p->Body << CHAR_PARAM("queries", root.write().c_str());
+
+	return p;
+}
+
 HttpRequest* facebook_client::unreadThreadsRequest()
 {
 	HttpRequest *p = new HttpRequest(REQUEST_POST, FACEBOOK_SERVER_REGULAR "/ajax/mercury/unread_threads.php");

--- a/protocols/FacebookRM/src/json.cpp
+++ b/protocols/FacebookRM/src/json.cpp
@@ -1165,36 +1165,40 @@ int FacebookProto::ParseUnreadThreads(std::string *data, std::vector< std::strin
 
 int FacebookProto::ParseThreadMessages(std::string *data, std::vector< facebook_message >* messages, bool unreadOnly)
 {
-	std::string jsonData = data->substr(9);
+	size_t len = data->find("\r\n");
+	if (len != data->npos)
+		data->erase(len);
 
-	JSONNode root = JSONNode::parse(jsonData.c_str());
+	JSONNode root = JSONNode::parse(data->c_str());
 	if (!root)
 		return EXIT_FAILURE;
 
-	const JSONNode &payload = root["payload"];
-	if (!payload)
+	const JSONNode &thread = root["o0"]["data"]["message_thread"];
+	if (!thread)
 		return EXIT_FAILURE;
 
-	const JSONNode &actions = payload["actions"];
-	const JSONNode &threads = payload["threads"];
-	if (!actions || !threads)
+	const JSONNode &nodes = thread["messages"]["nodes"];
+	if (!nodes)
 		return EXIT_FAILURE;
 
-	for (auto &it : actions) {
-		const JSONNode &author_ = it["author"];
-		const JSONNode &other_user_fbid_ = it["other_user_fbid"];
-		const JSONNode &body_ = it["body"];
-		const JSONNode &thread_id_ = it["thread_id"];
-		const JSONNode &thread_fbid_ = it["thread_fbid"];
-		const JSONNode &mid_ = it["message_id"];
-		const JSONNode &timestamp_ = it["timestamp"];
-		const JSONNode &filtered_ = it["is_filtered_content"];
-		const JSONNode &is_unread_ = it["is_unread"];
+	// TODO! process commented sections and better pair json (this is just quick attempt, + I do not know what everything means yet)
+
+	const JSONNode &other_user_fbid_ = thread["thread_key"]["other_user_id"];
+	const JSONNode &thread_fbid_ = thread["thread_key"]["thread_fbid"];
+
+	for (auto it = nodes.begin(); it != nodes.end(); ++it) {
+		const JSONNode &author_ = (*it)["message_sender"]["id"];
+		const JSONNode &body_ = (*it)["message"]["text"];
+		const JSONNode &thread_id_ = (*it)["offline_threading_id"];
+		const JSONNode &mid_ = (*it)["message_id"];
+		const JSONNode &timestamp_ = (*it)["timestamp_precise"];
+		// const JSONNode &filtered_ = (*it)["is_filtered_content"];
+		const JSONNode &is_unread_ = (*it)["unread"];
 
 		// Either there is "body" (for classic messages), or "log_message_type" and "log_message_body" (for log messages)
-		const JSONNode &log_type_ = it["log_message_type"];
-		const JSONNode &log_body_ = it["log_message_body"];
-		const JSONNode &log_data_ = it["log_message_data"]; // additional data for this log message
+		const JSONNode &log_type_ = (*it)["log_message_type"];
+		const JSONNode &log_body_ = (*it)["log_message_body"];
+		const JSONNode &log_data_ = (*it)["log_message_data"]; // additional data for this log message
 
 		if (!author_ || (!body_ && !log_body_) || !mid_ || (!thread_fbid_ && !thread_id_) || !timestamp_) {
 			debugLogA("ParseThreadMessages: ignoring message (%s) - missing attribute", mid_.as_string().c_str());
@@ -1212,10 +1216,11 @@ int FacebookProto::ParseThreadMessages(std::string *data, std::vector< facebook_
 			author_id = author_id.substr(pos + 1);
 
 		// Process attachements and stickers
-		ParseAttachments(message_text, it, other_user_fbid, true);
+		// TODO!!
+		//ParseAttachments(proto, &message_text, *it, other_user_fbid, true);
 
-		if (filtered_.as_bool() && message_text.empty())
-			message_text = Translate("This message is no longer available, because it was marked as abusive or spam.");
+		//if (filtered_.as_bool() && message_text.empty())
+		//	message_text = Translate("This message is no longer available, because it was marked as abusive or spam.");
 
 		message_text = utils::text::trim(utils::text::slashu_to_utf8(message_text), true);
 		if (message_text.empty()) {
@@ -1246,7 +1251,8 @@ int FacebookProto::ParseThreadMessages(std::string *data, std::vector< facebook_
 			message.thread_id = thread_id;
 		}
 
-		ParseMessageType(message, log_type_, log_body_, log_data_);
+		// TODO!!
+		//ParseMessageType(proto, message, log_type_, log_body_, log_data_);
 
 		messages->push_back(message);
 	}


### PR DESCRIPTION
Basically changed an old request for multiple threads to multiple requests for every thread and modified a bit ParseThreadMessages (but it needs to be improved).