### PR TITLE
Wine in Readme and minor grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Miranda NG
 
 Miranda NG is a successor of a popular multi-protocol instant messaging client
-for Windows — [Miranda IM][1].
+for Windows — [Miranda IM](https://sourceforge.net/projects/miranda/).
 It's very light on system resources and extremely fast.
 
 ## Protocol support
@@ -23,12 +23,13 @@ It's very light on system resources and extremely fast.
 
 ## Supported operating systems
 
-Windows 2003 / XP / Vista / 7 / 8 / 10 / 11
+* Windows 2003 / XP / Vista / 7 / 8 / 10 / 11
+* Linux with Wine 9: See [Miranda under Wine](https://wiki.miranda-ng.org/Miranda_under_Wine)
 
 
 ## License
 
-Miranda NG is published under the [GNU GPL license][2].
+[GNU GPL license v2](https://www.gnu.org/licenses/gpl-2.0.html).
 
 
 ## Links
@@ -44,6 +45,3 @@ Miranda NG is published under the [GNU GPL license][2].
 - [Miranda NG on Facebook](https://www.facebook.com/miranda.newgen)
 - [Miranda NG on Twitter](https://twitter.com/MirandaNewgen)
 - [Miranda NG commits on Twitter](https://twitter.com/MirandaNGcommit)
-
-[1]: https://sourceforge.net/projects/miranda/
-[2]: https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/AVS/src/services.cpp
+++ b/plugins/AVS/src/services.cpp
@@ -46,7 +46,7 @@ INT_PTR ProtectAvatar(WPARAM hContact, LPARAM lParam)
 {
 	uint8_t was_locked = db_get_b(hContact, "ContactPhoto", "Locked", 0);
 
-	if (was_locked == (uint8_t)lParam)      // no need for redundant lockings...
+	if (was_locked == (uint8_t)lParam)      // no need for redundant locks...
 		return 0;
 
 	if (hContact) {
@@ -62,8 +62,8 @@ INT_PTR ProtectAvatar(WPARAM hContact, LPARAM lParam)
 
 /*
  * set an avatar (service function)
- * if lParam == NULL, a open file dialog will be opened, otherwise, lParam is taken as a FULL
- * image filename (will be checked for existance, though)
+ * if lParam == NULL, an open file dialog will be opened, otherwise, lParam is taken as a FULL
+ * image filename (will be checked for existence, though)
  */
 
 struct OpenFileSubclassData
@@ -521,7 +521,7 @@ static int InternalSetMyAvatar(char *protocol, wchar_t *szFinalName, SetMyAvatar
 		if (ret)
 			g_plugin.setByte("GlobalUserAvatarNotConsistent", 1);
 		else {
-			// Copy avatar file to store as global one
+			// Copy an avatar file to store as global one
 			wchar_t globalFile[1024];
 			BOOL saved = TRUE;
 			if (FoldersGetCustomPathW(hGlobalAvatarFolder, globalFile, _countof(globalFile), L"")) {

--- a/plugins/Clist_modern/src/modern_awaymsg.cpp
+++ b/plugins/Clist_modern/src/modern_awaymsg.cpp
@@ -43,7 +43,7 @@ static HANDLE  hamProcessEvent = nullptr;
 static uint32_t   amRequestTick = 0;
 
 /*
-*  Add contact handle to requests queue
+*  Add a contact handle to request queue
 */
 static int amAddHandleToChain(MCONTACT hContact)
 {
@@ -58,7 +58,7 @@ static int amAddHandleToChain(MCONTACT hContact)
 }
 
 /*
-*	Gets handle from queue for request
+*	Gets a handle from queue for request
 */
 static MCONTACT amGetCurrentChain()
 {

--- a/plugins/Clist_modern/src/modern_clc.cpp
+++ b/plugins/Clist_modern/src/modern_clc.cpp
@@ -1368,7 +1368,7 @@ static LRESULT clcOnIntmIconChanged(ClcData *dat, HWND hwnd, UINT, WPARAM wParam
 		}
 	}
 	else {
-		// item in list already
+		// item is in the list already
 		if (contact && contact->iImage == lParam)
 			return 0;
 

--- a/plugins/Clist_modern/src/modern_clcpaint.cpp
+++ b/plugins/Clist_modern/src/modern_clcpaint.cpp
@@ -599,7 +599,7 @@ void CLCPaint::_PaintRowItemsEx(HDC hdcMem, ClcData *dat, ClcContact *Drawing, R
 	BOOL InClistWindow = (dat->hWnd == g_clistApi.hwndContactTree);
 	int height = RowHeight_CalcRowHeight(dat, Drawing, -1);
 
-	// TO DO DEPRECATE OLD ROW LAYOUT
+	// TODO DEPRECATE OLD ROW LAYOUT
 
 	if (Drawing->type == CLCIT_GROUP &&
 		Drawing->group->parent->groupId == 0 &&
@@ -1540,7 +1540,7 @@ void CLCPaint::_CalcItemsPos(HDC hdcMem, ClcData *dat, ClcContact *Drawing, RECT
 
 				if (rc.left < rc.right) // Store position
 					_StoreItemPos(Drawing, CIT_AVATAR, &rc);
-				//TO DO: CALC avatar overlays
+				//TODO: CALC avatar overlays
 			}
 			break;
 
@@ -1957,7 +1957,7 @@ void CLCPaint::_CalcItemsPos(HDC hdcMem, ClcData *dat, ClcContact *Drawing, RECT
 
 	*in_free_row_rc = free_row_rc;
 	*in_row_rc = row_rc;
-	Drawing->ext_fItemsValid = FALSE; /*TO DO: correctly implement placement recalculation*/
+	Drawing->ext_fItemsValid = FALSE; //TODO: correctly implement placement recalculation
 }
 
 BOOL CLCPaint::__IsVisible(RECT *firtRect, RECT *secondRect)

--- a/plugins/Clist_modern/src/modern_skinselector.cpp
+++ b/plugins/Clist_modern/src/modern_skinselector.cpp
@@ -161,7 +161,7 @@ static BOOL _GetParamValue(char *szText, unsigned int &start, unsigned int lengt
 			if (state == STATE_VALUE) break;
 			except |= EXCEPTION_NOT_EQUAL;
 			exitLoop = TRUE;
-			// fall trough
+			// fall through
 		case '=':
 			if (state == STATE_VALUE) break;
 			// search value end

--- a/plugins/ContactsPlus/src/send.cpp
+++ b/plugins/ContactsPlus/src/send.cpp
@@ -282,7 +282,7 @@ INT_PTR CALLBACK SendDlgProc(HWND hwndDlg, UINT msg, WPARAM wParam, LPARAM lPara
 			break;
 
 		case MSGERROR_DONE:
-			// contacts were delivered succesfully after timeout
+			// contacts were delivered successfully after timeout
 			SetFocus(GetDlgItem(hwndDlg, IDC_LIST));
 			wndData->UnhookProtoAck();
 			break;

--- a/protocols/JabberG/jabber_xstatus/res/JABBER_XSTATUS.rc
+++ b/protocols/JabberG/jabber_xstatus/res/JABBER_XSTATUS.rc
@@ -24,7 +24,7 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 // Icon
 //
 
-// Icon with lowest ID value placed first to ensure application icon
+// Icon with the lowest ID value placed first to ensure the application icon
 // remains consistent on all systems.
 1201                     ICON         "moods/afraid.ico"
 1202                     ICON         "moods/amazed.ico"

--- a/protocols/JabberG/proto_jabber/res/Proto_Jabber.rc
+++ b/protocols/JabberG/proto_jabber/res/Proto_Jabber.rc
@@ -49,7 +49,7 @@ END
 // Icon
 //
 
-// Icon with lowest ID value placed first to ensure application icon
+// Icon with the lowest ID value placed first to ensure the application icon
 // remains consistent on all systems.
 IDI_ICON1               ICON                    "Offline.ico"
 IDI_ICON2               ICON                    "Online.ico"

--- a/protocols/JabberG/res/jabber.rc
+++ b/protocols/JabberG/res/jabber.rc
@@ -804,7 +804,7 @@ END
 // Icon
 //
 
-// Icon with lowest ID value placed first to ensure application icon
+// Icon with the lowest ID value placed first to ensure the application icon
 // remains consistent on all systems.
 IDI_JABBER              ICON                    "jabber.ico"
 

--- a/protocols/JabberG/src/jabber_agent.cpp
+++ b/protocols/JabberG/src/jabber_agent.cpp
@@ -154,7 +154,7 @@ public:
 			JabberFormGetData(hwndFrame, query, xNode);
 		}
 		else {
-			// use old registration information form
+			// use an old registration information form
 			for (auto *n : TiXmlEnum(queryNode)) {
 				const char *pszName = n->Name();
 				if (pszName) {
@@ -222,7 +222,7 @@ public:
 			JabberFormCreateUI(hwndFrame, xNode, &m_formHeight);
 		}
 		else {
-			// use old registration information form
+			// use an old registration information form
 			TJabberFormLayoutInfo layout_info(hwndFrame, false);
 			for (auto *n : TiXmlEnum(queryNode)) {
 				const char *pszName = n->Name();

--- a/protocols/JabberG/src/jabber_api.cpp
+++ b/protocols/JabberG/src/jabber_api.cpp
@@ -255,7 +255,7 @@ int CJabberProto::AddFeatures(const char *szFeatures)
 	const char *szFeat = szFeatures;
 	while (szFeat[0]) {
 		JabberFeatCapPairDynamic *fcp = FindFeature(szFeat);
-		// if someone is trying to add one of core features, RegisterFeature() will return false, so we don't have to perform this check here
+		// if someone is trying to add one of the core features, RegisterFeature() will return false, so we don't have to perform this check here
 		if (!fcp) { // if the feature is not registered yet
 			if (!RegisterFeature(szFeat, nullptr))
 				ret = false;

--- a/protocols/JabberG/src/jabber_caps.cpp
+++ b/protocols/JabberG/src/jabber_caps.cpp
@@ -270,7 +270,7 @@ JabberCapsBits CJabberProto::GetResourceCapabilities(const char *jid, pResourceS
 		return jcbCaps | r->m_jcbManualDiscoveredCaps;
 	}
 
-	// no XEP-0115: send query each time it's needed
+	// no XEP-0115: send a query each time it's needed
 	switch (r->m_dwDiscoInfoRequestTime) {
 	case -1:
 		return r->m_jcbCachedCaps;

--- a/protocols/JabberG/src/jabber_chat.cpp
+++ b/protocols/JabberG/src/jabber_chat.cpp
@@ -742,7 +742,7 @@ public:
 
 		T2Utf text(ptrW(m_txtReason.GetText()));
 
-		// invite users from roster
+		// invite users from the roster
 		for (auto &hContact : m_proto->AccContacts()) {
 			if (m_proto->isChatRoom(hContact))
 				continue;
@@ -999,7 +999,7 @@ static void sttNickListHook(CJabberProto *ppro, JABBER_LIST_ITEM *item, GCHOOK* 
 			dwLastBanKickTime = GetTickCount();
 			szBuffer.Format(L"%s: ", Utf2T(me->m_szResourceName).get());
 			szTitle.Format(TranslateT("Reason to kick %s"), Utf2T(him->m_szResourceName).get());
-			char *resourceName_copy = mir_strdup(him->m_szResourceName); // copy resource name to prevent possible crash if user list rebuilds
+			char *resourceName_copy = mir_strdup(him->m_szResourceName); // copy resource name to prevent possible crash if the user list rebuilds
 			if (ppro->EnterString(szBuffer, szTitle, ESF_MULTILINE, "gcReason_"))
 				ppro->m_ThreadInfo->send(
 				XmlNodeIq("set", ppro->SerialNext(), item->jid) << XQUERY(JABBER_FEAT_MUC_ADMIN)
@@ -1092,7 +1092,7 @@ static void sttNickListHook(CJabberProto *ppro, JABBER_LIST_ITEM *item, GCHOOK* 
 	case IDM_LINK0: case IDM_LINK1: case IDM_LINK2: case IDM_LINK3: case IDM_LINK4:
 	case IDM_LINK5: case IDM_LINK6: case IDM_LINK7: case IDM_LINK8: case IDM_LINK9:
 		if ((GetTickCount() - dwLastBanKickTime) > BAN_KICK_INTERVAL) {
-			// copy resource name to prevent possible crash if user list rebuilds
+			// copy resource name to prevent possible crash if the user list rebuilds
 			char *resourceName_copy(NEWSTR_ALLOCA(him->m_szResourceName));
 
 			char *szInviteTo = nullptr;
@@ -1420,20 +1420,20 @@ void CJabberProto::AddMucListItem(JABBER_MUC_JIDLIST_INFO* jidListInfo, const ch
 void CJabberProto::DeleteMucListItem(JABBER_MUC_JIDLIST_INFO *jidListInfo, const char *jid)
 {
 	switch (jidListInfo->type) {
-	case MUC_VOICELIST:		// change role to visitor (from participant)
+	case MUC_VOICELIST:		// change a role to a visitor (from a participant)
 		AdminSet(jidListInfo->roomJid, JABBER_FEAT_MUC_ADMIN, "jid", jid, "role", "visitor");
 		break;
-	case MUC_BANLIST:		// change affiliation to none (from outcast)
-	case MUC_MEMBERLIST:	// change affiliation to none (from member)
+	case MUC_BANLIST:		// change an affiliation to none (from an outcast)
+	case MUC_MEMBERLIST:	// change an affiliation to none (from a member)
 		AdminSet(jidListInfo->roomJid, JABBER_FEAT_MUC_ADMIN, "jid", jid, "affiliation", "none");
 		break;
-	case MUC_MODERATORLIST:	// change role to participant (from moderator)
+	case MUC_MODERATORLIST:	// change a role to a participant (from a moderator)
 		AdminSet(jidListInfo->roomJid, JABBER_FEAT_MUC_ADMIN, "jid", jid, "role", "participant");
 		break;
-	case MUC_ADMINLIST:		// change affiliation to member (from admin)
+	case MUC_ADMINLIST:		// change an affiliation to a member (from an admin)
 		AdminSet(jidListInfo->roomJid, JABBER_FEAT_MUC_ADMIN, "jid", jid, "affiliation", "member");
 		break;
-	case MUC_OWNERLIST:		// change affiliation to admin (from owner)
+	case MUC_OWNERLIST:		// change an affiliation to an admin (from an owner)
 		AdminSet(jidListInfo->roomJid, JABBER_FEAT_MUC_ADMIN, "jid", jid, "affiliation", "admin");
 		break;
 	}

--- a/protocols/JabberG/src/jabber_events.cpp
+++ b/protocols/JabberG/src/jabber_events.cpp
@@ -73,7 +73,7 @@ bool CJabberProto::OnContactDeleted(MCONTACT hContact, uint32_t)
 				m_ThreadInfo->send(XmlNodeIq("set", SerialNext(), jid) << XQUERY(JABBER_FEAT_REGISTER) << XCHILD("remove"));
 		}
 
-		// Remove from roster, server also handles the presence unsubscription process.
+		// Remove from a roster, the server also handles the presence unsubscription process.
 		m_ThreadInfo->send(XmlNodeIq("set", SerialNext())
 			<< XQUERY(JABBER_FEAT_IQ_ROSTER) << XCHILD("item") << XATTR("jid", jid) << XATTR("subscription", "remove"));
 

--- a/protocols/JabberG/src/jabber_file.cpp
+++ b/protocols/JabberG/src/jabber_file.cpp
@@ -150,7 +150,7 @@ void __cdecl CJabberProto::FileReceiveHttpThread(filetransfer *ft)
 
 void CJabberProto::FileProcessHttpDownload(MCONTACT hContact, const char *jid, const char *pszUrl, const char *pszDescr)
 {
-	// create incoming file transfer instead of writing message
+	// create incoming file transfer instead of a writing message
 	CMStringA szName;
 	const char *b = strrchr(pszUrl, '/') + 1;
 	while (*b != 0 && *b != '#' && *b != '?')

--- a/protocols/JabberG/src/jabber_ft.cpp
+++ b/protocols/JabberG/src/jabber_ft.cpp
@@ -454,7 +454,7 @@ void CJabberProto::FtHandleSiRequest(const TiXmlElement *iqNode)
 			}
 
 			if (optionNode != nullptr) {
-				// Found known stream mechanism
+				// Found a known stream mechanism
 				filetransfer *ft = new filetransfer(this, 0);
 				ft->dwExpectedRecvFileSize = filesize;
 				ft->jid = mir_strdup(from);

--- a/protocols/JabberG/src/jabber_groupchat.cpp
+++ b/protocols/JabberG/src/jabber_groupchat.cpp
@@ -1069,7 +1069,7 @@ void CJabberProto::GroupchatProcessMessage(const TiXmlElement *node)
 	gce.pszText.a = szText;
 	gce.bIsMe = nick == nullptr ? FALSE : (mir_strcmp(resource, item->nick) == 0);
 
-	// if we log chat events, add them to log window
+	// if we log chat events, add them to a log window
 	if (item->bChatLogging)
 		gce.dwFlags |= GCEF_ADDTOLOG;
 	else if (m_bGcLogChatHistory) // else we need to suppress disk logging and sounds/popups

--- a/protocols/JabberG/src/jabber_iq_handlers.cpp
+++ b/protocols/JabberG/src/jabber_iq_handlers.cpp
@@ -214,7 +214,7 @@ bool CJabberProto::OnRosterPushRequest(const TiXmlElement*, CJabberIqInfo *pInfo
 		if (jid == nullptr || str == nullptr)
 			continue;
 
-		// we will not add new account when subscription=remove
+		// we will not add a new account when subscription=remove
 		if (!mir_strcmp(str, "to") || !mir_strcmp(str, "both") || !mir_strcmp(str, "from") || !mir_strcmp(str, "none")) {
 			const char *name = XmlGetAttr(itemNode, "name");
 			ptrA nick((name != nullptr) ? mir_strdup(name) : JabberNickFromJID(jid));
@@ -245,7 +245,7 @@ bool CJabberProto::OnRosterPushRequest(const TiXmlElement*, CJabberIqInfo *pInfo
 
 			debugLogA("Roster push for jid=%s (hContact=%d), set subscription to %s", jid, item->hContact, str);
 
-			// subscription = remove is to remove from roster list
+			// subscription = remove is to remove from the roster list
 			// but we will just set the contact to offline and not actually
 			// remove, so that history will be retained.
 			if (!mir_strcmp(str, "remove")) {

--- a/protocols/JabberG/src/jabber_iqid.cpp
+++ b/protocols/JabberG/src/jabber_iqid.cpp
@@ -250,7 +250,7 @@ void CJabberProto::OnLoggedIn()
 	// XEP-0083 support
 //	if (!(m_StrmMgmt.IsSessionResumed()))
 //	{
-		// ugly hack to prevent hangup during login process
+		// ugly hack to prevent hangup during a login process
 		CJabberIqInfo *pIqInfo = AddIQ(&CJabberProto::OnIqResultNestedRosterGroups, JABBER_IQ_TYPE_GET);
 		pIqInfo->SetTimeout(30000);
 		m_ThreadInfo->send(XmlNodeIq(pIqInfo) << XQUERY(JABBER_FEAT_PRIVATE_STORAGE) << XCHILDNS("roster", JABBER_FEAT_NESTED_ROSTER_GROUPS));
@@ -349,7 +349,7 @@ void CJabberProto::OnIqResultSetAuth(const TiXmlElement *iqNode, CJabberIqInfo*)
 	const char *type;
 
 	// RECVED: authentication result
-	// ACTION: if successfully logged in, continue by requesting roster list and set my initial status
+	// ACTION: if successfully logged in, continue by requesting a roster list and set my initial status
 	debugLogA("<iq/> iqIdSetAuth");
 	if ((type = XmlGetAttr(iqNode, "type")) == nullptr) return;
 
@@ -468,7 +468,7 @@ void CJabberProto::OnIqResultGetRoster(const TiXmlElement *iqNode, CJabberIqInfo
 
 		MCONTACT hContact = HContactFromJID(jid);
 		if (hContact == 0) // Received roster has a new JID.
-			hContact = DBCreateContact(jid, nick, false, false); // Add the jid (with empty resource) to Miranda contact list.
+			hContact = DBCreateContact(jid, nick, false, false); // Add the jid (with empty resource) to a Miranda's contact list.
 
 		JABBER_LIST_ITEM *item = ListAdd(LIST_ROSTER, jid, hContact);
 		item->subscription = sub;
@@ -606,7 +606,7 @@ void CJabberProto::OnIqResultGetVcardPhoto(const TiXmlElement *n, MCONTACT hCont
 				item = ListGetItemPtr(LIST_CHATROOM, jid);
 
 			if (item == nullptr) {
-				item = ListAdd(LIST_VCARD_TEMP, jid); // adding to the temp list to store information about photo
+				item = ListAdd(LIST_VCARD_TEMP, jid); // adding to the temp list to store information about a photo
 				if (item != nullptr)
 					item->bUseResource = true;
 			}
@@ -1150,7 +1150,7 @@ void CJabberProto::OnIqResultGetOmemodevicelist(const TiXmlElement* iqNode, CJab
 			delSetting(szSetting);
 		}
 
-		OmemoAnnounceDevice(false, true); //Publish own device if we can't retrieve up to date list 
+		OmemoAnnounceDevice(false, true); //Publish an own device if we can't retrieve the up-to-date list
 		OmemoSendBundle();
 	}
 }

--- a/protocols/JabberG/src/jabber_iqid_muc.cpp
+++ b/protocols/JabberG/src/jabber_iqid_muc.cpp
@@ -99,7 +99,7 @@ class CJabberMucJidListDlg : public CJabberDlgBase
 
 		FreeList();
 
-		// Populate displayed list from iqNode
+		// Populate the displayed list from iqNode
 		LVITEM lvi = {};
 		wchar_t tszItemText[JABBER_MAX_JID_LEN + 256];
 		TiXmlElement *iqNode = m_info->iqNode;
@@ -256,7 +256,7 @@ public:
 		// Set new GWL_USERDATA
 		m_info = pInfo;
 
-		// Populate displayed list from iqNode
+		// Populate the displayed list from iqNode
 		wchar_t title[256];
 		mir_wstrncpy(title, TranslateT("JID List"), _countof(title));
 		if (pInfo != nullptr) {

--- a/protocols/JabberG/src/jabber_list.h
+++ b/protocols/JabberG/src/jabber_list.h
@@ -73,8 +73,8 @@ enum JABBER_GC_ROLE
 
 enum JABBER_RESOURCE_MODE // initial default to RSMODE_LASTSEEN
 {
-	RSMODE_SERVER,		// always let server decide (always send correspondence without resouce name)
-	RSMODE_LASTSEEN,	// use the last seen resource (or let server decide if haven't seen anything yet)
+	RSMODE_SERVER,		// always let server decide (always send correspondence without a resource name)
+	RSMODE_LASTSEEN,	// use the last seen resource (or let the server decide if it hasn't seen anything yet)
 	RSMODE_MANUAL		// specify resource manually (see the defaultResource field - must not be nullptr)
 };
 

--- a/protocols/JabberG/src/jabber_mam.cpp
+++ b/protocols/JabberG/src/jabber_mam.cpp
@@ -77,7 +77,7 @@ void CJabberProto::MamRetrieveMissingMessages()
 	auto *query = iq << XCHILDNS("query", JABBER_FEAT_MAM);
 
 	if (szLastId.IsEmpty()) {
-		m_bMamDisableMessages = true; // our goal is to save message id, not to store messages
+		m_bMamDisableMessages = true; // our goal is to save a message id, not to store messages
 		m_bMamCreateRead = false;
 
 		char buf[100];
@@ -126,7 +126,7 @@ void CJabberProto::OnIqResultRsm(const TiXmlElement *iqNode, CJabberIqInfo *pInf
 	m_bMamDisableMessages = false;
 
 	if (auto *fin = XmlGetChildByTag(iqNode, "fin", "xmlns", JABBER_FEAT_MAM)) {
-		// if dataset is complete, there's nothing more to do
+		// if the dataset is complete, there's nothing more to do
 		if (!mir_strcmp(XmlGetAttr(fin, "complete"), "true"))
 			return;
 

--- a/protocols/JabberG/src/jabber_menu.cpp
+++ b/protocols/JabberG/src/jabber_menu.cpp
@@ -423,7 +423,7 @@ INT_PTR __cdecl CJabberProto::OnMenuTransportResolve(WPARAM hContact, LPARAM)
 INT_PTR __cdecl CJabberProto::OnMenuBookmarkAdd(WPARAM hContact, LPARAM)
 {
 	if (!hContact)
-		return 0; // we do not add ourself to the roster. (buggy situation - should not happen)
+		return 0; // do not add yourself to the roster. (buggy situation and should not happen)
 
 	ptrA roomID(ContactToJID(hContact));
 	if (roomID == nullptr)
@@ -538,7 +538,7 @@ void CJabberProto::OnBuildProtoMenu()
 		BuildPrivacyListsMenu(false);
 
 	//////////////////////////////////////////////////////////////////////////////////////
-	// build priority menu
+	// build a priority menu
 
 	BuildPriorityMenu();
 

--- a/protocols/JabberG/src/jabber_message_handlers.cpp
+++ b/protocols/JabberG/src/jabber_message_handlers.cpp
@@ -76,7 +76,7 @@ bool CJabberProto::OnMessageGroupchat(const TiXmlElement *node, ThreadData*, CJa
 	if (chatItem) // process GC message
 		GroupchatProcessMessage(node);
 	
-	// got message from unknown conference... let's leave it :)
+	// got a message from unknown conference... let's leave it :)
 	else { 
 //			wchar_t *conference = NEWWSTR_ALLOCA(from);
 //			if (wchar_t *s = wcschr(conference, '/')) *s = 0;

--- a/protocols/JabberG/src/jabber_misc.cpp
+++ b/protocols/JabberG/src/jabber_misc.cpp
@@ -259,7 +259,7 @@ static sttCapsNodeToName_Map[] =
 
 const char* CJabberProto::GetSoftName(const char *szName)
 {
-	// search through known software list
+	// search through the known software list
 	for (auto &it : sttCapsNodeToName_Map)
 		if (strstr(szName, it.node))
 			return it.name;

--- a/protocols/JabberG/src/jabber_omemo.cpp
+++ b/protocols/JabberG/src/jabber_omemo.cpp
@@ -506,7 +506,7 @@ complete:
 		}
 		*record = signal_buffer_create(dbv.pbVal, dbv.cpbVal);
 		db_free(&dbv);
-		return 1; //session exist and succesfully loaded
+		return 1; // session exists and successfully loaded
 	}
 
 	struct db_enum_settings_sub_cb_data
@@ -702,7 +702,7 @@ complete:
 		}
 		*record = signal_buffer_create(dbv.pbVal, dbv.cpbVal);
 		db_free(&dbv);
-		return SG_SUCCESS; //key exist and succesfully loaded
+		return SG_SUCCESS; //key exist and successfully loaded
 	}
 
 	int store_pre_key(uint32_t pre_key_id, uint8_t *record, size_t record_len, void *user_data)
@@ -789,7 +789,7 @@ complete:
 			return SG_ERR_INVALID_KEY_ID;
 		}
 		*record = signal_buffer_create(blob.data(), blob.length());
-		return SG_SUCCESS; //key exist and succesfully loaded
+		return SG_SUCCESS; //key exist and successfully loaded
 	}
 
 	int store_signed_pre_key(uint32_t signed_pre_key_id, uint8_t *record, size_t record_len, void *user_data)
@@ -1047,7 +1047,7 @@ complete:
 		}
 		mir_free(key_buf); // TODO: check this
 
-		// load  identity key
+		// load the identity key
 		ec_public_key *identity_key_p;
 		key_buf = (uint8_t*)mir_base64_decode(identity_key, &key_buf_len);
 		if (curve_decode_point(&identity_key_p, key_buf, key_buf_len, global_context)) {
@@ -1063,7 +1063,7 @@ complete:
 		session_pre_key_bundle_create(&retrieved_pre_key, registration_id, dev_id_int, key_id_int, prekey, signed_pre_key_id_int, signed_prekey, key_buf, key_buf_len, identity_key_p);
 		mir_free(key_buf);
 
-		/* Build a session with a pre key retrieved from the server. */
+		/* Build a session with the pre-key retrieved from the server. */
 		int ret = session_builder_process_pre_key_bundle(builder, retrieved_pre_key);
 		switch (ret) {
 		case SG_SUCCESS:
@@ -1093,7 +1093,7 @@ complete:
 	{
 		uint32_t id = pre_key_signal_message_get_pre_key_id(psm);
 
-		// generate and save pre keys set
+		// generate and save the pre-keys set
 		signal_protocol_key_helper_pre_key_list_node *keys_root;
 		signal_protocol_key_helper_generate_pre_keys(&keys_root, id, 1, proto->m_omemo.global_context);
 
@@ -1182,7 +1182,7 @@ void CJabberProto::OmemoInitDevice()
 		} while (!dev_id);
 		setDword("OmemoDeviceId", dev_id);
 
-		// generate and save device key
+		// generate and save a device key
 		if (signal_protocol_key_helper_generate_identity_key_pair(&device_key, m_omemo.global_context)) {
 			debugLogA("Jabber OMEMO: signal_protocol_key_helper_generate_identity_key_pair failed");
 			//TODO: handle error
@@ -1267,7 +1267,7 @@ bool CJabberProto::OmemoHandleMessage(const TiXmlElement *node, const char *jid,
 		signal_buffer *decrypted_key = nullptr;
 		bool decrypted = false;
 		if (isprekey) {
-			//try to decrypt as  pre_key_signal_message
+			//try to decrypt as a pre_key_signal_message
 			pre_key_signal_message *pm = nullptr;
 			int ret = pre_key_signal_message_deserialize(&pm, encrypted_key, encrypted_key_len, m_omemo.global_context);
 			if (ret == SG_SUCCESS && pm) {
@@ -1281,7 +1281,7 @@ bool CJabberProto::OmemoHandleMessage(const TiXmlElement *node, const char *jid,
 			}
 			else debugLogA("Jabber OMEMO: error %d at pre_key_signal_message_deserialize", ret);
 		}
-		else { //try to decrypt as signal message
+		else { //try to decrypt as a signal message
 			signal_message *sm = nullptr;
 			int ret = signal_message_deserialize(&sm, encrypted_key, encrypted_key_len, m_omemo.global_context);
 			if (ret == SG_SUCCESS && sm) {
@@ -1417,7 +1417,7 @@ bool CJabberProto::OmemoHandleDeviceList(const char *from, const TiXmlElement *n
 		}
 	}
 
-	//check if our device exist
+	//check if our device exists
 	bool own_device_listed = false;
 	int own_id = m_omemo.GetOwnDeviceId();
 	int i = 0;
@@ -1501,7 +1501,7 @@ void CJabberProto::OmemoSendBundle()
 	bundle_node << XCHILD("signedPreKeySignature", signature);
 	SIGNAL_UNREF(sspk);
 
-	// add identity key
+	// add an identity key
 	// it is must be a public key right ?, standart is a bit confusing...
 	bundle_node << XCHILD("identityKey", ptrA(getUStringA("OmemoDevicePublicKey")));
 
@@ -1606,7 +1606,7 @@ void CJabberProto::OmemoOnIqResultGetBundle(const TiXmlElement *iqNode, CJabberI
 
 	const char *type = XmlGetAttr(iqNode, "type");
 	if (mir_strcmp(type, "result")) {
-		// failed to get bundle, do not try to build session
+		// failed to get a bundle, do not try to build session
 		debugLogA("Jabber OMEMO: error: failed to get bundle for device, this may be due to absent data on server or due to our bug (incorrect device id in request)");
 		return;
 	}

--- a/protocols/JabberG/src/jabber_opt.cpp
+++ b/protocols/JabberG/src/jabber_opt.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 static BOOL(WINAPI *pfnEnableThemeDialogTexture)(HANDLE, uint32_t) = nullptr;
 
 /////////////////////////////////////////////////////////////////////////////////////////
-// JabberRegisterDlgProc - the dialog proc for registering new account
+// JabberRegisterDlgProc - the dialog proc for registering a new account
 
 struct { char *szCode; wchar_t *szDescription; } g_LanguageCodes[] = {
 	{ "aa", LPGENW("Afar") },

--- a/protocols/JabberG/src/jabber_privacy.h
+++ b/protocols/JabberG/src/jabber_privacy.h
@@ -250,7 +250,7 @@ public:
 			pRule = pRule->GetNext();
 		}
 
-		// create pointer array for sort procedure
+		// create a pointer array for sort procedure
 		CPrivacyListRule **pRules = (CPrivacyListRule **)mir_alloc(dwCount * sizeof(CPrivacyListRule *));
 		if (!pRules)
 			return false;

--- a/protocols/JabberG/src/jabber_proto.cpp
+++ b/protocols/JabberG/src/jabber_proto.cpp
@@ -399,7 +399,7 @@ int CJabberProto::Authorize(MEVENT hDbEvent)
 
 	m_ThreadInfo->send(XmlNode("presence") << XATTR("to", blob.get_email()) << XATTR("type", "subscribed"));
 
-	// Automatically add this user to my roster if option is enabled
+	// Automatically add this user to my roster if the option is enabled
 	if (m_bAutoAdd) {
 		if (auto *item = ListGetItemPtr(LIST_ROSTER, blob.get_email())) {
 			if (item->subscription != SUB_BOTH && item->subscription != SUB_TO) {
@@ -946,11 +946,11 @@ int CJabberProto::SendMsgEx(MCONTACT hContact, const char *pszSrc, XmlNode &m)
 
 	int id = SerialNext();
 	if (
-		// if message delivery check disabled by entity caps manager
+		// if the message delivery check disabled by entity caps manager
 		(jcb & JABBER_CAPS_MESSAGE_EVENTS_NO_DELIVERY) ||
-		// if client knows nothing about delivery
+		// if the client knows nothing about delivery
 		!(jcb & JABBER_CAPS_MESSAGE_RECEIPTS) ||
-		// if message sent to groupchat
+		// if the message sent to groupchat
 		!mir_strcmp(msgType, "groupchat") ||
 		// if message delivery check disabled in settings
 		!bSendReceipt) {

--- a/protocols/JabberG/src/jabber_proto.h
+++ b/protocols/JabberG/src/jabber_proto.h
@@ -875,7 +875,7 @@ struct CJabberProto : public PROTO<CJabberProto>, public IJabberInterface
 	void       SendPresenceTo(int status, const char* to, const TiXmlElement *extra = nullptr, const char *msg = nullptr);
 	void       SendPresence(int iStatus, bool bSendToAll);
 
-	int        SerialNext();  // Returns id that can be used for next message sent through SendXmlNode().
+	int        SerialNext();  // Returns id that can be used for the next message sent through SendXmlNode().
 
 	// returns buf or nullptr on error
 	char*      GetClientJID(MCONTACT hContact, char *dest, size_t destLen);

--- a/protocols/JabberG/src/jabber_roster.cpp
+++ b/protocols/JabberG/src/jabber_roster.cpp
@@ -294,7 +294,7 @@ public:
 				_RosterInsertListItem(jid, name, group, subscription, true);
 			}
 
-			// now it is require to process whole contact list to add not in roster contacts
+			// now it is required to process a whole contact list to add not in roster contacts
 			for (auto &hContact : m_proto->AccContacts()) {
 				ptrW tszJid(m_proto->getWStringA(hContact, "jid"));
 				if (tszJid == nullptr || Contact::IsGroupChat(hContact))

--- a/protocols/JabberG/src/jabber_search.cpp
+++ b/protocols/JabberG/src/jabber_search.cpp
@@ -68,7 +68,7 @@ static int JabberSearchFrameProc(HWND hwnd, int msg, WPARAM wParam, LPARAM lPara
 			}
 		}
 
-		// Transmit focus set notification to parent window
+		// Transmit focus set notification to a parent window
 		if (HIWORD(wParam) == EN_SETFOCUS)
 			PostMessage(GetParent(hwndDlg), WM_COMMAND, MAKEWPARAM(0, EN_SETFOCUS), (LPARAM)hwndDlg);
 	}
@@ -201,7 +201,7 @@ void CJabberProto::OnIqResultGetSearchFields(const TiXmlElement *iqNode, CJabber
 //////////////////////////////////////////////////////////////////////////////////////////
 //  Return results to search dialog
 //  The pmFields is the pointer to map of <field Name, field Label> Not unical but ordered
-//	This can help to made result parser routines more simple
+//	This can help to make result parser routines more simple
 
 static char *nickfields[] = { "nick", "nickname", "fullname", "name", "given", "first", "jid", nullptr };
 
@@ -215,7 +215,7 @@ static void SearchReturnResults(CJabberProto *ppro, HANDLE id, LIST<UNIQUE_MAP> 
 	LIST<char> ListOfNonEmptyFields(20, TCharKeyCmp);
 	LIST<char> ListOfFields(20);
 
-	// lets fill the ListOfNonEmptyFields but in users order
+	// let's fill the ListOfNonEmptyFields but in user's order
 	for (auto &pmUserData : plUsersInfo) {
 		int nUserFields = pmUserData->getCount();
 		for (int j = 0; j < nUserFields; j++) {
@@ -234,7 +234,7 @@ static void SearchReturnResults(CJabberProto *ppro, HANDLE id, LIST<UNIQUE_MAP> 
 		ListOfFields.insert(var);
 	}
 
-	// now lets transfer field names
+	// now let's transfer field names
 	int nFieldCount = ListOfFields.getCount();
 
 	CUSTOMSEARCHRESULTS Results = { 0 };
@@ -292,7 +292,7 @@ static void SearchReturnResults(CJabberProto *ppro, HANDLE id, LIST<UNIQUE_MAP> 
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Search field request result handler  (XEP-0055. Examples 3, 8)
+// Search field request result handler (XEP-0055. Examples 3, 8)
 
 void CJabberProto::OnIqResultAdvancedSearch(const TiXmlElement *iqNode, CJabberIqInfo*)
 {
@@ -536,7 +536,7 @@ static INT_PTR CALLBACK JabberSearchAdvancedDlgProc(HWND hwndDlg, UINT msg, WPAR
 				SendDlgItemMessageA(hwndDlg, IDC_SERVER, CB_ADDSTRING, 0, jud);
 			}
 
-			//TO DO: Add Transports here
+			//TODO: Add Transports here
 			for (auto &it : dat->ppro->m_lstTransports)
 				if (it != nullptr)
 					JabberSearchAddUrlToRecentCombo(hwndDlg, Utf2T(it));
@@ -549,7 +549,7 @@ static INT_PTR CALLBACK JabberSearchAdvancedDlgProc(HWND hwndDlg, UINT msg, WPAR
 					JabberSearchAddUrlToRecentCombo(hwndDlg, szValue);
 			}
 
-			//TO DO: Add 4 recently used
+			//TODO: Add 4 of recently used
 			dat->lastRequestIq = dat->ppro->SearchRenewFields(hwndDlg, dat);
 		}
 		return TRUE;
@@ -725,7 +725,7 @@ HANDLE CJabberProto::SearchAdvanced(HWND hwndDlg)
 	if (!dat)
 		return nullptr; //error
 
-	// check if server connected (at least one field exists)
+	// check if the server connected (at least one field exists)
 	if (dat->nJSInfCount == 0)
 		return nullptr;
 

--- a/protocols/JabberG/src/jabber_strm_mgmt.cpp
+++ b/protocols/JabberG/src/jabber_strm_mgmt.cpp
@@ -253,7 +253,7 @@ void strm_mgmt::RequestAck()
 		return;
 
 	if (!m_bRequestPending) {
-		// We should save m_nLocalSCount here bc the server acknowlages stanza count for the moment when it receives <r>
+		// We should save m_nLocalSCount here bc the server acknowledges stanzas count for the moment when it receives <r>
 		// NOT for the moment it sends <a>
 		m_bRequestPending = true;
 		m_nReqLocalSCount = m_nLocalSCount;
@@ -278,7 +278,7 @@ bool strm_mgmt::IsResumeIdPresent()
 
 void strm_mgmt::FinishLoginProcess(ThreadData *info)
 {
-	if (proto->m_arAuthMechs.getCount()) { //We are already logged-in
+	if (proto->m_arAuthMechs.getCount()) { //We are already logged in
 		info->send(
 			XmlNodeIq(proto->AddIQ(&CJabberProto::OnIqResultBind, JABBER_IQ_TYPE_SET))
 			<< XCHILDNS("bind", JABBER_FEAT_BIND)

--- a/protocols/JabberG/src/jabber_svc.cpp
+++ b/protocols/JabberG/src/jabber_svc.cpp
@@ -479,7 +479,7 @@ INT_PTR __cdecl CJabberProto::JabberServiceParseXmppURI(WPARAM, LPARAM lParam)
 		return 0;
 	}
 
-	// send file
+	// send the file
 	if (!mir_wstrcmpi(szCommand, L"sendfile")) {
 		MCONTACT hContact = HContactFromJID(jid, false);
 		if (hContact == 0)

--- a/protocols/JabberG/src/jabber_thread.cpp
+++ b/protocols/JabberG/src/jabber_thread.cpp
@@ -264,7 +264,7 @@ void CJabberProto::ServerThread(JABBER_CONN_DATA *pParam)
 	// fully reset strm_mgmt state
 	m_StrmMgmt.ResetState();
 
-	// quit all chatrooms (will send quit message)
+	// quit all chatrooms (will send a quit message)
 	LISTFOREACH(i, this, LIST_CHATROOM)
 		if (auto *item = ListGetItemPtrFromIndex(i)) {
 			if (item->si)
@@ -395,9 +395,9 @@ bool CJabberProto::ServerThreadStub(ThreadData &info)
 		}
 	}
 	else {
-		// Register new user connection, all connection parameters are already filled-in.
-		// Multiple thread allowed, although not possible :)
-		// thinking again.. multiple thread should not be allowed
+		// Register new user connection, all connection parameters are already filled in.
+		// Multiple threads allowed, although not possible :)
+		// Thinking again. The multiple threads should not be allowed.
 		info.reg_done = false;
 		info.conn.SetProgress(25, TranslateT("Connecting..."));
 		iqIdRegGetReg = -1;
@@ -765,7 +765,7 @@ void CJabberProto::OnProcessFeatures(const TiXmlElement *node, ThreadData *info)
 	if (m_bEnableStreamMgmt && m_StrmMgmt.IsResumeIdPresent()) // resume should be done here
 		m_StrmMgmt.CheckState();
 	else {
-		if (m_arAuthMechs.getCount()) { // we are already logged-in
+		if (m_arAuthMechs.getCount()) { // we are already logged in
 			info->send(
 				XmlNodeIq(AddIQ(&CJabberProto::OnIqResultBind, JABBER_IQ_TYPE_SET))
 				<< XCHILDNS("bind", JABBER_FEAT_BIND)
@@ -832,7 +832,7 @@ void CJabberProto::OnProcessSuccess(const TiXmlElement *node, ThreadData *info)
 	const char *type;
 	//	int iqId;
 	// RECVED: <success ...
-	// ACTION: if successfully logged in, continue by requesting roster list and set my initial status
+	// ACTION: if successfully logged in, continue by requesting a roster list and set my initial status
 	if ((type = XmlGetAttr(node, "xmlns")) == nullptr)
 		return;
 
@@ -1202,7 +1202,7 @@ void CJabberProto::OnProcessMessage(const TiXmlElement *node, ThreadData *info)
 		if (szMsgId = n->Attribute("id"))
 			setString("LastMamId", szMsgId);
 
-	// If message is from a stranger (not in roster), item is nullptr
+	// If a message is from a stranger (not in roster), item is nullptr
 	JABBER_LIST_ITEM *item = ListGetItemPtr(LIST_ROSTER, from);
 	if (item == nullptr)
 		item = ListGetItemPtr(LIST_VCARD_TEMP, from);
@@ -1400,7 +1400,7 @@ void CJabberProto::OnProcessMessage(const TiXmlElement *node, ThreadData *info)
 		return;
 	}
 
-	// we ignore messages without server id either if MAM is enabled
+	// we ignore messages without a server id either if MAM is enabled
 	if ((info->jabberServerCaps & JABBER_CAPS_MAM) && m_bEnableMam && m_iMamMode != 0 && szMsgId == nullptr) {
 		debugLogA("MAM is enabled, but there's no stanza-id: ignoting a message");
 		return;

--- a/protocols/JabberG/src/jabber_vcard.cpp
+++ b/protocols/JabberG/src/jabber_vcard.cpp
@@ -908,12 +908,12 @@ void CJabberProto::SetServerVcard(bool bPhotoChanged, wchar_t *szPhotoFileName)
 	n << XCHILD("HOME");
 	AppendVcardFromDB(n, "STREET", "Street");
 	AppendVcardFromDB(n, "EXTADR", "Street2");
-	AppendVcardFromDB(n, "EXTADD", "Street2");	// for compatibility with client using old vcard format
+	AppendVcardFromDB(n, "EXTADD", "Street2");	// for compatibility with a client using old vcard format
 	AppendVcardFromDB(n, "LOCALITY", "City");
 	AppendVcardFromDB(n, "REGION", "State");
 	AppendVcardFromDB(n, "PCODE", "ZIP");
 	AppendVcardFromDB(n, "CTRY", "Country");
-	AppendVcardFromDB(n, "COUNTRY", "Country");	// for compatibility with client using old vcard format
+	AppendVcardFromDB(n, "COUNTRY", "Country");	// for compatibility with a client using old vcard format
 	if (XmlGetChildCount(n) == 1)
 		v->DeleteChild(n);
 
@@ -921,12 +921,12 @@ void CJabberProto::SetServerVcard(bool bPhotoChanged, wchar_t *szPhotoFileName)
 	n << XCHILD("WORK");
 	AppendVcardFromDB(n, "STREET", "CompanyStreet");
 	AppendVcardFromDB(n, "EXTADR", "CompanyStreet2");
-	AppendVcardFromDB(n, "EXTADD", "CompanyStreet2");	// for compatibility with client using old vcard format
+	AppendVcardFromDB(n, "EXTADD", "CompanyStreet2");	// for compatibility with a client using old vcard format
 	AppendVcardFromDB(n, "LOCALITY", "CompanyCity");
 	AppendVcardFromDB(n, "REGION", "CompanyState");
 	AppendVcardFromDB(n, "PCODE", "CompanyZIP");
 	AppendVcardFromDB(n, "CTRY", "CompanyCountry");
-	AppendVcardFromDB(n, "COUNTRY", "CompanyCountry");	// for compatibility with client using old vcard format
+	AppendVcardFromDB(n, "COUNTRY", "CompanyCountry");	// for compatibility with a client using old vcard format
 	if (XmlGetChildCount(n) == 1)
 		v->DeleteChild(n);
 

--- a/protocols/JabberG/src/jabber_xstatus.cpp
+++ b/protocols/JabberG/src/jabber_xstatus.cpp
@@ -833,7 +833,7 @@ static int ActivityCheck(const char *szFirstNode, const char *szSecondNode)
 
 	int i = 0, nFirst = -1, nSecond = -1;
 	while (g_arrActivities[i].szFirst || g_arrActivities[i].szSecond) {
-		// check first node
+		// check the first node
 		if (g_arrActivities[i].szFirst && !mir_strcmp(szFirstNode, g_arrActivities[i].szFirst)) {
 			// first part found
 			nFirst = i;

--- a/protocols/WhatsApp/src/signal.cpp
+++ b/protocols/WhatsApp/src/signal.cpp
@@ -215,7 +215,7 @@ static int load_pre_key(signal_buffer **record, uint32_t pre_key_id, void *user_
 	}
 
 	*record = signal_buffer_create(blob.data(), blob.length());
-	return SG_SUCCESS; //key exists and succesfully loaded
+	return SG_SUCCESS; //key exists and successfully loaded
 }
 
 static int remove_pre_key(uint32_t pre_key_id, void *user_data)
@@ -280,7 +280,7 @@ static int load_signed_pre_key(signal_buffer **record, uint32_t signed_pre_key_i
 	}
 
 	*record = signal_buffer_create(blob.data(), blob.length());
-	return SG_SUCCESS; //key exist and succesfully loaded
+	return SG_SUCCESS; //key exist and successfully loaded
 }
 
 static int store_signed_pre_key(uint32_t signed_pre_key_id, uint8_t *record, size_t record_len, void *user_data)


### PR DESCRIPTION
The CLion has a built-in grammar checker that makes a lot of annoying warnings: mostly about missing articles.
I decided to just quickly fix most of them, but only in comments.
Mostly affected the Jabber plugin that I studying now.