### PR TITLE
improve memory allocation handling

### DIFF
--- a/plugins/AvatarHistory/src/AvatarDlg.cpp
+++ b/plugins/AvatarHistory/src/AvatarDlg.cpp
@@ -79,6 +79,9 @@ int OpenAvatarDialog(MCONTACT hContact, char* fn)
 	}
 
 	AvatarDialogData *avdlg = (AvatarDialogData*)calloc(1, sizeof(AvatarDialogData));
+	if (avdlg == nullptr)
+		return 1;
+
 	avdlg->hContact = hContact;
 	if (fn == nullptr)
 		avdlg->fn[0] = '\0';


### PR DESCRIPTION
plugins/AvatarHistory/src/AvatarDlg.cpp:82:2: warning: If memory allocation fails, then there is a possible null pointer dereference: avdlg [nullPointerOutOfMemory]
plugins/AvatarHistory/src/AvatarDlg.cpp:84:3: warning: If memory allocation fails, then there is a possible null pointer dereference: avdlg [nullPointerOutOfMemory]
plugins/AvatarHistory/src/AvatarDlg.cpp:86:42: warning: If memory allocation fails, then there is a possible null pointer dereference: avdlg [nullPointerOutOfMemory]
plugins/AvatarHistory/src/AvatarDlg.cpp:86:62: warning: If memory allocation fails, then there is a possible null pointer dereference: avdlg [nullPointerOutOfMemory]