### PR TITLE
Correction of the Russian text plagin TabSRMM

### DIFF
--- a/langpacks/russian/Langpack_russian.txt
+++ b/langpacks/russian/Langpack_russian.txt
@@ -28065,7 +28065,7 @@ ID текущего контакта (если определён). Наприм
 [Last received: %s at %s]
 Последнее сообщение было получено %s в %s
 [%s has entered text.]
-%s ввёл(а) текст.
+%s ввел(а) текст.
 [%s is typing a message]
 %s набирает текст
 [Auto scrolling is disabled, %d message(s) queued (press F12 to enable it)]

--- a/langpacks/russian/Plugins/TabSRMM.txt
+++ b/langpacks/russian/Plugins/TabSRMM.txt
@@ -1285,7 +1285,7 @@ ID текущего контакта (если определён). Наприм
 [Last received: %s at %s]
 Последнее сообщение было получено %s в %s
 [%s has entered text.]
-%s ввёл(а) текст.
+%s ввел(а) текст.
 [%s is typing a message]
 %s набирает текст
 [Auto scrolling is disabled, %d message(s) queued (press F12 to enable it)]


### PR DESCRIPTION
Замена строки 1288 в файле langpacks/russian/Plugins/TabSRMM.txt с "%s ввёл(а) текст." на "%s ввел(а) текст.".

Replacing line 1288 in the langpacks/russian/Plugins/TabSRMM.txt was "%s ввёл(а) текст." on "%s ввел(а) текст.".