### PR TITLE
Correction of the Russian translation

### DIFF
--- a/langpacks/russian/Langpack_russian.txt
+++ b/langpacks/russian/Langpack_russian.txt
@@ -28065,7 +28065,7 @@ ID текущего контакта (если определён). Наприм
 [Last received: %s at %s]
 Последнее сообщение было получено %s в %s
 [%s has entered text.]
-%s ввёл(а) текст.
+%s ввел(а) текст.
 [%s is typing a message]
 %s набирает текст
 [Auto scrolling is disabled, %d message(s) queued (press F12 to enable it)]


### PR DESCRIPTION
Replacing line 28068 in the langpacks/russian/Langpack_russian.txt was "%s ввёл(а) текст." on "%s ввел(а) текст.".