### PR TITLE
Fix: Import plugin fails to match duplicate contacts when their IDs are stored as WideChar properties

### DIFF
--- a/plugins/Import/src/import.cpp
+++ b/plugins/Import/src/import.cpp
@@ -811,6 +811,14 @@ static MCONTACT ImportContact(MCONTACT hSrc)
 			hDst = HContactFromID(szDstModuleName, pszUniqueSetting, pszUniqueID);
 		break;
 
+	case DBVT_WCHAR:
+		pszUniqueID = NEWWSTR_ALLOCA(dbv.pwszVal);
+		if (bIsChat)
+			hDst = HContactFromChatID(szDstModuleName, pszUniqueID);
+		else
+			hDst = HContactFromID(szDstModuleName, pszUniqueSetting, pszUniqueID);
+		break;
+
 	default:
 		hDst = INVALID_CONTACT_ID;
 		pszUniqueID = nullptr;


### PR DESCRIPTION
Jabber started storing JIDs as Unicode strings at some point. Import plugin fails to recognize this and considers such contacts ID-less, adding them as duplicates.

This has been masked by the fact that Jabber continues to read old Ansi JIDs so if you have a relatively old contact list you're not going to see duplicates.

I think this fixes it.