### PR TITLE
Add ability to paste file URL instead of file sending initiation

### DIFF
--- a/include/m_srmm_int.h
+++ b/include/m_srmm_int.h
@@ -197,6 +197,7 @@ protected:
 
 	int  NotifyEvent(int code);
 	bool ProcessFileDrop(HDROP hDrop, MCONTACT hContact);
+	bool PasteFilesAsURL(HDROP hDrop, MCONTACT hContact);
 	bool ProcessHotkeys(int key, bool bShift, bool bCtrl, bool bAlt);
 	void RefreshButtonStatus(void);
 	void RunUserMenu(HWND hwndOwner, struct USERINFO *ui, const POINT &pt);

--- a/protocols/ICQ-WIM/src/server.cpp
+++ b/protocols/ICQ-WIM/src/server.cpp
@@ -391,17 +391,18 @@ void CIcqProto::ParseMessage(MCONTACT hContact, __int64 &lastMsgId, const JSONNo
 
 		// user added you
 		if (it["class"].as_mstring() == L"event" && it["eventTypeId"].as_mstring() == L"27:33000") {
-			CMStringA id = getMStringA(hContact, DB_KEY_ID);
-			int pos = id.Find('@');
-			CMStringA nick = (pos == -1) ? id : id.Left(pos);
+			if (bLocalTime) {
+				CMStringA id = getMStringA(hContact, DB_KEY_ID);
+				int pos = id.Find('@');
+				CMStringA nick = (pos == -1) ? id : id.Left(pos);
+				DB::AUTH_BLOB blob(hContact, nick, nullptr, nullptr, id, nullptr);
 
-			DB::AUTH_BLOB blob(hContact, nick, nullptr, nullptr, id, nullptr);
-
-			PROTORECVEVENT pre = {};
-			pre.timestamp = (DWORD)time(0);
-			pre.lParam = blob.size();
-			pre.szMessage = blob;
-			ProtoChainRecv(hContact, PSR_AUTH, 0, (LPARAM)&pre);
+				PROTORECVEVENT pre = {};
+				pre.timestamp = (DWORD)time(0);
+				pre.lParam = blob.size();
+				pre.szMessage = blob;
+				ProtoChainRecv(hContact, PSR_AUTH, 0, (LPARAM)&pre);
+			}
 			return;
 		}
 	}

--- a/src/mir_app/src/srmm_base.cpp
+++ b/src/mir_app/src/srmm_base.cpp
@@ -755,10 +755,13 @@ If enabled pastes droped files as list of URL of file:/// type
 bool CSrmmBaseDialog::PasteFilesAsURL(HDROP hDrop, MCONTACT hContact)
 {
 	bool isShift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
-	if (db_get_b(0, CHAT_MODULE, "ShiftDropFilePasteURL", 1) == 0 || !isShift) {
+	if (db_get_b(0, CHAT_MODULE, "ShiftDropFilePasteURL", 1) == 0 || !isShift) 
 		return false;
-	}
-	int fileCount = DragQueryFile(hDrop, -1, nullptr, 0), totalCount = 0;
+	
+	int fileCount = DragQueryFile(hDrop, -1, nullptr, 0);
+	if (fileCount == 0)
+		return false;
+
 	CMStringW pasteString;
 	for (size_t i = 0; i < fileCount; i++) {
 		wchar_t szFilename[MAX_PATH];
@@ -769,16 +772,18 @@ bool CSrmmBaseDialog::PasteFilesAsURL(HDROP hDrop, MCONTACT hContact)
 			fileString.Replace(L" ", L"%20");
 			if (i == 0)
 				fileString.Insert(0, L" ");
-			if (i != fileCount - 1)
-				fileString.Append(L"\r\n");
+
 			if (i == fileCount - 1)
 				fileString.Append(L" ");
+			else
+				fileString.Append(L"\r\n");
+
 			pasteString += fileString;
 		}
 	}
-	if (pasteString.GetLength()) {
+	if (pasteString.GetLength()) 
 		SendMessageW(m_message.GetHwnd(), EM_REPLACESEL, TRUE, (LPARAM)pasteString.c_str());
-	}
+	
 	return true;
 }
 


### PR DESCRIPTION
Add ability to paste file URL to chat message window instead of file sending initiation when SHIFT pressed during file dropping.

Uses Chat/ShiftDropFilePasteURL database bool variable as control parameter. 
Default is true

Test pasted overwrites current text selection on just in place of text caret if nothing selected.

But unfortunately right now dragging file over message window (even without dropping) moves caret to begin of text. This is unrelated to this request, just want you know it.