### PR TITLE
Facebook - alternative loading of contacts' statuses

### DIFF
--- a/protocols/FacebookRM/src/client.h
+++ b/protocols/FacebookRM/src/client.h
@@ -207,6 +207,7 @@ public:
 
 	HttpRequest* userInfoRequest(const LIST<char> &userIds);
 	HttpRequest* userInfoAllRequest();
+	HttpRequest* buddylistUpdate();
 
 	// feeds.cpp
 	HttpRequest* newsfeedRequest();

--- a/protocols/FacebookRM/src/connection.cpp
+++ b/protocols/FacebookRM/src/connection.cpp
@@ -230,9 +230,12 @@ void FacebookProto::UpdateLoop(void *)
 	debugLogA(">>> Entering Facebook::UpdateLoop[%d]", tim);
 
 	for (int i = -1; !isOffline(); i = (i + 1) % 50) {
-		if (i != -1)
+		if (i != -1) {
 			if (getByte(FACEBOOK_KEY_EVENT_FEEDS_ENABLE, DEFAULT_EVENT_FEEDS_ENABLE))
 				ProcessFeeds(nullptr);
+		}
+
+		ProcessBuddylistUpdate(nullptr);
 
 		debugLogA("*** FacebookProto::UpdateLoop[%d] going to sleep...", tim);
 		if (WaitForSingleObjectEx(update_loop_event, GetPollRate() * 1000, true) != WAIT_TIMEOUT)

--- a/protocols/FacebookRM/src/contacts.cpp
+++ b/protocols/FacebookRM/src/contacts.cpp
@@ -715,3 +715,22 @@ HttpRequest* facebook_client::userInfoAllRequest()
 
 	return p;
 }
+
+HttpRequest* facebook_client::buddylistUpdate()
+{
+	HttpRequest *p = new HttpRequest(REQUEST_POST, FACEBOOK_SERVER_MOBILE "/buddylist_update.php");
+    
+	p->Body
+		<< CHAR_PARAM("data_fetch", "true")
+		<< CHAR_PARAM("m_sess", "")
+		<< CHAR_PARAM("fb_dtsg", dtsg_.c_str())
+		<< CHAR_PARAM("jazoest", "21824")
+		<< CHAR_PARAM("__dyn", __dyn())
+		<< CHAR_PARAM("__req", __req())
+		<< CHAR_PARAM("__ajax__", "")
+		<< CHAR_PARAM("__user", self_.user_id.c_str());
+
+	// send_full_data=true sends more data
+
+	return p;
+}

--- a/protocols/FacebookRM/src/json.cpp
+++ b/protocols/FacebookRM/src/json.cpp
@@ -1192,6 +1192,36 @@ int FacebookProto::ParseMessages(std::string &pData, std::vector<facebook_messag
 	return EXIT_SUCCESS;
 }
 
+
+int FacebookProto::ParseBuddylistUpdate(std::string* data)
+{
+	std::string jsonData = data->substr(9);
+
+	JSONNode root = JSONNode::parse(jsonData.c_str());
+	if (!root)
+		return EXIT_FAILURE;
+
+	const JSONNode &buddylist = root["payload"].at("buddylist");
+	if (!buddylist)
+		return EXIT_FAILURE;
+
+	setAllContactStatuses(ID_STATUS_OFFLINE);
+
+	for (auto &it : buddylist) {
+		const JSONNode &id = it["id"];
+		const JSONNode &status = it["status"];
+
+		// Facebook now sends info also about some nonfriends, so we just ignore status change of contacts we don't have in list
+		MCONTACT hContact = ContactIDToHContact(id.as_string());
+		if (!hContact)
+			continue;
+
+		setWord(hContact, "Status", ID_STATUS_ONLINE);
+	}
+
+	return EXIT_SUCCESS;
+}
+
 int FacebookProto::ParseUnreadThreads(std::string *data, std::vector< std::string >* threads)
 {
 	std::string jsonData = data->substr(9);

--- a/protocols/FacebookRM/src/process.cpp
+++ b/protocols/FacebookRM/src/process.cpp
@@ -26,6 +26,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * Helper function for loading name from database (or use default one specified as parameter), used for title of few notifications.
  */
 
+
+
+void FacebookProto::ProcessBuddylistUpdate(void*)
+{
+	if (isOffline())
+		return;
+
+	facy.handle_entry("buddylist_update");
+
+	// Get friends list
+	http::response resp = facy.sendRequest(facy.buddylistUpdate());
+	if (resp.code != HTTP_CODE_OK) {
+		facy.handle_error("buddylist_update");
+		return;
+	}
+
+	debugLogA("*** Starting processing buddylist update");
+
+	if (ParseBuddylistUpdate(&resp.data) != EXIT_SUCCESS) {
+		debugLogA("*** Error processing buddylist update");
+		return;
+	}
+
+	debugLogA("*** Buddylist update processed");
+}
+
+
 void FacebookProto::ProcessFriendList(void*)
 {
 	if (isOffline())

--- a/protocols/FacebookRM/src/proto.h
+++ b/protocols/FacebookRM/src/proto.h
@@ -46,6 +46,7 @@ class FacebookProto : public PROTO<FacebookProto>
 	int ParseThreadMessages(std::string*, std::vector< facebook_message >*, bool unreadOnly);
 	int ParseUnreadThreads(std::string*, std::vector< std::string >*);
 	int ParseUserInfo(std::string* data, facebook_user* fbu);
+	int ParseBuddylistUpdate(std::string* data);
 
 	const char* ParseIcon(const std::string &url);
 
@@ -185,6 +186,7 @@ public:
 
 	// Processing threads
 	void __cdecl ProcessFriendList(void*);
+	void __cdecl ProcessBuddylistUpdate(void*);
 	void __cdecl ProcessUnreadMessages(void*);
 	void __cdecl ProcessUnreadMessage(void*);
 	void __cdecl ProcessFeeds(void*);


### PR DESCRIPTION
See #1980 

This is a workaround and not a perfect solution. Facebook excluded buddylist from `/pull` responses. This modification adds periodical polling `/buddylist_update.php` endpoint (it's the same loop as for feeds, so period is controlled by `PollRate` value in database). First poll occurs during the login. It returns only online contacts without any further details.

I was testing it with older version of basecode (because of my other local modifications) and rebased it only for this PR. If possible please test it in your environment before merging (to the extent "it doesn't crash on login" is fine).