### PR TITLE
docs: fix typo in Steam API documentation

### DIFF
--- a/protocols/Steam/doc/API.md
+++ b/protocols/Steam/doc/API.md
@@ -270,7 +270,7 @@ To check for new messages (can be used over http and when a message
 
  - `steamid`
  - `umqid`
- - `message` - id of last message recieved used to check for newer mesages
+ - `message` - id of last message received used to check for newer mesages
 
 #### Returns ####
  


### PR DESCRIPTION
Fixes a small typo in the Steam API documentation: `recieved` → `received`.

This is a documentation-only change.