### PR TITLE
Don't show unknown login error as a notification

### DIFF
--- a/protocols/Steam/src/steam_login.cpp
+++ b/protocols/Steam/src/steam_login.cpp
@@ -340,7 +340,6 @@ void CSteamProto::OnLoggedOn(const HttpResponse &response, void*)
 	if (!response.IsSuccess()) {
 		// Probably timeout or no connection, we can do nothing here
 		debugLogA(__FUNCTION__ ": unknown login error");
-		ShowNotification(TranslateT("Unknown login error."));
 		SetStatus(ID_STATUS_OFFLINE);
 		return;
 	}


### PR DESCRIPTION
There is no need to show this error as a notification because it generally happens when there is no connectivity and none of the other protocols behave this way.